### PR TITLE
Remove alloc errors from lazy ops to improve usability

### DIFF
--- a/src/models/linear.zig
+++ b/src/models/linear.zig
@@ -72,8 +72,8 @@ pub fn Model(comptime T: type) type {
 
         // TODO: uncomment when optimizer is implemented
         // test "linear model" {
-        //     const time = try Tensor(T).initArange(tac, &.{5}, 0, 20);
-        //     const speed = try Tensor(T).initArange(tac, &.{5}, 5, 25);
+        //     const time = try Tensor(T).initLinspace(tac, &.{5}, 0, 20);
+        //     const speed = try Tensor(T).initLinspace(tac, &.{5}, 5, 25);
 
         //     var model = try Model(T).build(tac, 2, 1, time, speed);
         //     defer model.deinit();

--- a/src/models/quad.zig
+++ b/src/models/quad.zig
@@ -80,8 +80,8 @@ pub fn Model(comptime T: type) type {
 
         // TODO: write optimizer to make this work properly, uncomment when done
         // test "quadratic model" {
-        //     const time = try Tensor(T).initArange(tac, &.{5}, 0, 20);
-        //     const speed = try Tensor(T).initArange(tac, &.{5}, 5, 25);
+        //     const time = try Tensor(T).initLinspace(tac, &.{5}, 0, 20);
+        //     const speed = try Tensor(T).initLinspace(tac, &.{5}, 5, 25);
 
         //     var model = try Model(T).build(tac, 1, 1, 1, time, speed);
         //     defer model.deinit();


### PR DESCRIPTION
Composing functions together is hard to read in its current state.
See for example:
<table>
<tr>
<td>Before this PR</td>
<td>After this PR</td>
</tr>
<tr>
<td>

```zig
fn sqrSum(input: *Tensor(T)) Alloc.Error!*Tensor(T) {
    return try (try input.sqr()).sumAll();
}
```

</td>
<td>

```zig
fn sqrSum(input: *Tensor(T)) *Tensor(T) {
    return input.sqr().sumAll();
}
```

</td>
</tr>
</table>

The readability difference there is huge, and without operator overloading in Zig, this seems to be the best alternative route. Complicated math functions get increasingly hard to read with the `try` syntax everywhere.
Maybe if `try {}` block syntax was permitted, returning errors would be OK without destroying readibility. 

In some applications, an OOM/Alloc error is useful, but in this type of application making most allocations for ops up front, it seems like it'd be OK for it to be an unrecoverable error.