### PR TITLE
Maximal-munch fusion, SIMD conv2d rearrangement

### DIFF
--- a/src/fusion.zig
+++ b/src/fusion.zig
@@ -60,10 +60,17 @@ pub fn FusionDetector(comptime T: type) type {
         // =================================================================
 
         pub fn detect(self: *Self, alloc: std.mem.Allocator) !void {
-            // Forward high-level patterns (largest subgraphs first)
-            for (self.nodes[0..self.forward_node_count], 0..) |node, idx| {
-                if (self.fused_skip[idx]) continue;
-                _ = try self.tryForwardPattern(alloc, node, idx);
+            // Forward high-level patterns: scan high-to-low (maximal munch).
+            // The graph is topologically ordered, so composed patterns like
+            // relu(bias(conv(x))) always have higher output indices than their
+            // sub-patterns. Scanning in reverse ensures the widest match wins.
+            {
+                var idx: usize = self.forward_node_count;
+                while (idx > 0) {
+                    idx -= 1;
+                    if (self.fused_skip[idx]) continue;
+                    _ = try self.tryForwardPattern(alloc, self.nodes[idx], idx);
+                }
             }
 
             // Backward patterns (conv2d, maxpool2d)
@@ -238,8 +245,10 @@ pub fn FusionDetector(comptime T: type) type {
         fn detectConv2dForward(self: *Self, node: *Tensor(T), idx: usize) ?FusionPlan(T) {
             var core = node;
             var activation: ?*Tensor(T) = null;
+            var step_node: ?*Tensor(T) = null;
             var bias: ?*Tensor(T) = null;
             var bias_node: ?*Tensor(T) = null;
+            var bias_add: ?*Tensor(T) = null;
 
             // Peel optional relu: mul(x, step(x))
             if (core.opTag() == .mul) {
@@ -247,9 +256,11 @@ pub fn FusionDetector(comptime T: type) type {
                 const s1 = core.source1() orelse return null;
                 if (s1.opTag() == .step and s1.source0() == s0) {
                     activation = core;
+                    step_node = s1;
                     core = s0;
                 } else if (s0.opTag() == .step and s0.source0() == s1) {
                     activation = core;
+                    step_node = s0;
                     core = s1;
                 }
             }
@@ -264,6 +275,7 @@ pub fn FusionDetector(comptime T: type) type {
                 if (bias_side) |bs| {
                     const other = if (bs == s1) s0 else s1;
                     if (other.opTag() == .reshape) {
+                        bias_add = core;
                         bias = bs.source0();
                         bias_node = bs;
                         core = other;
@@ -272,6 +284,8 @@ pub fn FusionDetector(comptime T: type) type {
             }
 
             if (core.opTag() != .reshape or core.n_dims != 4) return null;
+            // Guard: skip if core was already claimed by another fusion plan.
+            if (self.ptr_to_idx.get(core)) |ci| { if (self.fused_skip[ci]) return null; }
             const sum_node = expect(core.source0(), .sum) orelse return null;
             const mul_node = expect(sum_node.source0(), .mul) orelse return null;
             const input_view = expect(mul_node.source0(), .as_strided) orelse return null;
@@ -283,7 +297,8 @@ pub fn FusionDetector(comptime T: type) type {
 
             self.markNodes(&.{ input_view, kernel_view, mul_node, sum_node, core, node });
             if (bias_node) |bn| self.markNodes(&.{bn});
-            if (activation) |act| if (act != node) self.markNodes(&.{act});
+            if (bias_add) |ba| self.markNodes(&.{ba});
+            if (step_node) |sn| self.markNodes(&.{sn});
 
             return .{ .output_idx = idx, .payload = .{ .conv2d = .{
                 .input = input, .kernel = kernel, .input_view = input_view,

--- a/src/tensor/forward.zig
+++ b/src/tensor/forward.zig
@@ -36,7 +36,7 @@ const SQRT_2_OVER_PI: comptime_float = @sqrt(2.0 / std.math.pi);
 
 /// Returns the default SIMD vector width (in lanes) for type T.
 /// Used for element-wise ops. Targets 256-bit (conservative portable default).
-fn simdVecSize(comptime T: type) comptime_int {
+pub fn simdVecSize(comptime T: type) comptime_int {
     const lanes = 32 / @sizeOf(T);
     return if (lanes >= 4) lanes else 4;
 }

--- a/src/tensor/fused.zig
+++ b/src/tensor/fused.zig
@@ -1037,42 +1037,39 @@ fn executeConv2dPlan(comptime T: type, plan: Conv2dPlan(T)) void {
 
     // 3. Rearrange [c_out, NB] → [batch, c_out, N] with fused bias + activation.
     const output = plan.output.data;
-    if (plan.bias) |bias| {
-        if (plan.activation != null) {
-            for (0..d.batch) |n| {
-                for (0..d.c_out) |oc| {
-                    const b = bias.data[oc];
-                    const src = mm_temp[oc * NB + n * d.N ..][0..d.N];
-                    const dst = output[n * d.N * d.c_out + oc * d.N ..][0..d.N];
-                    for (dst, src) |*dv, sv| dv.* = @max(sv + b, 0);
-                }
-            }
-        } else {
-            for (0..d.batch) |n| {
-                for (0..d.c_out) |oc| {
-                    const b = bias.data[oc];
-                    const src = mm_temp[oc * NB + n * d.N ..][0..d.N];
-                    const dst = output[n * d.N * d.c_out + oc * d.N ..][0..d.N];
-                    for (dst, src) |*dv, sv| dv.* = sv + b;
-                }
-            }
-        }
-    } else if (plan.activation != null) {
-        for (0..d.batch) |n| {
-            for (0..d.c_out) |oc| {
-                const src = mm_temp[oc * NB + n * d.N ..][0..d.N];
-                const dst = output[n * d.N * d.c_out + oc * d.N ..][0..d.N];
-                for (dst, src) |*dv, sv| dv.* = @max(sv, 0);
-            }
-        }
-    } else {
-        for (0..d.batch) |n| {
-            for (0..d.c_out) |oc| {
-                const src = mm_temp[oc * NB + n * d.N ..][0..d.N];
-                const dst = output[n * d.N * d.c_out + oc * d.N ..][0..d.N];
+    const has_bias = plan.bias != null;
+    const has_relu = plan.activation != null;
+    for (0..d.batch) |n| {
+        for (0..d.c_out) |oc| {
+            const src = mm_temp[oc * NB + n * d.N ..][0..d.N];
+            const dst = output[n * d.N * d.c_out + oc * d.N ..][0..d.N];
+            if (has_bias or has_relu) {
+                const b = if (plan.bias) |bv| bv.data[oc] else 0;
+                if (has_relu) rearrangeSimd(T, dst, src, b, true) else rearrangeSimd(T, dst, src, b, false);
+            } else {
                 @memcpy(dst, src);
             }
         }
+    }
+}
+
+/// SIMD copy with fused bias add + optional ReLU.
+fn rearrangeSimd(comptime T: type, dst: []T, src: []const T, bias: T, comptime relu: bool) void {
+    const vl = comptime forward.simdVecSize(T);
+    const V = @Vector(vl, T);
+    const bv: V = @splat(bias);
+    const len = dst.len;
+
+    var i: usize = 0;
+    while (i + vl <= len) : (i += vl) {
+        var v: V = src[i..][0..vl].* + bv;
+        if (relu) v = @max(v, @as(V, @splat(0)));
+        dst[i..][0..vl].* = v;
+    }
+    while (i < len) : (i += 1) {
+        var v = src[i] + bias;
+        if (relu) v = @max(v, 0);
+        dst[i] = v;
     }
 }
 


### PR DESCRIPTION
## Summary
- Fix forward fusion to scan high-to-low (maximal munch) so composed patterns like `conv2d+bias+relu` match before sub-patterns like bare `conv2d`
- Mark all intermediate nodes (bias add, relu step) when peeling optional wrappers — previously these ran as redundant unfused ops
- Vectorize post-GEMM rearrangement in conv2d with explicit SIMD + `@memcpy` fast path

The previous low-to-high scan created **3 redundant conv2d fusion plans** for a single conv layer, each running the full im2col+GEMM. This fix eliminates that and properly fuses bias/relu into the single conv2d plan.

**MNIST CNN (batch=32, 1-thread CPU):** ~1.2x faster than PyTorch, up from ~0.8x before.

## Test plan
- [x] All existing tests pass (`zig build test`)
- [x] `zig build op-bench` shows 1 conv2d forward step (was 3), 12 total forward steps (was 16)
- [x] `zig build bench-inference` unchanged
- [x] Verified no other forward patterns (cross_entropy, log_softmax, softmax, layer_norm, maxpool) are affected by reverse scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)