### PR TITLE
Per-op microbenchmarks, BLAS conv2d, SIMD fused chains

### DIFF
--- a/benchmarks/mnist_pytorch.py
+++ b/benchmarks/mnist_pytorch.py
@@ -1,0 +1,107 @@
+"""MNIST CNN benchmark — PyTorch CPU baseline for comparison with zgml."""
+
+import time
+import torch
+import torch.nn as nn
+import torch.optim as optim
+from torchvision import datasets, transforms
+
+torch.set_num_threads(1)  # single-thread for fair comparison
+
+# Same architecture as zgml: Conv(5x5, 1->8) -> ReLU -> MaxPool(2x2) -> FC(1152->10)
+class ConvClassifier(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv = nn.Conv2d(1, 8, 5, padding=0)  # 28x28 -> 24x24
+        self.pool = nn.MaxPool2d(2)                  # 24x24 -> 12x12
+        self.fc = nn.Linear(8 * 12 * 12, 10)
+
+    def forward(self, x):
+        x = self.pool(torch.relu(self.conv(x)))
+        x = x.view(x.size(0), -1)
+        return self.fc(x)
+
+def main():
+    print("\nMNIST CNN Training Benchmark (PyTorch CPU, 1 thread)")
+    print("=" * 52, "\n")
+
+    transform = transforms.ToTensor()
+    train_ds = datasets.MNIST("data_pytorch", train=True, download=True, transform=transform)
+    test_ds = datasets.MNIST("data_pytorch", train=False, download=True, transform=transform)
+
+    batch_size = 32
+    n_epochs = 10
+
+    train_loader = torch.utils.data.DataLoader(train_ds, batch_size=batch_size, shuffle=True, num_workers=0)
+    test_loader = torch.utils.data.DataLoader(test_ds, batch_size=batch_size, shuffle=False, num_workers=0)
+
+    print(f"  Train: {len(train_ds)} images, Test: {len(test_ds)} images")
+    print(f"  Image size: 28x28\n")
+    print("Architecture: Conv(5x5, 1->8) -> ReLU -> MaxPool(2x2) -> FC(1152->10)")
+    print(f"Optimizer: Adam (lr=1e-3)")
+    print(f"Batch size: {batch_size}, Epochs: {n_epochs}\n")
+
+    model = ConvClassifier()
+    optimizer = optim.Adam(model.parameters(), lr=1e-3)
+    criterion = nn.CrossEntropyLoss()
+
+    total_start = time.perf_counter()
+
+    for epoch in range(n_epochs):
+        epoch_start = time.perf_counter()
+        running_loss = 0.0
+        correct = 0
+        total = 0
+
+        model.train()
+        for batch_idx, (images, labels) in enumerate(train_loader):
+            optimizer.zero_grad()
+            outputs = model(images)
+            loss = criterion(outputs, labels)
+            loss.backward()
+            optimizer.step()
+
+            running_loss += loss.item()
+            _, predicted = outputs.max(1)
+            correct += predicted.eq(labels).sum().item()
+            total += labels.size(0)
+
+            if (batch_idx + 1) % 100 == 0:
+                print(f"  epoch {epoch+1}/{n_epochs} batch {batch_idx+1}/{len(train_loader)}"
+                      f" loss={running_loss/(batch_idx+1):.4f}"
+                      f" train_acc={100.*correct/total:.1f}%", end="\r")
+
+        epoch_ms = (time.perf_counter() - epoch_start) * 1000
+        avg_loss = running_loss / len(train_loader)
+        train_acc = 100.0 * correct / total
+        imgs_per_sec = total / (epoch_ms / 1000)
+
+        print(f"  Epoch {epoch+1}/{n_epochs}: loss={avg_loss:.4f}"
+              f"  train_acc={train_acc:.1f}%"
+              f"  {epoch_ms:.0f}ms  ({imgs_per_sec:.0f} img/s)")
+
+    total_ms = (time.perf_counter() - total_start) * 1000
+
+    # Test evaluation
+    print("\nEvaluating on test set...")
+    model.eval()
+    test_correct = 0
+    test_total = 0
+    with torch.no_grad():
+        for images, labels in test_loader:
+            outputs = model(images)
+            _, predicted = outputs.max(1)
+            test_correct += predicted.eq(labels).sum().item()
+            test_total += labels.size(0)
+
+    test_acc = 100.0 * test_correct / test_total
+
+    print(f"\nResults")
+    print(f"-------")
+    print(f"  Test accuracy: {test_acc:.2f}% ({test_correct}/{test_total})")
+    print(f"  Total training time: {total_ms:.0f}ms")
+    print(f"  Avg time per epoch: {total_ms/n_epochs:.0f}ms")
+    print()
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/op_bench.zig
+++ b/benchmarks/op_bench.zig
@@ -1,0 +1,168 @@
+//! Per-op microbenchmark for MNIST CNN ops.
+//!
+//! Uses the library's built-in `profileNodes` to get per-op timing on
+//! the full ConvClassifier graph (unfused, so every primitive is visible).
+//! Then runs the same profiling with fusion enabled for comparison.
+//!
+//! Run with: zig build op-bench
+
+const std = @import("std");
+const zgml = @import("zgml");
+const Tensor = zgml.Tensor;
+const ComputeGraph = zgml.ComputeGraph;
+const ConvClassifier = zgml.models.ConvClassifier;
+
+const BATCH = 32;
+const WARMUP = 5;
+const ITERS = 20;
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const alloc = gpa.allocator();
+
+    const stdout_file = std.fs.File.stdout();
+    var buf: [16384]u8 = undefined;
+    var w = stdout_file.writer(&buf);
+
+    try w.interface.print("\nPer-Op Microbenchmark — MNIST CNN (batch={})\n", .{BATCH});
+    try w.interface.print("===============================================\n\n", .{});
+
+    // --- Unfused profiling ---
+    {
+        try w.interface.print("UNFUSED (every primitive op timed separately)\n", .{});
+        try w.interface.print("----------------------------------------------\n", .{});
+
+        var model = try ConvClassifier(f32).build(alloc, 28, 28, 5, 8, 10, BATCH);
+        defer model.deinit();
+        // No fusionPass — we want to see every primitive
+
+        // Fill synthetic data
+        var prng = std.Random.DefaultPrng.init(42);
+        const rand = prng.random();
+        for (model.xs_batch.data) |*v| v.* = rand.float(f32);
+        for (model.ys_batch.data) |*v| v.* = @floatFromInt(rand.intRangeAtMost(u32, 0, 9));
+
+        // Warmup
+        for (0..WARMUP) |_| {
+            model.g.reset();
+            model.g.resetGrads();
+            if (model.loss.grad) |grad| _ = grad.setAllScalar(1);
+            model.g.compute();
+        }
+
+        // Accumulate across ITERS runs
+        const op_count = @typeInfo(zgml.Op).@"enum".fields.len;
+        var accum_fwd = [_]u64{0} ** op_count;
+        var accum_bwd = [_]u64{0} ** op_count;
+        var accum_fwd_n = [_]u64{0} ** op_count;
+        var accum_bwd_n = [_]u64{0} ** op_count;
+
+        for (0..ITERS) |_| {
+            model.g.reset();
+            model.g.resetGrads();
+
+            var np = try model.g.profileNodes(alloc, .{
+                .loss_grad = model.loss.grad,
+            });
+            defer np.deinit();
+
+            for (np.buckets, 0..) |b, i| {
+                accum_fwd[i] += b.fwd_ns;
+                accum_bwd[i] += b.bwd_ns;
+                accum_fwd_n[i] = b.fwd_count; // count is same every iter
+                accum_bwd_n[i] = b.bwd_count;
+            }
+        }
+
+        // Build averaged profile and print
+        const avg_buckets = try alloc.alloc(ComputeGraph(f32).OpBucket, op_count);
+        defer alloc.free(avg_buckets);
+        var avg_fwd_total: u64 = 0;
+        var avg_bwd_total: u64 = 0;
+        for (0..op_count) |i| {
+            avg_buckets[i] = .{
+                .tag = @enumFromInt(i),
+                .fwd_count = accum_fwd_n[i],
+                .bwd_count = accum_bwd_n[i],
+                .fwd_ns = accum_fwd[i] / ITERS,
+                .bwd_ns = accum_bwd[i] / ITERS,
+            };
+            avg_fwd_total += avg_buckets[i].fwd_ns;
+            avg_bwd_total += avg_buckets[i].bwd_ns;
+        }
+
+        const avg_profile = ComputeGraph(f32).NodeProfile{
+            .buckets = avg_buckets,
+            .fwd_total_ns = avg_fwd_total,
+            .bwd_total_ns = avg_bwd_total,
+            .alloc = alloc,
+        };
+        try avg_profile.render(&w.interface);
+        try w.interface.print("\n", .{});
+        w.interface.flush() catch {};
+    }
+
+    // --- Fused per-step profiling ---
+    {
+        try w.interface.print("FUSED (per-step profiling)\n", .{});
+        try w.interface.print("---------------------------------------------\n", .{});
+
+        var model = try ConvClassifier(f32).build(alloc, 28, 28, 5, 8, 10, BATCH);
+        defer model.deinit();
+        try model.g.fusionPass();
+
+        var prng = std.Random.DefaultPrng.init(42);
+        const rand = prng.random();
+        for (model.xs_batch.data) |*v| v.* = rand.float(f32);
+        for (model.ys_batch.data) |*v| v.* = @floatFromInt(rand.intRangeAtMost(u32, 0, 9));
+
+        // Warmup
+        for (0..WARMUP) |_| {
+            model.g.reset();
+            model.g.resetGrads();
+            if (model.loss.grad) |grad| _ = grad.setAllScalar(1);
+            model.g.compute();
+        }
+
+        // Single step profile run for detailed breakdown
+        var sp = try model.g.profileSteps(alloc, .{ .loss_grad = model.loss.grad });
+        defer sp.deinit();
+        try sp.renderDetailed(&w.interface, 100.0); // show detail for steps > 100 us
+
+        // Whole-graph timing (multiple iterations)
+        var fwd_times: [ITERS]u64 = undefined;
+        var bwd_times: [ITERS]u64 = undefined;
+        for (0..ITERS) |i| {
+            const profile = try model.g.profileExecution(.{ .loss_grad = model.loss.grad });
+            fwd_times[i] = profile.forward_ns;
+            bwd_times[i] = profile.backward_ns;
+        }
+        std.mem.sort(u64, &fwd_times, {}, std.sort.asc(u64));
+        std.mem.sort(u64, &bwd_times, {}, std.sort.asc(u64));
+        var fwd_sum: u64 = 0;
+        var bwd_sum: u64 = 0;
+        for (fwd_times) |t| fwd_sum += t;
+        for (bwd_times) |t| bwd_sum += t;
+
+        try w.interface.print("  forward:  min={d:>8.1}  p50={d:>8.1}  mean={d:>8.1} us\n", .{
+            @as(f64, @floatFromInt(fwd_times[0])) / 1000.0,
+            @as(f64, @floatFromInt(fwd_times[ITERS / 2])) / 1000.0,
+            @as(f64, @floatFromInt(fwd_sum / ITERS)) / 1000.0,
+        });
+        try w.interface.print("  backward: min={d:>8.1}  p50={d:>8.1}  mean={d:>8.1} us\n", .{
+            @as(f64, @floatFromInt(bwd_times[0])) / 1000.0,
+            @as(f64, @floatFromInt(bwd_times[ITERS / 2])) / 1000.0,
+            @as(f64, @floatFromInt(bwd_sum / ITERS)) / 1000.0,
+        });
+        const total_mean = (fwd_sum + bwd_sum) / ITERS;
+        try w.interface.print("  total:    mean={d:>8.1} us  ({d:.0} img/s)\n\n", .{
+            @as(f64, @floatFromInt(total_mean)) / 1000.0,
+            @as(f64, @floatFromInt(BATCH)) / (@as(f64, @floatFromInt(total_mean)) / 1_000_000_000.0),
+        });
+        w.interface.flush() catch {};
+    }
+
+    try w.interface.print("({} warmup + {} timed iterations)\n\n", .{ WARMUP, ITERS });
+    w.interface.flush() catch {};
+}

--- a/benchmarks/op_bench_pytorch.py
+++ b/benchmarks/op_bench_pytorch.py
@@ -1,0 +1,179 @@
+"""Per-op microbenchmark for MNIST CNN ops — PyTorch CPU (1 thread) baseline.
+
+Matches the exact shapes from the zgml ConvClassifier:
+  Conv2d(5x5, 1->8)  :  [32,1,28,28] * [8,1,5,5]  -> [32,8,24,24]
+  ReLU                :  [32,8,24,24]               -> [32,8,24,24]
+  MaxPool2d(2x2)      :  [32,8,24,24]               -> [32,8,12,12]
+  FC (linear)         :  [32,1152] * [10,1152]^T    -> [32,10]
+  CrossEntropyLoss    :  [32,10] + labels[32]        -> scalar
+
+Run with: uv run --with torch benchmarks/op_bench_pytorch.py
+"""
+
+import time
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+torch.set_num_threads(1)
+
+BATCH = 32
+WARMUP = 20
+ITERS = 200
+
+
+def bench(name, fn, *, shapes=""):
+    """Benchmark a callable, returning (fwd_us, bwd_us)."""
+    # Warmup
+    for _ in range(WARMUP):
+        fn()
+
+    times = []
+    for _ in range(ITERS):
+        t0 = time.perf_counter_ns()
+        fn()
+        times.append(time.perf_counter_ns() - t0)
+
+    times.sort()
+    min_us = times[0] / 1000
+    p50_us = times[len(times) // 2] / 1000
+    p90_us = times[len(times) * 9 // 10] / 1000
+    mean_us = sum(times) / len(times) / 1000
+    print(f"  {name:<22} {min_us:>10.1f} {p50_us:>10.1f} {p90_us:>10.1f} {mean_us:>10.1f}   {shapes}")
+    return mean_us
+
+
+def main():
+    print(f"\nPer-Op Microbenchmark — PyTorch CPU 1-thread (batch={BATCH})")
+    print("=" * 62)
+    print()
+
+    # ── Conv2d forward + backward ──
+    print(f"  {'op':<22} {'min_us':>10} {'p50_us':>10} {'p90_us':>10} {'mean_us':>10}   shapes")
+    print(f"  {'':-<22} {'':->10} {'':->10} {'':->10} {'':->10}")
+
+    conv = nn.Conv2d(1, 8, 5, bias=False)
+    x_conv = torch.randn(BATCH, 1, 28, 28, requires_grad=True)
+
+    def conv_fwd():
+        return conv(x_conv)
+
+    bench("conv2d_fwd", conv_fwd, shapes="[32,1,28,28]*[8,1,5,5]->[32,8,24,24]")
+
+    def conv_fwd_bwd():
+        out = conv(x_conv)
+        out.backward(torch.ones_like(out))
+        if x_conv.grad is not None:
+            x_conv.grad = None
+        conv.weight.grad = None
+
+    bench("conv2d_fwd+bwd", conv_fwd_bwd)
+
+    # ── ReLU forward + backward ──
+    x_relu = torch.randn(BATCH, 8, 24, 24, requires_grad=True)
+
+    def relu_fwd():
+        return F.relu(x_relu)
+
+    bench("relu_fwd", relu_fwd, shapes="[32,8,24,24]->[32,8,24,24]")
+
+    def relu_fwd_bwd():
+        out = F.relu(x_relu)
+        out.backward(torch.ones_like(out))
+        x_relu.grad = None
+
+    bench("relu_fwd+bwd", relu_fwd_bwd)
+
+    # ── MaxPool2d forward + backward ──
+    pool = nn.MaxPool2d(2)
+    x_pool = torch.randn(BATCH, 8, 24, 24, requires_grad=True)
+
+    def pool_fwd():
+        return pool(x_pool)
+
+    bench("maxpool_fwd", pool_fwd, shapes="[32,8,24,24]->[32,8,12,12]")
+
+    def pool_fwd_bwd():
+        out = pool(x_pool)
+        out.backward(torch.ones_like(out))
+        x_pool.grad = None
+
+    bench("maxpool_fwd+bwd", pool_fwd_bwd)
+
+    # ── FC (Linear) forward + backward ──
+    fc = nn.Linear(1152, 10)
+    x_fc = torch.randn(BATCH, 1152, requires_grad=True)
+
+    def fc_fwd():
+        return fc(x_fc)
+
+    bench("fc_fwd", fc_fwd, shapes="[32,1152]*[10,1152]->[32,10]")
+
+    def fc_fwd_bwd():
+        out = fc(x_fc)
+        out.backward(torch.ones_like(out))
+        x_fc.grad = None
+        fc.weight.grad = None
+        fc.bias.grad = None
+
+    bench("fc_fwd+bwd", fc_fwd_bwd)
+
+    # ── CrossEntropyLoss forward + backward ──
+    logits = torch.randn(BATCH, 10, requires_grad=True)
+    labels = torch.randint(0, 10, (BATCH,))
+
+    def xent_fwd():
+        return F.cross_entropy(logits, labels)
+
+    bench("xent_fwd", xent_fwd, shapes="[32,10]+labels->[1]")
+
+    def xent_fwd_bwd():
+        loss = F.cross_entropy(logits, labels)
+        loss.backward()
+        logits.grad = None
+
+    bench("xent_fwd+bwd", xent_fwd_bwd)
+
+    # ── Full model forward + backward ──
+    print()
+    print("  Full model (Conv->ReLU->Pool->FC->XEnt):")
+    print(f"  {'':-<22} {'':->10} {'':->10} {'':->10} {'':->10}")
+
+    class Model(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.conv = nn.Conv2d(1, 8, 5)
+            self.pool = nn.MaxPool2d(2)
+            self.fc = nn.Linear(8 * 12 * 12, 10)
+
+        def forward(self, x):
+            x = self.pool(F.relu(self.conv(x)))
+            x = x.view(x.size(0), -1)
+            return self.fc(x)
+
+    model = Model()
+    criterion = nn.CrossEntropyLoss()
+    x_full = torch.randn(BATCH, 1, 28, 28)
+    y_full = torch.randint(0, 10, (BATCH,))
+
+    def full_fwd():
+        return model(x_full)
+
+    bench("model_fwd", full_fwd, shapes="[32,1,28,28]->[32,10]")
+
+    def full_fwd_bwd():
+        out = model(x_full)
+        loss = criterion(out, y_full)
+        loss.backward()
+        for p in model.parameters():
+            p.grad = None
+
+    mean_total = bench("model_fwd+bwd", full_fwd_bwd)
+    imgs_per_sec = BATCH / (mean_total / 1_000_000)
+    print(f"\n  Throughput: {imgs_per_sec:.0f} img/s (at mean)")
+
+    print(f"\n({WARMUP} warmup + {ITERS} timed iterations per op)\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/build.zig
+++ b/build.zig
@@ -86,7 +86,7 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    const use_blas = b.option(bool, "use-blas", "Use BLAS library") orelse false;
+    const use_blas = b.option(bool, "use-blas", "Use BLAS library") orelse (target.result.os.tag == .macos);
 
     _ = package(b, target, optimize, .{ .options = .{ .use_blas = use_blas } });
 
@@ -225,6 +225,29 @@ pub fn build(b: *std.Build) void {
         const step = b.step("bench-inference", "Benchmark inference session (f32 vs int8)");
         step.dependOn(&b.addRunArtifact(exe).step);
     }
+
+    // Per-op microbenchmark
+    const zgml_opbench_pkg = package(b, target, .ReleaseFast, .{ .options = .{ .use_blas = use_blas } });
+    const opbench_mod = b.createModule(.{
+        .root_source_file = b.path("benchmarks/op_bench.zig"),
+        .target = target,
+        .optimize = .ReleaseFast,
+        .imports = &.{
+            .{ .name = "zgml", .module = zgml_opbench_pkg.zgml },
+            .{ .name = "zgml_options", .module = zgml_opbench_pkg.zgml_options },
+        },
+    });
+    const opbench_exe = b.addExecutable(.{
+        .name = "op-bench",
+        .root_module = opbench_mod,
+    });
+    if (use_blas) {
+        linkBlas(target, opbench_exe);
+        opbench_exe.addIncludePath(.{ .cwd_relative = "/usr/include/openblas" });
+    }
+    b.installArtifact(opbench_exe);
+    const opbench_step = b.step("op-bench", "Per-op microbenchmark for MNIST CNN ops");
+    opbench_step.dependOn(&b.addRunArtifact(opbench_exe).step);
 
     // Text generation binary
     const zgml_gen_pkg = package(b, target, .ReleaseFast, .{ .options = .{ .use_blas = use_blas } });

--- a/src/graph.zig
+++ b/src/graph.zig
@@ -712,6 +712,356 @@ pub fn ComputeGraph(comptime T: type) type {
             return profile;
         }
 
+        // ---------------------------------------------------------------
+        // Per-node profiling
+        // ---------------------------------------------------------------
+
+        /// Timing for a single op tag, aggregated across all nodes that share it.
+        pub const OpBucket = struct {
+            tag: Op,
+            fwd_count: u64 = 0,
+            bwd_count: u64 = 0,
+            fwd_ns: u64 = 0,
+            bwd_ns: u64 = 0,
+        };
+
+        /// Result of `profileNodes`: per-op timing for one iteration.
+        pub const NodeProfile = struct {
+            buckets: []OpBucket,
+            fwd_total_ns: u64 = 0,
+            bwd_total_ns: u64 = 0,
+            alloc: Alloc,
+
+            pub fn deinit(self: *NodeProfile) void {
+                self.alloc.free(self.buckets);
+            }
+
+            /// Print a table sorted by total time descending.
+            pub fn render(self: *const NodeProfile, writer: anytype) !void {
+                // Copy and sort by total descending
+                const a = self.alloc;
+                const sorted = try a.alloc(OpBucket, self.buckets.len);
+                defer a.free(sorted);
+                var n: usize = 0;
+                for (self.buckets) |b| {
+                    if (b.fwd_ns > 0 or b.bwd_ns > 0) {
+                        sorted[n] = b;
+                        n += 1;
+                    }
+                }
+                const active = sorted[0..n];
+                std.mem.sortUnstable(OpBucket, active, {}, struct {
+                    fn lessThan(_: void, a_: OpBucket, b_: OpBucket) bool {
+                        return (a_.fwd_ns + a_.bwd_ns) > (b_.fwd_ns + b_.bwd_ns);
+                    }
+                }.lessThan);
+
+                const total_ns = self.fwd_total_ns + self.bwd_total_ns;
+                const total_f: f64 = @floatFromInt(@max(total_ns, 1));
+
+                try writer.print("{s:<22} {s:>6} {s:>10} {s:>6} {s:>10} {s:>10} {s:>6}\n", .{
+                    "op", "fwd_n", "fwd_us", "bwd_n", "bwd_us", "total_us", "pct",
+                });
+                try writer.print("{s:-<22} {s:->6} {s:->10} {s:->6} {s:->10} {s:->10} {s:->6}\n", .{
+                    "", "", "", "", "", "", "",
+                });
+
+                for (active) |b| {
+                    const fwd_us = @as(f64, @floatFromInt(b.fwd_ns)) / 1_000.0;
+                    const bwd_us = @as(f64, @floatFromInt(b.bwd_ns)) / 1_000.0;
+                    const total_us = fwd_us + bwd_us;
+                    const pct = @as(f64, @floatFromInt(b.fwd_ns + b.bwd_ns)) / total_f * 100.0;
+                    try writer.print("{s:<22} {d:>6} {d:>10.1} {d:>6} {d:>10.1} {d:>10.1} {d:>5.1}%\n", .{
+                        @tagName(b.tag), b.fwd_count, fwd_us, b.bwd_count, bwd_us, total_us, pct,
+                    });
+                }
+
+                try writer.print("{s:-<22} {s:->6} {s:->10} {s:->6} {s:->10} {s:->10} {s:->6}\n", .{
+                    "", "", "", "", "", "", "",
+                });
+                try writer.print("{s:<22} {s:>6} {d:>10.1} {s:>6} {d:>10.1} {d:>10.1}\n", .{
+                    "TOTAL", "",
+                    @as(f64, @floatFromInt(self.fwd_total_ns)) / 1_000.0, "",
+                    @as(f64, @floatFromInt(self.bwd_total_ns)) / 1_000.0,
+                    @as(f64, @floatFromInt(total_ns)) / 1_000.0,
+                });
+            }
+        };
+
+        /// Profile every node individually, grouping by op tag.
+        /// Runs one forward + backward pass, timing each node.
+        /// Caller must call `reset()`/`resetGrads()` beforehand.
+        /// Call `deinit()` on the result when done.
+        pub fn profileNodes(self: *Self, alloc_: Alloc, options: struct {
+            loss_grad: ?*Tensor(T) = null,
+            forward_only: bool = false,
+        }) !NodeProfile {
+            // One bucket per Op variant
+            const op_count = @typeInfo(Op).@"enum".fields.len;
+            const buckets = try alloc_.alloc(OpBucket, op_count);
+            for (buckets, 0..) |*b, i| {
+                b.* = .{ .tag = @enumFromInt(i) };
+            }
+
+            var fwd_total_ns: u64 = 0;
+            var bwd_total_ns: u64 = 0;
+
+            // Forward: time each node individually
+            const fwd_nodes = self.nodes.items[0..self.forward_node_count];
+            for (fwd_nodes) |node| {
+                const idx: usize = @intFromEnum(node.opTag());
+                var timer = try std.time.Timer.start();
+                timer.reset();
+                node.compute();
+                const elapsed = timer.read();
+                buckets[idx].fwd_count += 1;
+                buckets[idx].fwd_ns += elapsed;
+                fwd_total_ns += elapsed;
+            }
+
+            // Backward: time each node individually
+            if (!options.forward_only) {
+                if (options.loss_grad) |grad| _ = grad.setAllScalar(1);
+                const bwd_nodes = self.nodes.items[self.forward_node_count..];
+                for (bwd_nodes) |node| {
+                    const idx: usize = @intFromEnum(node.opTag());
+                    var timer = try std.time.Timer.start();
+                    timer.reset();
+                    node.compute();
+                    const elapsed = timer.read();
+                    buckets[idx].bwd_count += 1;
+                    buckets[idx].bwd_ns += elapsed;
+                    bwd_total_ns += elapsed;
+                }
+            }
+
+            return .{
+                .buckets = buckets,
+                .fwd_total_ns = fwd_total_ns,
+                .bwd_total_ns = bwd_total_ns,
+                .alloc = alloc_,
+            };
+        }
+
+        // ---------------------------------------------------------------
+        // Per-step profiling (works with fusion enabled)
+        // ---------------------------------------------------------------
+
+        /// Label for an execution step — either a fused region kind or a single-node op.
+        pub const StepKind = union(enum) {
+            fusion: fused.FusionKind,
+            node: Op,
+
+            pub fn name(self: @This()) []const u8 {
+                return switch (self) {
+                    .fusion => |k| @tagName(k),
+                    .node => |op| @tagName(op),
+                };
+            }
+        };
+
+        /// Compact tensor layout descriptor for profiling output.
+        pub const TensorLayout = struct {
+            n_dims: u8,
+            ne: [tensorlib.max_dims]usize,
+            strides: [tensorlib.max_dims]usize,
+            storage_offset: usize,
+            dense: bool,
+            contiguous: bool,
+
+            pub fn from(t: *const Tensor(T)) TensorLayout {
+                return .{
+                    .n_dims = @intCast(t.n_dims),
+                    .ne = t.ne,
+                    .strides = t.strides,
+                    .storage_offset = t.storage_offset,
+                    .dense = t.isDenseLayout(),
+                    .contiguous = t.isContiguous(),
+                };
+            }
+
+            pub fn render(self: @This(), writer: anytype) !void {
+                try writer.print("shape={any} strides={any}", .{
+                    self.ne[0..self.n_dims], self.strides[0..self.n_dims],
+                });
+                if (self.storage_offset != 0) try writer.print(" off={}", .{self.storage_offset});
+                if (self.contiguous) {
+                    try writer.print(" [contiguous]", .{});
+                } else if (self.dense) {
+                    try writer.print(" [dense+offset]", .{});
+                } else {
+                    try writer.print(" [strided]", .{});
+                }
+            }
+        };
+
+        /// Timing for a single execution step.
+        pub const StepEntry = struct {
+            kind: StepKind,
+            ns: u64,
+            n_elements: usize,
+            /// Layout of the output tensor (dst). Null for fused regions.
+            dst_layout: ?TensorLayout = null,
+            /// Layout of src0 (if applicable).
+            src0_layout: ?TensorLayout = null,
+            /// Layout of src1 (if applicable).
+            src1_layout: ?TensorLayout = null,
+        };
+
+        /// Result of `profileSteps`: per-step timing for forward and backward.
+        pub const StepProfile = struct {
+            forward: []StepEntry,
+            backward: []StepEntry,
+            alloc: Alloc,
+
+            pub fn deinit(self: *StepProfile) void {
+                self.alloc.free(self.forward);
+                self.alloc.free(self.backward);
+            }
+
+            pub fn render(self: *const StepProfile, writer: anytype) !void {
+                try self.renderPhase(writer, "FORWARD", self.forward, false);
+                try self.renderPhase(writer, "BACKWARD", self.backward, false);
+            }
+
+            /// Like render() but includes tensor shape/stride detail for slow steps.
+            pub fn renderDetailed(self: *const StepProfile, writer: anytype, min_us: f64) !void {
+                try self.renderPhase(writer, "FORWARD", self.forward, false);
+                try self.renderPhase(writer, "BACKWARD", self.backward, true);
+                // Show detail for slow backward steps
+                try writer.print("DETAIL (backward steps > {d:.0} us)\n", .{min_us});
+                try writer.print("{s:-<70}\n", .{""});
+                for (self.backward, 0..) |e, idx| {
+                    const us = @as(f64, @floatFromInt(e.ns)) / 1_000.0;
+                    if (us < min_us) continue;
+                    try writer.print("  step[{d}] {s} {d:.1} us ({d} elems)\n", .{ idx, e.kind.name(), us, e.n_elements });
+                    if (e.dst_layout) |l| {
+                        try writer.print("    dst: ", .{});
+                        try l.render(writer);
+                        try writer.print("\n", .{});
+                    }
+                    if (e.src0_layout) |l| {
+                        try writer.print("    src0: ", .{});
+                        try l.render(writer);
+                        try writer.print("\n", .{});
+                    }
+                    if (e.src1_layout) |l| {
+                        try writer.print("    src1: ", .{});
+                        try l.render(writer);
+                        try writer.print("\n", .{});
+                    }
+                }
+                try writer.print("\n", .{});
+            }
+
+            fn renderPhase(self: *const StepProfile, writer: anytype, label: []const u8, entries: []const StepEntry, comptime _: bool) !void {
+                if (entries.len == 0) return;
+
+                // Sort by time descending (copy first)
+                const sorted = try self.alloc.alloc(StepEntry, entries.len);
+                defer self.alloc.free(sorted);
+                @memcpy(sorted, entries);
+                std.mem.sortUnstable(StepEntry, sorted, {}, struct {
+                    fn lessThan(_: void, a: StepEntry, b: StepEntry) bool {
+                        return a.ns > b.ns;
+                    }
+                }.lessThan);
+
+                var total_ns: u64 = 0;
+                for (entries) |e| total_ns += e.ns;
+                const total_f: f64 = @floatFromInt(@max(total_ns, 1));
+
+                try writer.print("{s} steps ({d} total, {d:.1} us)\n", .{
+                    label, entries.len, @as(f64, @floatFromInt(total_ns)) / 1_000.0,
+                });
+                try writer.print("{s:<24} {s:>10} {s:>10} {s:>6}\n", .{ "step", "us", "elements", "pct" });
+                try writer.print("{s:-<24} {s:->10} {s:->10} {s:->6}\n", .{ "", "", "", "" });
+
+                for (sorted) |e| {
+                    const us = @as(f64, @floatFromInt(e.ns)) / 1_000.0;
+                    const pct = @as(f64, @floatFromInt(e.ns)) / total_f * 100.0;
+                    try writer.print("{s:<24} {d:>10.1} {d:>10} {d:>5.1}%\n", .{
+                        e.kind.name(), us, e.n_elements, pct,
+                    });
+                }
+                try writer.print("\n", .{});
+            }
+        };
+
+        /// Profile each execution step individually (works with fusion).
+        /// Returns per-step timing for forward and backward passes.
+        pub fn profileSteps(self: *Self, alloc_: Alloc, options: ExecutionProfileOptions) !StepProfile {
+            if (options.reset) self.reset();
+            if (options.reset_grads) self.resetGrads();
+            if (options.loss_grad) |grad| _ = grad.setAllScalar(1);
+
+            const fwd_steps = self.forward_execution_steps.items;
+            const all_steps = self.execution_steps.items;
+            const bwd_steps = if (all_steps.len > fwd_steps.len) all_steps[fwd_steps.len..] else &[_]ExecutionStep{};
+
+            const forward = try alloc_.alloc(StepEntry, fwd_steps.len);
+            errdefer alloc_.free(forward);
+            self.timeSteps(fwd_steps, forward);
+
+            const backward = if (!options.forward_only) blk: {
+                const b = try alloc_.alloc(StepEntry, bwd_steps.len);
+                self.timeSteps(bwd_steps, b);
+                break :blk b;
+            } else try alloc_.alloc(StepEntry, 0);
+
+            return .{ .forward = forward, .backward = backward, .alloc = alloc_ };
+        }
+
+        fn timeSteps(self: *const Self, steps: []const ExecutionStep, out: []StepEntry) void {
+            const pool = if (self.thread_pool) |*tp| @constCast(tp) else null;
+            var timer = std.time.Timer.start() catch @panic("timer");
+            for (steps, 0..) |step, i| {
+                timer.reset();
+                switch (step) {
+                    .fusion => |idx| {
+                        const plan = self.fused_chains.items[idx];
+                        if (pool != null and plan.kind() == .elementwise_chain) {
+                            fused.executeFusedChainParallel(T, plan.payload.elementwise_chain, pool.?);
+                        } else {
+                            fused.executeFusionPlan(T, plan);
+                        }
+                        const elapsed = timer.read();
+                        const out_node = self.nodes.items[plan.output_idx];
+                        out[i] = .{
+                            .kind = .{ .fusion = plan.kind() },
+                            .ns = elapsed,
+                            .n_elements = out_node.nElems(),
+                            .dst_layout = TensorLayout.from(out_node),
+                            .src0_layout = if (out_node.src0) |s| TensorLayout.from(s) else null,
+                        };
+                    },
+                    .node => |node| {
+                        if (pool != null and node.opTag() == .matmul) {
+                            const flags = node.matmul_flags;
+                            const s0 = node.src0.?;
+                            const s1 = node.src1.?;
+                            if (flags.trans0) {
+                                if (flags.trans1) Tensor(T).computeMatMulParallel(node, s0, true, s1, true, pool.?) else Tensor(T).computeMatMulParallel(node, s0, true, s1, false, pool.?);
+                            } else {
+                                if (flags.trans1) Tensor(T).computeMatMulParallel(node, s0, false, s1, true, pool.?) else Tensor(T).computeMatMulParallel(node, s0, false, s1, false, pool.?);
+                            }
+                        } else {
+                            node.compute();
+                        }
+                        const elapsed = timer.read();
+                        out[i] = .{
+                            .kind = .{ .node = node.opTag() },
+                            .ns = elapsed,
+                            .n_elements = node.nElems(),
+                            .dst_layout = TensorLayout.from(node),
+                            .src0_layout = if (node.src0) |s| TensorLayout.from(s) else null,
+                            .src1_layout = if (node.src1) |s| TensorLayout.from(s) else null,
+                        };
+                    },
+                }
+            }
+        }
+
         pub fn dumpTensorLineage(self: *const Self, writer: anytype, needle: *Tensor(T)) !void {
             const idx = fused.indexOfNodeMaybe(T, self.nodes.items, needle) orelse {
                 try writer.print("tensor not found in graph\n", .{});

--- a/src/main.zig
+++ b/src/main.zig
@@ -4,6 +4,7 @@ pub const Tensor = @import("tensor.zig").Tensor;
 pub const IndexTensor = @import("index.zig").IndexTensor;
 pub const max_dims = @import("tensor.zig").max_dims;
 pub const ComputeGraph = @import("graph.zig").ComputeGraph;
+pub const Op = @import("op.zig").Op;
 
 pub const shaped = @import("shaped.zig");
 pub const Shaped = shaped.Shaped;

--- a/src/tensor.zig
+++ b/src/tensor.zig
@@ -492,6 +492,15 @@ pub fn Tensor(comptime T: type) type {
             return true;
         }
 
+        /// True if all strides are zero — a scalar broadcast to any shape.
+        /// Every element maps to data[storage_offset].
+        pub fn isBroadcastScalar(self: *const Self) bool {
+            for (self.strides[0..]) |s| {
+                if (s != 0) return false;
+            }
+            return true;
+        }
+
         /// True if this is a 1-D vector (dims 1+ are all 1).
         pub fn isVector(self: *const Self) bool {
             for (self.ne[1..]) |s| {
@@ -521,14 +530,32 @@ pub fn Tensor(comptime T: type) type {
             return true;
         }
 
-        /// True if data is laid out contiguously in memory (no stride gaps).
+        /// True if data is laid out contiguously in memory starting at offset 0.
         pub fn isContiguous(self: *const Self) bool {
             if (self.storage_offset != 0) return false;
+            return self.isDenseLayout();
+        }
+
+        /// True if elements are densely packed (standard strides) but possibly
+        /// at a non-zero storage_offset. Use `denseSlice()` to get the actual
+        /// contiguous element range.
+        pub fn isDenseLayout(self: *const Self) bool {
             if (self.strides[0] != 1) return false;
             for (1..max_dims) |i| {
                 if (self.strides[i] != self.strides[i - 1] * self.ne[i - 1]) return false;
             }
             return true;
+        }
+
+        /// Returns the densely-packed element slice `data[offset..offset+nElems]`.
+        /// Only valid when `isDenseLayout()` is true.
+        pub fn denseSlice(self: *const Self) []T {
+            return self.data[self.storage_offset..][0..self.nElems()];
+        }
+
+        /// Const version of `denseSlice()`.
+        pub fn denseSliceConst(self: *const Self) []const T {
+            return self.data[self.storage_offset..][0..self.nElems()];
         }
 
         /// True if self can be broadcast (repeated) to match `other`'s shape.

--- a/src/tensor/forward.zig
+++ b/src/tensor/forward.zig
@@ -11,12 +11,7 @@ const std = @import("std");
 const assert = std.debug.assert;
 const builtin = @import("builtin");
 const Op = @import("../op.zig").Op;
-const opts = if (@hasDecl(@import("root"), "zgml_options"))
-    @import("zgml_options")
-else
-    struct {
-        pub const use_blas = false;
-    };
+const opts = @import("zgml_options");
 
 const c = if (opts.use_blas)
     switch (builtin.os.tag) {
@@ -217,6 +212,14 @@ fn computeStructuralDup(comptime Self: type, dst: *Self, src0: *const Self) void
 }
 
 fn computeBinaryGeneric(comptime Self: type, comptime Tt: type, dst: *Self, src0: *const Self, src1: *const Self, comptime f: fn (Tt, Tt) Tt) void {
+    // Fast path: vectorize inner dim when all three tensors are dense and match at dim 0
+    if (dst.strides[0] == 1 and
+        src0.strides[0] == 1 and src0.ne[0] == dst.ne[0] and
+        src1.strides[0] == 1 and src1.ne[0] == dst.ne[0])
+    {
+        computeBinaryInnerSimd(Self, Tt, dst, src0, src1, f);
+        return;
+    }
     var coords: [max_dims]usize = [_]usize{0} ** max_dims;
     var lhs_coords: [max_dims]usize = [_]usize{0} ** max_dims;
     var rhs_coords: [max_dims]usize = [_]usize{0} ** max_dims;
@@ -233,6 +236,64 @@ fn computeBinaryGeneric(comptime Self: type, comptime Tt: type, dst: *Self, src0
         );
         if (!nextCoord(coords[0..dst.n_dims], dst.ne[0..dst.n_dims])) break;
     }
+}
+
+/// Vectorized binary op for tensors where the innermost dimension is contiguous.
+/// Merges consecutive dense dims into a single SIMD span, then iterates outer
+/// (possibly broadcast) dims with stride arithmetic.
+/// Precondition: all three tensors have stride[0]==1 and ne[0] matches.
+fn computeBinaryInnerSimd(comptime Self: type, comptime Tt: type, dst: *Self, src0: *const Self, src1: *const Self, comptime f: fn (Tt, Tt) Tt) void {
+    const vec_size = comptime simdVecSize(Tt);
+    const VecT = @Vector(vec_size, Tt);
+
+    // Merge consecutive dims where all three tensors are dense and non-broadcast.
+    var inner_span: usize = dst.ne[0];
+    var outer_dim: usize = 1;
+    while (outer_dim < dst.n_dims) : (outer_dim += 1) {
+        if (dst.strides[outer_dim] != inner_span) break;
+        if (src0.strides[outer_dim] != inner_span or src0.ne[outer_dim] != dst.ne[outer_dim]) break;
+        if (src1.strides[outer_dim] != inner_span or src1.ne[outer_dim] != dst.ne[outer_dim]) break;
+        inner_span *= dst.ne[outer_dim];
+    }
+
+    // Iterate outer dimensions with broadcast-aware offsets.
+    var coords: [max_dims]usize = [_]usize{0} ** max_dims;
+    while (true) {
+        var d_off: usize = dst.storage_offset;
+        var s0_off: usize = src0.storage_offset;
+        var s1_off: usize = src1.storage_offset;
+        for (outer_dim..dst.n_dims) |dim| {
+            d_off += coords[dim] * dst.strides[dim];
+            s0_off += if (src0.ne[dim] > 1) coords[dim] * src0.strides[dim] else 0;
+            s1_off += if (src1.ne[dim] > 1) coords[dim] * src1.strides[dim] else 0;
+        }
+
+        const d = dst.data[d_off..];
+        const a = src0.data[s0_off..];
+        const b = src1.data[s1_off..];
+        var j: usize = 0;
+        while (j + vec_size <= inner_span) : (j += vec_size) {
+            const va: VecT = a[j..][0..vec_size].*;
+            const vb: VecT = b[j..][0..vec_size].*;
+            d[j..][0..vec_size].* = vecBinaryOp(Tt, f, va, vb);
+        }
+        while (j < inner_span) : (j += 1) {
+            d[j] = f(a[j], b[j]);
+        }
+
+        if (outer_dim >= dst.n_dims) break;
+        if (!nextCoord(coords[outer_dim..dst.n_dims], dst.ne[outer_dim..dst.n_dims])) break;
+    }
+}
+
+/// Element-wise binary op on SIMD vectors via comptime scalar function.
+fn vecBinaryOp(comptime Tt: type, comptime f: fn (Tt, Tt) Tt, a: anytype, b: anytype) @TypeOf(a) {
+    const vec_size = @typeInfo(@TypeOf(a)).vector.len;
+    var result: @TypeOf(a) = undefined;
+    inline for (0..vec_size) |i| {
+        result[i] = f(a[i], b[i]);
+    }
+    return result;
 }
 
 fn computeReduceGeneric(comptime Self: type, comptime Tt: type, dst: *Self, src0: *const Self, comptime op: enum { sum, max }, mean_divisor: ?Tt) void {
@@ -495,6 +556,56 @@ pub fn selectMatMulKernel(comptime T: type) MatMulFnType(T) {
     return State.cached;
 }
 
+/// BLAS-accelerated sgemm with the same stride-based calling convention as MatMulFnType.
+/// Dispatches to cblas_sgemm when BLAS is available, otherwise falls back to the
+/// best tiled kernel. Used by fused conv2d kernels to route GEMMs through Accelerate/OpenBLAS.
+pub fn blasSgemm(
+    dst: []f32,
+    A: []const f32,
+    B: []const f32,
+    M: usize,
+    N: usize,
+    K: usize,
+    a_row_stride: usize,
+    a_col_stride: usize,
+    b_row_stride: usize,
+    b_col_stride: usize,
+    a_offset: usize,
+    b_offset: usize,
+    dst_offset: usize,
+    dst_row_stride: usize,
+) void {
+    if (opts.use_blas) {
+        // Map stride convention to BLAS transpose flags + leading dimensions.
+        // col_stride == 1 → NoTrans (row-major), ld = row_stride
+        // row_stride == 1 → Trans (column stored as rows), ld = col_stride
+        const trans_a: c_uint = if (a_col_stride == 1) c.CblasNoTrans else c.CblasTrans;
+        const lda: c_int = @intCast(if (a_col_stride == 1) a_row_stride else a_col_stride);
+        const trans_b: c_uint = if (b_col_stride == 1) c.CblasNoTrans else c.CblasTrans;
+        const ldb: c_int = @intCast(if (b_col_stride == 1) b_row_stride else b_col_stride);
+
+        c.cblas_sgemm(
+            c.CblasRowMajor,
+            trans_a,
+            trans_b,
+            @intCast(M),
+            @intCast(N),
+            @intCast(K),
+            1.0,
+            A[a_offset..].ptr,
+            lda,
+            B[b_offset..].ptr,
+            ldb,
+            0.0,
+            dst[dst_offset..].ptr,
+            @intCast(dst_row_stride),
+        );
+    } else {
+        const mm = selectMatMulKernel(f32);
+        mm(dst, A, B, M, N, K, a_row_stride, a_col_stride, b_row_stride, b_col_stride, a_offset, b_offset, dst_offset, dst_row_stride);
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Forward compute operations parameterized on the tensor type
 // ---------------------------------------------------------------------------
@@ -731,32 +842,27 @@ pub fn Ops(comptime Self: type, comptime T: type) type {
 
         pub fn computeAdd(dst: *Self, src0: *const Self, src1: *const Self) void {
             if (src0.isSameShape(src1) and dst.isSameShape(src0)) {
-                if (dst.isContiguous() and src0.isContiguous() and src1.isContiguous()) {
-                    simdMapBinary(T, .vec_vec, src0.data, src1.data, dst.data, addVec, addScalar);
+                if (dst.isDenseLayout() and src0.isDenseLayout() and src1.isDenseLayout()) {
+                    simdMapBinary(T, .vec_vec, src0.denseSliceConst(), src1.denseSliceConst(), dst.denseSlice(), addVec, addScalar);
+                } else if (src0.isBroadcastScalar() and dst.isDenseLayout() and src1.isDenseLayout()) {
+                    simdMapBinary(T, .scalar_lhs, src0.data[src0.storage_offset..][0..1], src1.denseSliceConst(), dst.denseSlice(), addVec, addScalar);
+                } else if (src1.isBroadcastScalar() and dst.isDenseLayout() and src0.isDenseLayout()) {
+                    simdMapBinary(T, .scalar_rhs, src0.denseSliceConst(), src1.data[src1.storage_offset..][0..1], dst.denseSlice(), addVec, addScalar);
                 } else {
-                    if (dst.n_dims > 4) {
-                        computeBinaryGeneric(Self, T, dst, src0, src1, addScalar);
-                        return;
-                    }
-                    for (0..dst.ne[3]) |d3| {
-                        for (0..dst.ne[2]) |d2| {
-                            for (0..dst.ne[1]) |d1| {
-                                for (0..dst.ne[0]) |d0| {
-                                    const dst_idx = elemOffset(dst.strides, d0, d1, d2, d3);
-                                    const src0_idx = elemOffset(src0.strides, d0, d1, d2, d3);
-                                    const src1_idx = elemOffset(src1.strides, d0, d1, d2, d3);
-                                    dst.data[dst_idx] = src0.data[src0_idx] + src1.data[src1_idx];
-                                }
-                            }
-                        }
-                    }
+                    computeBinaryGeneric(Self, T, dst, src0, src1, addScalar);
                 }
-            } else if (src1.isScalar() and dst.isSameShape(src0)) {
-                assert(dst.isSameShape(src0));
-                simdMapBinary(T, .scalar_rhs, src0.data, src1.data, dst.data, addVec, addScalar);
-            } else if (src0.isScalar() and dst.isSameShape(src1)) {
-                assert(dst.isSameShape(src1));
-                simdMapBinary(T, .scalar_lhs, src0.data, src1.data, dst.data, addVec, addScalar);
+            } else if ((src1.isScalar() or src1.isBroadcastScalar()) and dst.isSameShape(src0)) {
+                if (dst.isDenseLayout() and src0.isDenseLayout()) {
+                    simdMapBinary(T, .scalar_rhs, src0.denseSliceConst(), src1.data[src1.storage_offset..][0..1], dst.denseSlice(), addVec, addScalar);
+                } else {
+                    simdMapBinary(T, .scalar_rhs, src0.data, src1.data, dst.data, addVec, addScalar);
+                }
+            } else if ((src0.isScalar() or src0.isBroadcastScalar()) and dst.isSameShape(src1)) {
+                if (dst.isDenseLayout() and src1.isDenseLayout()) {
+                    simdMapBinary(T, .scalar_lhs, src0.data[src0.storage_offset..][0..1], src1.denseSliceConst(), dst.denseSlice(), addVec, addScalar);
+                } else {
+                    simdMapBinary(T, .scalar_lhs, src0.data, src1.data, dst.data, addVec, addScalar);
+                }
             } else {
                 computeBinaryGeneric(Self, T, dst, src0, src1, addScalar);
             }
@@ -764,8 +870,8 @@ pub fn Ops(comptime Self: type, comptime T: type) type {
 
         pub fn computeSub(dst: *Self, src0: *const Self, src1: *const Self) void {
             if (src0.isSameShape(src1) and dst.isSameShape(src0)) {
-                if (dst.isContiguous() and src0.isContiguous() and src1.isContiguous()) {
-                    simdMapBinary(T, .vec_vec, src0.data, src1.data, dst.data, subVec, subScalar);
+                if (dst.isDenseLayout() and src0.isDenseLayout() and src1.isDenseLayout()) {
+                    simdMapBinary(T, .vec_vec, src0.denseSliceConst(), src1.denseSliceConst(), dst.denseSlice(), subVec, subScalar);
                 } else {
                     if (dst.n_dims > 4) {
                         computeBinaryGeneric(Self, T, dst, src0, src1, subScalar);
@@ -786,44 +892,47 @@ pub fn Ops(comptime Self: type, comptime T: type) type {
                 }
             } else if (src1.isScalar() and dst.isSameShape(src0)) {
                 assert(dst.isSameShape(src0));
-                simdMapBinary(T, .scalar_rhs, src0.data, src1.data, dst.data, subVec, subScalar);
+                if (dst.isDenseLayout() and src0.isDenseLayout()) {
+                    simdMapBinary(T, .scalar_rhs, src0.denseSliceConst(), src1.denseSliceConst(), dst.denseSlice(), subVec, subScalar);
+                } else {
+                    simdMapBinary(T, .scalar_rhs, src0.data, src1.data, dst.data, subVec, subScalar);
+                }
             } else if (src0.isScalar() and dst.isSameShape(src1)) {
                 assert(dst.isSameShape(src1));
-                simdMapBinary(T, .scalar_lhs, src0.data, src1.data, dst.data, subVec, subScalar);
+                if (dst.isDenseLayout() and src1.isDenseLayout()) {
+                    simdMapBinary(T, .scalar_lhs, src0.denseSliceConst(), src1.denseSliceConst(), dst.denseSlice(), subVec, subScalar);
+                } else {
+                    simdMapBinary(T, .scalar_lhs, src0.data, src1.data, dst.data, subVec, subScalar);
+                }
             } else {
                 computeBinaryGeneric(Self, T, dst, src0, src1, subScalar);
             }
         }
 
         pub fn computeMul(dst: *Self, src0: *const Self, src1: *const Self) void {
-            if (src0.isScalar()) {
-                assert(dst.isSameShape(src1));
-                simdMapBinary(T, .scalar_lhs, src0.data, src1.data, dst.data, mulVec, mulScalar);
-            } else if (src1.isScalar()) {
-                assert(dst.isSameShape(src0));
-                simdMapBinary(T, .scalar_rhs, src0.data, src1.data, dst.data, mulVec, mulScalar);
+            if (src0.isScalar() or src0.isBroadcastScalar()) {
+                if (dst.isDenseLayout() and src1.isDenseLayout()) {
+                    simdMapBinary(T, .scalar_lhs, src0.data[src0.storage_offset..][0..1], src1.denseSliceConst(), dst.denseSlice(), mulVec, mulScalar);
+                } else {
+                    simdMapBinary(T, .scalar_lhs, src0.data, src1.data, dst.data, mulVec, mulScalar);
+                }
+            } else if (src1.isScalar() or src1.isBroadcastScalar()) {
+                if (dst.isDenseLayout() and src0.isDenseLayout()) {
+                    simdMapBinary(T, .scalar_rhs, src0.denseSliceConst(), src1.data[src1.storage_offset..][0..1], dst.denseSlice(), mulVec, mulScalar);
+                } else {
+                    simdMapBinary(T, .scalar_rhs, src0.data, src1.data, dst.data, mulVec, mulScalar);
+                }
             } else {
                 assert(dst.isBroadcastable(src0));
                 assert(src0.isBroadcastable(src1));
-                if (dst.isContiguous() and src0.isContiguous() and src1.isContiguous()) {
-                    simdMapBinary(T, .vec_vec, src0.data, src1.data, dst.data, mulVec, mulScalar);
+                if (dst.isDenseLayout() and src0.isDenseLayout() and src1.isDenseLayout() and dst.isSameShape(src0) and src0.isSameShape(src1)) {
+                    simdMapBinary(T, .vec_vec, src0.denseSliceConst(), src1.denseSliceConst(), dst.denseSlice(), mulVec, mulScalar);
+                } else if (src0.isBroadcastScalar() and dst.isDenseLayout() and src1.isDenseLayout()) {
+                    simdMapBinary(T, .scalar_lhs, src0.data[src0.storage_offset..][0..1], src1.denseSliceConst(), dst.denseSlice(), mulVec, mulScalar);
+                } else if (src1.isBroadcastScalar() and dst.isDenseLayout() and src0.isDenseLayout()) {
+                    simdMapBinary(T, .scalar_rhs, src0.denseSliceConst(), src1.data[src1.storage_offset..][0..1], dst.denseSlice(), mulVec, mulScalar);
                 } else {
-                    if (dst.n_dims > 4 or !dst.isSameShape(src0) or !src0.isSameShape(src1)) {
-                        computeBinaryGeneric(Self, T, dst, src0, src1, mulScalar);
-                        return;
-                    }
-                    for (0..dst.ne[3]) |d3| {
-                        for (0..dst.ne[2]) |d2| {
-                            for (0..dst.ne[1]) |d1| {
-                                for (0..dst.ne[0]) |d0| {
-                                    const dst_idx = elemOffset(dst.strides, d0, d1, d2, d3);
-                                    const src0_idx = elemOffset(src0.strides, d0, d1, d2, d3);
-                                    const src1_idx = elemOffset(src1.strides, d0, d1, d2, d3);
-                                    dst.data[dst_idx] = src0.data[src0_idx] * src1.data[src1_idx];
-                                }
-                            }
-                        }
-                    }
+                    computeBinaryGeneric(Self, T, dst, src0, src1, mulScalar);
                 }
             }
         }
@@ -831,15 +940,23 @@ pub fn Ops(comptime Self: type, comptime T: type) type {
         pub fn computeDiv(dst: *Self, src0: *const Self, src1: *const Self) void {
             if (src0.isScalar()) {
                 assert(dst.isSameShape(src1));
-                simdMapBinary(T, .scalar_lhs, src0.data, src1.data, dst.data, divVec, divScalar);
+                if (dst.isDenseLayout() and src1.isDenseLayout()) {
+                    simdMapBinary(T, .scalar_lhs, src0.denseSliceConst(), src1.denseSliceConst(), dst.denseSlice(), divVec, divScalar);
+                } else {
+                    simdMapBinary(T, .scalar_lhs, src0.data, src1.data, dst.data, divVec, divScalar);
+                }
             } else if (src1.isScalar()) {
                 assert(dst.isSameShape(src0));
-                simdMapBinary(T, .scalar_rhs, src0.data, src1.data, dst.data, divVec, divScalar);
+                if (dst.isDenseLayout() and src0.isDenseLayout()) {
+                    simdMapBinary(T, .scalar_rhs, src0.denseSliceConst(), src1.denseSliceConst(), dst.denseSlice(), divVec, divScalar);
+                } else {
+                    simdMapBinary(T, .scalar_rhs, src0.data, src1.data, dst.data, divVec, divScalar);
+                }
             } else {
                 assert(dst.isBroadcastable(src0));
                 assert(src0.isBroadcastable(src1));
-                if (dst.isContiguous() and src0.isContiguous() and src1.isContiguous()) {
-                    simdMapBinary(T, .vec_vec, src0.data, src1.data, dst.data, divVec, divScalar);
+                if (dst.isDenseLayout() and src0.isDenseLayout() and src1.isDenseLayout() and dst.isSameShape(src0) and src0.isSameShape(src1)) {
+                    simdMapBinary(T, .vec_vec, src0.denseSliceConst(), src1.denseSliceConst(), dst.denseSlice(), divVec, divScalar);
                 } else {
                     if (dst.n_dims > 4 or !dst.isSameShape(src0) or !src0.isSameShape(src1)) {
                         computeBinaryGeneric(Self, T, dst, src0, src1, divScalar);

--- a/src/tensor/fused.zig
+++ b/src/tensor/fused.zig
@@ -260,12 +260,15 @@ pub fn FusionPlan(comptime T: type) type {
                 },
                 .conv2d_bwd_input => |*p| {
                     const d = Conv2dDims(T).fromBwdInput(p.*);
-                    p.scratch = try alloc.alloc(T, d.K * d.N);
+                    const NB = d.N * d.batch;
+                    // Batched: col_buf[K, NB] + rearranged grad[c_out, NB]
+                    p.scratch = try alloc.alloc(T, (d.K + d.c_out) * NB);
                 },
                 .conv2d_bwd_kernel => |*p| {
                     const d = Conv2dDims(T).fromBwdKernel(p.*);
-                    // Batched: [K, N*batch] — one im2col for all samples
-                    p.scratch = try alloc.alloc(T, d.K * d.N * d.batch);
+                    const NB = d.N * d.batch;
+                    // Batched: col_buf[K, NB] + rearranged grad[c_out, NB]
+                    p.scratch = try alloc.alloc(T, (d.K + d.c_out) * NB);
                 },
                 else => {},
             }
@@ -350,7 +353,50 @@ fn fusedOpForNode(comptime T: type, plan: ElementwiseFusionPlan(T), idx: usize) 
     };
 }
 
-/// Apply a single op to a value. Comptime-dispatched — no runtime branching.
+// ---------------------------------------------------------------------------
+// SIMD + stride helpers
+// ---------------------------------------------------------------------------
+
+/// SIMD vector width (in lanes) for type T. Targets 256-bit.
+fn vecSize(comptime T: type) comptime_int {
+    const lanes = 32 / @sizeOf(T);
+    return if (lanes >= 4) lanes else 4;
+}
+
+const max_dims = @import("../tensor.zig").max_dims;
+
+/// Advance an N-dimensional coordinate by 1, returning false when done.
+inline fn nextCoord(coords: []usize, shape: []const usize) bool {
+    var d: usize = 0;
+    while (d < coords.len) : (d += 1) {
+        coords[d] += 1;
+        if (coords[d] < shape[d]) return true;
+        coords[d] = 0;
+    }
+    return false;
+}
+
+/// Compute strided offset for a set of coordinates.
+inline fn stridedOffset(strides: []const usize, coords: []const usize, base: usize) usize {
+    var off: usize = base;
+    for (strides, coords) |s, c| off += s * c;
+    return off;
+}
+
+/// Load one scalar element from a chain "other" operand.
+inline fn loadOther(comptime T: type, other: anytype, i: usize) T {
+    return if (other.nElems() <= 1) other.data[other.storage_offset] else other.data[i + other.storage_offset];
+}
+
+/// Load a SIMD vector from a chain "other" operand: splat if scalar, load if dense.
+inline fn loadOtherVec(comptime T: type, comptime V: comptime_int, other: anytype, i: usize) @Vector(V, T) {
+    return if (other.nElems() <= 1)
+        @splat(other.data[other.storage_offset])
+    else
+        other.data[i + other.storage_offset ..][0..V].*;
+}
+
+/// Apply a single op to a scalar value. Comptime-dispatched — no runtime branching.
 fn applyOp(comptime T: type, comptime op: FusedOp, val: T, node: anytype, i: usize) T {
     return switch (op) {
         .neg => -val,
@@ -364,25 +410,39 @@ fn applyOp(comptime T: type, comptime op: FusedOp, val: T, node: anytype, i: usi
         .gelu => 0.5 * val * (1.0 + std.math.tanh(
             @as(T, SQRT_2_OVER_PI) * val * (1.0 + @as(T, GELU_COEF_A) * val * val),
         )),
-        .add_src1 => blk: {
-            const other = node.src1.?;
-            break :blk val + if (other.data.len <= 1) other.data[0] else other.data[i];
+        .add_src1 => val + loadOther(T, node.src1.?, i),
+        .add_src0 => val + loadOther(T, node.src0.?, i),
+        .mul_src1 => if (node.src0.? == node.src1.?) val * val else val * loadOther(T, node.src1.?, i),
+        .mul_src0 => if (node.src0.? == node.src1.?) val * val else val * loadOther(T, node.src0.?, i),
+    };
+}
+
+/// Apply a single op to a SIMD vector. Comptime-dispatched — no runtime branching.
+fn applyOpVec(comptime T: type, comptime V: comptime_int, comptime op: FusedOp, val: @Vector(V, T), node: anytype, i: usize) @Vector(V, T) {
+    const VecT = @Vector(V, T);
+    return switch (op) {
+        .neg => -val,
+        .abs => @abs(val),
+        .sgn => blk: {
+            const zero: VecT = @splat(0);
+            break :blk @select(T, val > zero, @as(VecT, @splat(@as(T, 1))), @select(T, val < zero, @as(VecT, @splat(@as(T, -1))), zero));
         },
-        .add_src0 => blk: {
-            const other = node.src0.?;
-            break :blk val + if (other.data.len <= 1) other.data[0] else other.data[i];
+        .step => @select(T, val > @as(VecT, @splat(@as(T, 0))), @as(VecT, @splat(@as(T, 1))), @as(VecT, @splat(@as(T, 0)))),
+        .sqrt => @sqrt(val),
+        .recip => @as(VecT, @splat(@as(T, 1))) / val,
+        .exp => @exp(val),
+        .log => @log(val),
+        .gelu => blk: {
+            const one: VecT = @splat(@as(T, 1));
+            const two: VecT = @splat(@as(T, 2));
+            const inner = @as(VecT, @splat(@as(T, SQRT_2_OVER_PI))) * val * (one + @as(VecT, @splat(@as(T, GELU_COEF_A))) * val * val);
+            const e2 = @exp(two * inner);
+            break :blk @as(VecT, @splat(@as(T, 0.5))) * val * (one + (e2 - one) / (e2 + one));
         },
-        .mul_src1 => blk: {
-            // sqr: src0 == src1, both operands are the chain value
-            if (node.src0.? == node.src1.?) break :blk val * val;
-            const other = node.src1.?;
-            break :blk val * if (other.data.len <= 1) other.data[0] else other.data[i];
-        },
-        .mul_src0 => blk: {
-            if (node.src0.? == node.src1.?) break :blk val * val;
-            const other = node.src0.?;
-            break :blk val * if (other.data.len <= 1) other.data[0] else other.data[i];
-        },
+        .add_src1 => val + loadOtherVec(T, V, node.src1.?, i),
+        .add_src0 => val + loadOtherVec(T, V, node.src0.?, i),
+        .mul_src1 => if (node.src0.? == node.src1.?) val * val else val * loadOtherVec(T, V, node.src1.?, i),
+        .mul_src0 => if (node.src0.? == node.src1.?) val * val else val * loadOtherVec(T, V, node.src0.?, i),
     };
 }
 
@@ -394,52 +454,96 @@ pub fn FusedKernel(comptime T: type, comptime ops: []const FusedOp) type {
             executeRange(nodes, 0, nodes[nodes.len - 1].nElems());
         }
 
+        /// SIMD-vectorized execution for dense (contiguous) inputs only.
+        /// Non-dense inputs must be handled by the generic interpreter.
         pub fn executeRange(nodes: []const *Tensor(T), start: usize, end: usize) void {
-            const input_data = nodes[0].source0().?.data;
-            for (start..end) |i| {
-                var val: T = input_data[i];
+            const V = comptime vecSize(T);
+            const VecT = @Vector(V, T);
+            const input = nodes[0].source0().?;
+            const input_data = input.data;
+            const input_off = input.storage_offset;
+
+            var i: usize = start;
+            while (i + V <= end) : (i += V) {
+                var val: VecT = input_data[i + input_off ..][0..V].*;
+                inline for (ops, 0..) |op, k| {
+                    val = applyOpVec(T, V, op, val, nodes[k], i);
+                    nodes[k].data[i + nodes[k].storage_offset ..][0..V].* = val;
+                }
+            }
+            while (i < end) : (i += 1) {
+                var val: T = input_data[i + input_off];
                 inline for (ops, 0..) |op, k| {
                     val = applyOp(T, op, val, nodes[k], i);
-                    nodes[k].data[i] = val;
+                    nodes[k].data[i + nodes[k].storage_offset] = val;
                 }
             }
         }
     };
 }
 
-/// Runtime interpreter for a range of elements. Used by both the generic
-/// fallback and the parallel executor.
+/// Runtime interpreter for a range of elements. Uses SIMD for the main loop
+/// with a scalar tail. Used by both the generic fallback and parallel executor.
 fn executeFusedGenericRange(comptime T: type, plan: ElementwiseFusionPlan(T), start: usize, end: usize) void {
+    const V = comptime vecSize(T);
+    const VecT = @Vector(V, T);
     const nodes = plan.nodes;
-    const input_data = plan.input.data;
+    const input = plan.input;
+    const input_data = input.data;
+    const input_dense = input.isDenseLayout();
 
-    for (start..end) |i| {
-        var val: T = input_data[i];
-        for (nodes, 0..) |node, node_idx| {
-            val = switch (node.op) {
-                .neg => -val,
-                .abs => @abs(val),
-                .sgn => if (val > 0) 1 else if (val < 0) @as(T, -1) else 0,
-                .step => if (val > 0) @as(T, 1) else 0,
-                .sqrt => @sqrt(val),
-                .recip => 1.0 / val,
-                .exp => @exp(val),
-                .log => @log(val),
-                .gelu => 0.5 * val * (1.0 + std.math.tanh(
-                    @as(T, SQRT_2_OVER_PI) * val * (1.0 + @as(T, GELU_COEF_A) * val * val),
-                )),
-                .add => blk: {
-                    const other = plan.otherOperand(node_idx).?;
-                    break :blk val + if (other.data.len <= 1) other.data[0] else other.data[i];
-                },
-                .mul => blk: {
-                    if (node.src0.? == node.src1.?) break :blk val * val;
-                    const other = plan.otherOperand(node_idx).?;
-                    break :blk val * if (other.data.len <= 1) other.data[0] else other.data[i];
-                },
-                else => unreachable,
-            };
-            node.data[i] = val;
+    if (input_dense) {
+        const input_off = input.storage_offset;
+        var i: usize = start;
+        while (i + V <= end) : (i += V) {
+            var val: VecT = input_data[i + input_off ..][0..V].*;
+            for (nodes, 0..) |node, node_idx| {
+                const fop = fusedOpForNode(T, plan, node_idx).?;
+                inline for (fusible_ops) |c| if (fop == c) { val = applyOpVec(T, V, c, val, node, i); };
+                node.data[i + node.storage_offset ..][0..V].* = val;
+            }
+        }
+        while (i < end) : (i += 1) {
+            var val: T = input_data[i + input_off];
+            for (nodes, 0..) |node, node_idx| {
+                const fop = fusedOpForNode(T, plan, node_idx).?;
+                inline for (fusible_ops) |c| if (fop == c) { val = applyOp(T, c, val, node, i); };
+                node.data[i + node.storage_offset] = val;
+            }
+        }
+    } else {
+        // Non-dense input: coordinate-based gather, SIMD for chain ops.
+        const n_dims = input.n_dims;
+        var coords: [max_dims]usize = [_]usize{0} ** max_dims;
+        if (start > 0) {
+            var remaining = start;
+            var d: usize = 0;
+            while (d < n_dims) : (d += 1) {
+                coords[d] = remaining % input.ne[d];
+                remaining /= input.ne[d];
+            }
+        }
+        var i: usize = start;
+        while (i + V <= end) : (i += V) {
+            var val: VecT = undefined;
+            inline for (0..V) |lane| {
+                val[lane] = input_data[stridedOffset(input.strides[0..n_dims], coords[0..n_dims], input.storage_offset)];
+                _ = nextCoord(coords[0..n_dims], input.ne[0..n_dims]);
+            }
+            for (nodes, 0..) |node, node_idx| {
+                const fop = fusedOpForNode(T, plan, node_idx).?;
+                inline for (fusible_ops) |c| if (fop == c) { val = applyOpVec(T, V, c, val, node, i); };
+                node.data[i + node.storage_offset ..][0..V].* = val;
+            }
+        }
+        while (i < end) : (i += 1) {
+            var val: T = input_data[stridedOffset(input.strides[0..n_dims], coords[0..n_dims], input.storage_offset)];
+            _ = nextCoord(coords[0..n_dims], input.ne[0..n_dims]);
+            for (nodes, 0..) |node, node_idx| {
+                const fop = fusedOpForNode(T, plan, node_idx).?;
+                inline for (fusible_ops) |c| if (fop == c) { val = applyOp(T, c, val, node, i); };
+                node.data[i + node.storage_offset] = val;
+            }
         }
     }
 }
@@ -514,6 +618,8 @@ pub fn executeFusedChain(comptime T: type, plan: ElementwiseFusionPlan(T)) void 
 }
 
 fn executeFused2(comptime T: type, plan: ElementwiseFusionPlan(T)) void {
+    // Comptime-specialized kernels require dense input for linear SIMD access.
+    if (!plan.input.isDenseLayout()) return executeFusedGeneric(T, plan);
     const op0 = fusedOpForNode(T, plan, 0) orelse return executeFusedGeneric(T, plan);
     const op1 = fusedOpForNode(T, plan, 1) orelse return executeFusedGeneric(T, plan);
     inline for (fusible_ops) |c0| {
@@ -529,6 +635,8 @@ fn executeFused2(comptime T: type, plan: ElementwiseFusionPlan(T)) void {
 
 fn executeFused3(comptime T: type, plan: ElementwiseFusionPlan(T)) void {
     @setEvalBranchQuota(20000);
+    // Comptime-specialized kernels require dense input for linear SIMD access.
+    if (!plan.input.isDenseLayout()) return executeFusedGeneric(T, plan);
     const op0 = fusedOpForNode(T, plan, 0) orelse return executeFusedGeneric(T, plan);
     const op1 = fusedOpForNode(T, plan, 1) orelse return executeFusedGeneric(T, plan);
     const op2 = fusedOpForNode(T, plan, 2) orelse return executeFusedGeneric(T, plan);
@@ -546,17 +654,16 @@ fn executeFused3(comptime T: type, plan: ElementwiseFusionPlan(T)) void {
 }
 
 pub fn isSafeElementwiseChain(comptime T: type, plan: ElementwiseFusionPlan(T)) bool {
-    // Fused kernel indexes data[i] linearly — requires all tensors to be contiguous.
-    if (!plan.input.isContiguous()) return false;
+    // Chain nodes and other operands are indexed linearly and must be dense.
+    // The input may be non-dense (permuted strides); execution handles it.
     var prev = plan.input;
     const n_elems = plan.nodes[plan.nodes.len - 1].nElems();
     for (plan.nodes, 0..) |node, node_idx| {
         if (!node.isSameShape(prev)) return false;
-        if (!node.isContiguous()) return false;
+        if (!node.isDenseLayout()) return false;
         const other = plan.otherOperand(node_idx);
         if (other) |src| {
-            // Must be scalar (1 elem) or contiguous with matching element count
-            if (src.data.len > 1 and (!src.isContiguous() or src.data.len < n_elems)) return false;
+            if (src.nElems() > 1 and (!src.isDenseLayout() or src.nElems() < n_elems)) return false;
         }
         prev = node;
     }
@@ -743,7 +850,6 @@ fn executeMaxPool2d(comptime T: type, plan: MaxPool2dPlan(T)) void {
 
 /// Shared dimension info for conv2d forward and backward.
 fn Conv2dDims(comptime T: type) type {
-    const max_dims = @import("../tensor.zig").max_dims;
     return struct {
         kw: usize,
         kh: usize,
@@ -843,13 +949,16 @@ fn im2col(comptime T: type, d: Conv2dDims(T), col_buf: []T, n: usize, col_stride
 }
 
 /// Scatter-add columns back to image layout (inverse of im2col).
-/// Accumulates col_buf[K, N] into dst_data at the positions that im2col would read from.
-fn col2im(comptime T: type, d: Conv2dDims(T), dst_data: []T, dst_strides: [@import("../tensor.zig").max_dims]usize, col_buf: []const T, n: usize) void {
+/// Accumulates col_buf into dst_data at the positions that im2col would read from.
+///
+/// col_stride: number of columns per row in col_buf (N for non-batched, N*batch for batched).
+/// col_offset: column offset within each row (0 for non-batched, n*N for batched).
+fn col2im(comptime T: type, d: Conv2dDims(T), dst_data: []T, dst_strides: [@import("../tensor.zig").max_dims]usize, col_buf: []const T, n: usize, col_stride: usize, col_offset: usize) void {
     if (dst_strides[0] == 1) {
         for (0..d.c_in) |ic| {
             for (0..d.kh) |ky| {
                 for (0..d.kw) |kx| {
-                    const row = (kx + ky * d.kw + ic * d.kw * d.kh) * d.N;
+                    const row = (kx + ky * d.kw + ic * d.kw * d.kh) * col_stride + col_offset;
                     for (0..d.out_h) |oy| {
                         const dst_base = kx + (oy + ky) * d.in_w + ic * dst_strides[2] + n * dst_strides[3];
                         const src_base = row + oy * d.out_w;
@@ -864,7 +973,7 @@ fn col2im(comptime T: type, d: Conv2dDims(T), dst_data: []T, dst_strides: [@impo
         for (0..d.c_in) |ic| {
             for (0..d.kh) |ky| {
                 for (0..d.kw) |kx| {
-                    const row = (kx + ky * d.kw + ic * d.kw * d.kh) * d.N;
+                    const row = (kx + ky * d.kw + ic * d.kw * d.kh) * col_stride + col_offset;
                     for (0..d.out_h) |oy| {
                         for (0..d.out_w) |ox| {
                             dst_data[
@@ -894,6 +1003,12 @@ fn freeScratch(comptime T: type, buf: []T) void {
     scratch_allocator.free(buf);
 }
 
+/// Select the best matmul for fused conv2d: BLAS when available (f32), else tiled.
+fn selectConvMatMul(comptime T: type) forward.MatMulFnType(T) {
+    if (T == f32) return &forward.blasSgemm;
+    return forward.selectMatMulKernel(T);
+}
+
 // ---------------------------------------------------------------------------
 // Conv2d execution: forward, backward-input, backward-kernel
 // ---------------------------------------------------------------------------
@@ -917,7 +1032,7 @@ fn executeConv2dPlan(comptime T: type, plan: Conv2dPlan(T)) void {
     }
 
     // 2. Single matmul: kernel[c_out, K] @ col_buf[K, NB] → mm_temp[c_out, NB]
-    const mm = forward.selectMatMulKernel(T);
+    const mm = selectConvMatMul(T);
     mm(mm_temp, d.kernel_data, col_buf.ptr[0..col_buf.len], d.c_out, NB, d.K, d.K, 1, NB, 1, 0, 0, 0, NB);
 
     // 3. Rearrange [c_out, NB] → [batch, c_out, N] with fused bias + activation.
@@ -963,58 +1078,71 @@ fn executeConv2dPlan(comptime T: type, plan: Conv2dPlan(T)) void {
 
 fn executeConv2dBwdInputPlan(comptime T: type, plan: Conv2dBwdInputPlan(T)) void {
     const d = Conv2dDims(T).fromBwdInput(plan);
-    const col_buf = plan.scratch orelse allocScratch(T, d.K * d.N) orelse {
+    const NB = d.N * d.batch;
+    const total_scratch = (d.K + d.c_out) * NB;
+    const scratch = plan.scratch orelse allocScratch(T, total_scratch) orelse {
         conv2dBwdInputNaive(T, d, plan);
         return;
     };
-    defer if (plan.scratch == null) freeScratch(T, col_buf);
+    defer if (plan.scratch == null) freeScratch(T, scratch);
 
-    const mm = forward.selectMatMulKernel(T);
+    const col_buf = scratch[0 .. d.K * NB];
+    const grad_buf = scratch[d.K * NB ..][0 .. d.c_out * NB];
+
+    // 1. Rearrange output_grad from [N, c_out, batch] to [c_out, N*batch]
+    for (0..d.c_out) |oc| {
+        for (0..d.batch) |n| {
+            @memcpy(
+                grad_buf[oc * NB + n * d.N ..][0..d.N],
+                plan.output_grad.data[n * d.N * d.c_out + oc * d.N ..][0..d.N],
+            );
+        }
+    }
+
+    // 2. Single GEMM: kernel^T[K, c_out] @ grad_buf[c_out, NB] → col_buf[K, NB]
+    const mm = selectConvMatMul(T);
+    mm(col_buf, d.kernel_data, grad_buf, d.K, NB, d.c_out, 1, d.K, NB, 1, 0, 0, 0, NB);
+
+    // 3. col2im per batch from batched col_buf
     @memset(plan.output.data, 0);
-
     for (0..d.batch) |n| {
-        // kernel^T[K, c_out] @ out_grad_n[c_out, N] → col_buf[K, N]
-        mm(col_buf, d.kernel_data, plan.output_grad.data, d.K, d.N, d.c_out, 1, d.K, d.N, 1, 0, n * d.N * d.c_out, 0, d.N);
-        col2im(T, d, plan.output.data, plan.output.strides, col_buf, n);
+        col2im(T, d, plan.output.data, plan.output.strides, col_buf, n, NB, n * d.N);
     }
 }
 
 fn executeConv2dBwdKernelPlan(comptime T: type, plan: Conv2dBwdKernelPlan(T)) void {
     const d = Conv2dDims(T).fromBwdKernel(plan);
     const NB = d.N * d.batch;
+    const total_scratch = (d.K + d.c_out) * NB;
 
-    const col_buf = plan.scratch orelse allocScratch(T, d.K * NB) orelse {
+    const scratch = plan.scratch orelse allocScratch(T, total_scratch) orelse {
         conv2dBwdKernelNaive(T, d, plan);
         return;
     };
-    defer if (plan.scratch == null) freeScratch(T, col_buf);
+    defer if (plan.scratch == null) freeScratch(T, scratch);
 
-    // Build batched im2col: [K, N*batch] — all samples concatenated.
+    const col_buf = scratch[0 .. d.K * NB];
+    const grad_buf = scratch[d.K * NB ..][0 .. d.c_out * NB];
+
+    // 1. Build batched im2col: [K, N*batch] — all samples concatenated.
     for (0..d.batch) |n| {
         im2col(T, d, col_buf, n, NB, n * d.N);
     }
 
-    // Per-batch matmul: out_grad_n[c_out, N] @ col_n^T[N, K] → accumulate into output[c_out, K].
-    // Layout is [out_w, out_h, c_out, batch] — channels are interleaved with batches,
-    // so we can't do a single batched matmul.
-    const mm = forward.selectMatMulKernel(T);
-
-    // First batch: write directly to output.
-    // col_buf layout is [K, NB] — rows have stride NB, not N.
-    mm(plan.output.data, plan.output_grad.data, col_buf, d.c_out, d.K, d.N, d.N, 1, 1, NB, 0, 0, 0, d.K);
-
-    // Remaining batches: matmul into temp, then accumulate.
-    if (d.batch > 1) {
-        const temp = allocScratch(T, d.c_out * d.K) orelse {
-            conv2dBwdKernelNaive(T, d, plan);
-            return;
-        };
-        defer freeScratch(T, temp);
-        for (1..d.batch) |n| {
-            mm(temp, plan.output_grad.data, col_buf, d.c_out, d.K, d.N, d.N, 1, 1, NB, n * d.N * d.c_out, n * d.N, 0, d.K);
-            for (0..d.c_out * d.K) |j| plan.output.data[j] += temp[j];
+    // 2. Rearrange output_grad from [N, c_out, batch] to [c_out, N*batch]
+    for (0..d.c_out) |oc| {
+        for (0..d.batch) |n| {
+            @memcpy(
+                grad_buf[oc * NB + n * d.N ..][0..d.N],
+                plan.output_grad.data[n * d.N * d.c_out + oc * d.N ..][0..d.N],
+            );
         }
     }
+
+    // 3. Single GEMM: grad_buf[c_out, NB] @ col_buf^T[NB, K] → output[c_out, K]
+    //    Inner dim NB inherently sums across all batches.
+    const mm = selectConvMatMul(T);
+    mm(plan.output.data, grad_buf, col_buf, d.c_out, d.K, NB, NB, 1, 1, NB, 0, 0, 0, d.K);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **Per-op profiling infrastructure**: `profileNodes` (unfused per-op timing) and `profileSteps` (fused per-step timing with tensor layout detail) on `ComputeGraph`, plus `op_bench.zig` benchmark harness
- **BLAS-accelerated conv2d**: Route fused conv2d forward + both backward GEMMs through `cblas_sgemm` via new `blasSgemm` wrapper; batch backward into single GEMMs instead of per-sample loops
- **SIMD fused elementwise chains**: Vectorize both comptime-specialized and generic chain interpreters; support non-dense inputs (e.g. maxpool `as_strided` views) via coordinate-based gather + SIMD chain ops
- **SIMD broadcast binary ops**: `computeBinaryInnerSimd` merges consecutive dense dims into a single vectorized span with broadcast-aware outer iteration
- **Tensor helpers**: `isDenseLayout`, `denseSlice`, `isBroadcastScalar`; default `use-blas=true` on macOS

CNN batch=32 on Apple M3 (1 thread): **22,726 img/s** (was ~6,300 before this branch). PyTorch CPU baseline: 25,865 img/s (88% parity).

## Test plan
- [x] `zig build test` (BLAS enabled, macOS default)
- [x] `zig build test -Duse-blas=false` (fallback path)
- [x] `zig build op-bench` — benchmark output confirms performance

🤖 Generated with [Claude Code](https://claude.com/claude-code)