### PR TITLE
Improve fused conv correctness, profiling, and workspace scheduling

### DIFF
--- a/benchmarks/grad_check.zig
+++ b/benchmarks/grad_check.zig
@@ -1,0 +1,147 @@
+const std = @import("std");
+const zgml = @import("zgml");
+
+const Tensor = zgml.Tensor;
+const ComputeGraph = zgml.ComputeGraph;
+const loss = zgml.loss;
+const nn = zgml.nn;
+
+fn maxAbsDiff(actual: []const f32, expected: []const f32) f32 {
+    std.debug.assert(actual.len == expected.len);
+    var max_diff: f32 = 0;
+    for (actual, expected) |a, e| {
+        const diff = @abs(a - e);
+        if (diff > max_diff) max_diff = diff;
+    }
+    return max_diff;
+}
+
+fn expectAllClose(actual: []const f32, expected: []const f32, tol: f32) !void {
+    std.debug.assert(actual.len == expected.len);
+    for (actual, expected, 0..) |a, e, i| {
+        _ = i;
+        try std.testing.expectApproxEqAbs(e, a, tol);
+    }
+}
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const backing = gpa.allocator();
+
+    var g = ComputeGraph(f32).init(backing);
+    defer g.deinit();
+    const a = g.allocator();
+
+    const ks: usize = 3;
+    const n_filters: usize = 2;
+    const n_classes: usize = 3;
+    const batch_size: usize = 2;
+    const in_w: usize = 4;
+    const in_h: usize = 4;
+    const conv_w = in_w - ks + 1;
+    const conv_h = in_h - ks + 1;
+    const flat_dim = (conv_w / 2) * (conv_h / 2) * n_filters;
+
+    const conv_k_ref = [_]f32{
+        0.1523585468530655,   -0.5199920535087585,  0.37522560358047485,
+        0.47028234601020813,  -0.9755175709724426,  -0.6510897278785706,
+        0.06392019987106323,  -0.15812130272388458, -0.00840057898312807,
+        -0.4265219569206238,  0.4396989941596985,   0.3888959586620331,
+        0.03301534801721573,  0.5636206269264221,   0.23375466465950012,
+        -0.42964622378349304, 0.18437539041042328,  -0.4794413149356842,
+    };
+    const fc_w_ref = [_]f32{
+        0.43922513723373413, -0.024962956085801125, -0.09243118017911911,
+        -0.3404647707939148, 0.6112706661224365,    -0.07726474106311798,
+    };
+    const xs_ref = [_]f32{
+        -0.4283278286457062,  -0.35213354229927063, 0.5323091745376587,   0.3654440641403198,
+        0.4127326011657715,   0.4308210015296936,   2.1416475772857666,   -0.40641501545906067,
+        -0.5122427344322205,  -0.8137727379798889,  0.6159794330596924,   1.1289722919464111,
+        -0.11394745856523514, -0.8401564955711365,  -0.824481189250946,   0.6505928039550781,
+        0.7432541847229004,   0.543154239654541,    -0.6655097007751465,  0.23216132819652557,
+        0.11668580770492554,  0.21868859231472015,  0.8714287877082825,   0.2235955446958542,
+        0.6789135336875916,   0.06757906824350357,  0.2891193926334381,   0.6312882304191589,
+        -1.4571558237075806,  -0.3196712136268616,  -0.47037264704704285, -0.6388778686523438,
+    };
+    const ys_ref = [_]f32{ 0.0, 2.0 };
+
+    const conv_out_expected = [_]f32{
+        -1.2122365,  -1.9742179,  0.9268430,  -2.8479621,
+        0.7666551,   1.5745969,   0.80403054, 1.0811217,
+        -1.1144669,  -0.42360207, 0.25751454, -0.9378939,
+        -0.42404205, -0.16175698, 1.3060079,  1.0465225,
+    };
+    const pooled_expected = [_]f32{ 0.9268430, 1.5745969, 0.25751454, 1.3060079 };
+    const logits_expected = [_]f32{ -0.12900202, 0.9393681, -0.20733, -0.33154282, 0.791896, -0.12471073 };
+    const loss_expected: f32 = 1.5188972950;
+
+    const fc_w_grad_expected = [_]f32{
+        -0.3433099687099457, 0.3535996377468109, -0.01028965413570404,
+        -0.5013872981071472, 0.8524644374847412, -0.3510770797729492,
+    };
+    const fc_b_grad_expected = [_]f32{ -0.30234625935554504, 0.5908272862434387, -0.2884809970855713 };
+    const conv_k_grad_expected = [_]f32{
+        -0.07051549851894379, -0.06685634702444077, -0.34737417101860046,
+        0.1449003666639328,   0.15976813435554504,  -0.09723096340894699,
+        -0.07979748398065567, 0.13781847059726715,  0.12433333694934845,
+        -0.08933824300765991, 0.20409604907035828,  0.2661745846271515,
+        0.252902090549469,    0.6791850328445435,   -0.07611781358718872,
+        -0.5082465410232544,  0.13608230650424957,  0.26960235834121704,
+    };
+    const conv_b_grad_expected = [_]f32{ -0.12088222801685333, 0.4863830506801605 };
+
+    const conv_k = try g.param(&.{ ks, ks, 1, n_filters });
+    const conv_b = try g.param(&.{n_filters});
+    const fc_w = try g.param(&.{ n_classes, flat_dim });
+    const fc_b = try g.param(&.{n_classes});
+    conv_k.setData(&conv_k_ref);
+    conv_b.setData(&.{ 0.0, 0.0 });
+    fc_w.setData(&fc_w_ref);
+    fc_b.setData(&.{ 0.0, 0.0, 0.0 });
+
+    const xs = try Tensor(f32).init(a, &.{ in_w, in_h, 1, batch_size });
+    const ys = try Tensor(f32).init(a, &.{batch_size});
+    xs.setData(&xs_ref);
+    ys.setData(&ys_ref);
+
+    const conv_out = xs.conv2d(conv_k);
+    const cb_4d = conv_b.reshape(&.{ 1, 1, n_filters, 1 });
+    const conv_act = conv_out.add(cb_4d.repeat(conv_out.ne[0..conv_out.n_dims])).relu();
+    const pooled = conv_act.maxPool2d();
+    const flat = pooled.reshape(&.{ flat_dim, batch_size });
+    const logits = nn.linear(f32, flat, fc_w, fc_b);
+    const ce = loss.crossEntropy(f32, logits, ys);
+
+    try g.buildForward(ce);
+    try g.buildBackward(false);
+    try g.fusionPass();
+    _ = ce.grad.?.setAllScalar(1);
+    g.compute();
+
+    const tol: f32 = 1e-5;
+    try expectAllClose(conv_out.data, &conv_out_expected, tol);
+    try expectAllClose(pooled.data, &pooled_expected, tol);
+    try expectAllClose(logits.data, &logits_expected, tol);
+    try std.testing.expectApproxEqAbs(loss_expected, ce.data[0], tol);
+    try expectAllClose(fc_w.grad.?.data, &fc_w_grad_expected, tol);
+    try expectAllClose(fc_b.grad.?.data, &fc_b_grad_expected, tol);
+    try expectAllClose(conv_k.grad.?.data, &conv_k_grad_expected, tol);
+    try expectAllClose(conv_b.grad.?.data, &conv_b_grad_expected, tol);
+
+    const stdout_file = std.fs.File.stdout();
+    var buf: [2048]u8 = undefined;
+    var w = stdout_file.writer(&buf);
+
+    try w.interface.print("grad-check passed\n", .{});
+    try w.interface.print("  loss diff: {d:.10}\n", .{@abs(ce.data[0] - loss_expected)});
+    try w.interface.print("  conv_out max diff: {d:.10}\n", .{maxAbsDiff(conv_out.data, &conv_out_expected)});
+    try w.interface.print("  pooled max diff: {d:.10}\n", .{maxAbsDiff(pooled.data, &pooled_expected)});
+    try w.interface.print("  logits max diff: {d:.10}\n", .{maxAbsDiff(logits.data, &logits_expected)});
+    try w.interface.print("  conv_k.grad max diff: {d:.10}\n", .{maxAbsDiff(conv_k.grad.?.data, &conv_k_grad_expected)});
+    try w.interface.print("  conv_b.grad max diff: {d:.10}\n", .{maxAbsDiff(conv_b.grad.?.data, &conv_b_grad_expected)});
+    try w.interface.print("  fc_w.grad max diff: {d:.10}\n", .{maxAbsDiff(fc_w.grad.?.data, &fc_w_grad_expected)});
+    try w.interface.print("  fc_b.grad max diff: {d:.10}\n", .{maxAbsDiff(fc_b.grad.?.data, &fc_b_grad_expected)});
+    w.interface.flush() catch {};
+}

--- a/benchmarks/grad_check.zig
+++ b/benchmarks/grad_check.zig
@@ -67,12 +67,6 @@ pub fn main() !void {
     };
     const ys_ref = [_]f32{ 0.0, 2.0 };
 
-    const conv_out_expected = [_]f32{
-        -1.2122365,  -1.9742179,  0.9268430,  -2.8479621,
-        0.7666551,   1.5745969,   0.80403054, 1.0811217,
-        -1.1144669,  -0.42360207, 0.25751454, -0.9378939,
-        -0.42404205, -0.16175698, 1.3060079,  1.0465225,
-    };
     const pooled_expected = [_]f32{ 0.9268430, 1.5745969, 0.25751454, 1.3060079 };
     const logits_expected = [_]f32{ -0.12900202, 0.9393681, -0.20733, -0.33154282, 0.791896, -0.12471073 };
     const loss_expected: f32 = 1.5188972950;
@@ -114,14 +108,45 @@ pub fn main() !void {
     const logits = nn.linear(f32, flat, fc_w, fc_b);
     const ce = loss.crossEntropy(f32, logits, ys);
 
+    var g_unfused = ComputeGraph(f32).init(backing);
+    defer g_unfused.deinit();
+    const au = g_unfused.allocator();
+
+    const conv_k_u = try g_unfused.param(&.{ ks, ks, 1, n_filters });
+    const conv_b_u = try g_unfused.param(&.{n_filters});
+    const fc_w_u = try g_unfused.param(&.{ n_classes, flat_dim });
+    const fc_b_u = try g_unfused.param(&.{n_classes});
+    conv_k_u.setData(&conv_k_ref);
+    conv_b_u.setData(&.{ 0.0, 0.0 });
+    fc_w_u.setData(&fc_w_ref);
+    fc_b_u.setData(&.{ 0.0, 0.0, 0.0 });
+
+    const xs_u = try Tensor(f32).init(au, &.{ in_w, in_h, 1, batch_size });
+    const ys_u = try Tensor(f32).init(au, &.{batch_size});
+    xs_u.setData(&xs_ref);
+    ys_u.setData(&ys_ref);
+
+    const conv_out_u = xs_u.conv2d(conv_k_u);
+    const cb_4d_u = conv_b_u.reshape(&.{ 1, 1, n_filters, 1 });
+    const conv_act_u = conv_out_u.add(cb_4d_u.repeat(conv_out_u.ne[0..conv_out_u.n_dims])).relu();
+    const pooled_u = conv_act_u.maxPool2d();
+    const flat_u = pooled_u.reshape(&.{ flat_dim, batch_size });
+    const logits_u = nn.linear(f32, flat_u, fc_w_u, fc_b_u);
+    const ce_u = loss.crossEntropy(f32, logits_u, ys_u);
+
     try g.buildForward(ce);
     try g.buildBackward(false);
     try g.fusionPass();
     _ = ce.grad.?.setAllScalar(1);
+
+    try g_unfused.buildForward(ce_u);
+    try g_unfused.buildBackward(false);
+    _ = ce_u.grad.?.setAllScalar(1);
+
     g.compute();
+    g_unfused.compute();
 
     const tol: f32 = 1e-5;
-    try expectAllClose(conv_out.data, &conv_out_expected, tol);
     try expectAllClose(pooled.data, &pooled_expected, tol);
     try expectAllClose(logits.data, &logits_expected, tol);
     try std.testing.expectApproxEqAbs(loss_expected, ce.data[0], tol);
@@ -129,6 +154,13 @@ pub fn main() !void {
     try expectAllClose(fc_b.grad.?.data, &fc_b_grad_expected, tol);
     try expectAllClose(conv_k.grad.?.data, &conv_k_grad_expected, tol);
     try expectAllClose(conv_b.grad.?.data, &conv_b_grad_expected, tol);
+    try expectAllClose(pooled.data, pooled_u.data, tol);
+    try expectAllClose(logits.data, logits_u.data, tol);
+    try std.testing.expectApproxEqAbs(ce_u.data[0], ce.data[0], tol);
+    try expectAllClose(conv_k_u.grad.?.data, conv_k.grad.?.data, tol);
+    try expectAllClose(conv_b_u.grad.?.data, conv_b.grad.?.data, tol);
+    try expectAllClose(fc_w_u.grad.?.data, fc_w.grad.?.data, tol);
+    try expectAllClose(fc_b_u.grad.?.data, fc_b.grad.?.data, tol);
 
     const stdout_file = std.fs.File.stdout();
     var buf: [2048]u8 = undefined;
@@ -136,7 +168,7 @@ pub fn main() !void {
 
     try w.interface.print("grad-check passed\n", .{});
     try w.interface.print("  loss diff: {d:.10}\n", .{@abs(ce.data[0] - loss_expected)});
-    try w.interface.print("  conv_out max diff: {d:.10}\n", .{maxAbsDiff(conv_out.data, &conv_out_expected)});
+    try w.interface.print("  conv_out materialized in unfused path only\n", .{});
     try w.interface.print("  pooled max diff: {d:.10}\n", .{maxAbsDiff(pooled.data, &pooled_expected)});
     try w.interface.print("  logits max diff: {d:.10}\n", .{maxAbsDiff(logits.data, &logits_expected)});
     try w.interface.print("  conv_k.grad max diff: {d:.10}\n", .{maxAbsDiff(conv_k.grad.?.data, &conv_k_grad_expected)});

--- a/build.zig
+++ b/build.zig
@@ -189,6 +189,28 @@ pub fn build(b: *std.Build) void {
     const micro_step = b.step("mnist-micro", "Build and run MNIST CNN training micro-benchmark");
     micro_step.dependOn(&b.addRunArtifact(micro_exe).step);
 
+    const zgml_conv_phase_pkg = package(b, target, .ReleaseFast, .{ .options = .{ .use_blas = use_blas } });
+    const conv_phase_mod = b.createModule(.{
+        .root_source_file = b.path("src/conv_phase_bench.zig"),
+        .target = target,
+        .optimize = .ReleaseFast,
+        .imports = &.{
+            .{ .name = "zgml", .module = zgml_conv_phase_pkg.zgml },
+            .{ .name = "zgml_options", .module = zgml_conv_phase_pkg.zgml_options },
+        },
+    });
+    const conv_phase_exe = b.addExecutable(.{
+        .name = "conv-phase-bench",
+        .root_module = conv_phase_mod,
+    });
+    if (use_blas) {
+        linkBlas(target, conv_phase_exe);
+        conv_phase_exe.addIncludePath(.{ .cwd_relative = "/usr/include/openblas" });
+    }
+    b.installArtifact(conv_phase_exe);
+    const conv_phase_step = b.step("conv-phase-bench", "Run parameterized conv phase benchmark");
+    conv_phase_step.dependOn(&b.addRunArtifact(conv_phase_exe).step);
+
     // Gradient check — compare zgml vs PyTorch reference
     const zgml_gc_pkg = package(b, target, optimize, .{ .options = .{ .use_blas = use_blas } });
     const gc_mod = b.createModule(.{

--- a/build.zig
+++ b/build.zig
@@ -189,6 +189,29 @@ pub fn build(b: *std.Build) void {
     const micro_step = b.step("mnist-micro", "Build and run MNIST CNN training micro-benchmark");
     micro_step.dependOn(&b.addRunArtifact(micro_exe).step);
 
+    // Gradient check — compare zgml vs PyTorch reference
+    const zgml_gc_pkg = package(b, target, optimize, .{ .options = .{ .use_blas = use_blas } });
+    const gc_mod = b.createModule(.{
+        .root_source_file = b.path("benchmarks/grad_check.zig"),
+        .target = target,
+        .optimize = optimize,
+        .imports = &.{
+            .{ .name = "zgml", .module = zgml_gc_pkg.zgml },
+            .{ .name = "zgml_options", .module = zgml_gc_pkg.zgml_options },
+        },
+    });
+    const gc_exe = b.addExecutable(.{
+        .name = "grad-check",
+        .root_module = gc_mod,
+    });
+    if (use_blas) {
+        linkBlas(target, gc_exe);
+        gc_exe.addIncludePath(.{ .cwd_relative = "/usr/include/openblas" });
+    }
+    b.installArtifact(gc_exe);
+    const gc_step = b.step("grad-check", "Compare gradients with PyTorch reference");
+    gc_step.dependOn(&b.addRunArtifact(gc_exe).step);
+
     // Per-op backward profiler
     const zgml_prof_pkg = package(b, target, .ReleaseFast, .{ .options = .{ .use_blas = use_blas } });
     const prof_mod = b.createModule(.{
@@ -240,7 +263,10 @@ pub fn build(b: *std.Build) void {
             },
         });
         const exe = b.addExecutable(.{ .name = "bench-inference", .root_module = mod });
-        if (use_blas) { linkBlas(target, exe); exe.addIncludePath(.{ .cwd_relative = "/usr/include/openblas" }); }
+        if (use_blas) {
+            linkBlas(target, exe);
+            exe.addIncludePath(.{ .cwd_relative = "/usr/include/openblas" });
+        }
         b.installArtifact(exe);
         const step = b.step("bench-inference", "Benchmark inference session (f32 vs int8)");
         step.dependOn(&b.addRunArtifact(exe).step);
@@ -282,7 +308,10 @@ pub fn build(b: *std.Build) void {
             },
         });
         const exe = b.addExecutable(.{ .name = "bench-metal", .root_module = mod });
-        if (use_blas) { linkBlas(target, exe); exe.addIncludePath(.{ .cwd_relative = "/usr/include/openblas" }); }
+        if (use_blas) {
+            linkBlas(target, exe);
+            exe.addIncludePath(.{ .cwd_relative = "/usr/include/openblas" });
+        }
         linkMetal(b, target, exe);
         b.installArtifact(exe);
         const step = b.step("bench-metal", "Benchmark Metal GPU vs CPU BLAS matmul");
@@ -302,7 +331,10 @@ pub fn build(b: *std.Build) void {
             },
         });
         const exe = b.addExecutable(.{ .name = "bench-metal-inference", .root_module = mod });
-        if (use_blas) { linkBlas(target, exe); exe.addIncludePath(.{ .cwd_relative = "/usr/include/openblas" }); }
+        if (use_blas) {
+            linkBlas(target, exe);
+            exe.addIncludePath(.{ .cwd_relative = "/usr/include/openblas" });
+        }
         linkMetal(b, target, exe);
         b.installArtifact(exe);
         const step = b.step("bench-metal-inference", "Benchmark CPU vs Metal inference tok/s");

--- a/src/conv_phase_bench.zig
+++ b/src/conv_phase_bench.zig
@@ -1,0 +1,126 @@
+const std = @import("std");
+const zgml = @import("zgml");
+
+const ConvClassifier = zgml.models.ConvClassifier;
+
+const Config = struct {
+    name: []const u8,
+    in_w: usize,
+    in_h: usize,
+    kernel_size: usize,
+    n_filters: usize,
+    n_classes: usize,
+    batch_size: usize,
+    warmup_iters: usize = 3,
+    bench_iters: usize = 30,
+};
+
+fn nsToMs(ns: u64) f64 {
+    return @as(f64, @floatFromInt(ns)) / 1_000_000.0;
+}
+
+fn runCase(alloc: std.mem.Allocator, writer: anytype, cfg: Config) !void {
+    var model = try ConvClassifier(f32).build(alloc, cfg.in_w, cfg.in_h, cfg.kernel_size, cfg.n_filters, cfg.n_classes, cfg.batch_size);
+    defer model.deinit();
+    try model.g.fusionPass();
+    model.g.enableThreading() catch {};
+
+    var prng = std.Random.DefaultPrng.init(42);
+    const rand = prng.random();
+    for (model.xs_batch.data) |*v| v.* = rand.float(f32);
+    for (model.ys_batch.data) |*v| v.* = @floatFromInt(rand.intRangeAtMost(u32, 0, @intCast(cfg.n_classes - 1)));
+
+    const p = model.params();
+    var sgd = try zgml.optim.sgd.SGD(f32).init(alloc, p, .{ .lr = 0.01, .momentum = 0.9 });
+    defer sgd.deinit();
+
+    for (0..cfg.warmup_iters) |_| {
+        model.g.reset();
+        model.g.resetGrads();
+        if (model.loss.grad) |grad| _ = grad.setAllScalar(1);
+        model.g.compute();
+        sgd.step();
+    }
+
+    var total_ns: u64 = 0;
+    var forward_ns: u64 = 0;
+    var backward_ns: u64 = 0;
+    var fwd_im2col_ns: u64 = 0;
+    var fwd_gemm_ns: u64 = 0;
+    var fwd_epilogue_ns: u64 = 0;
+    var bwd_input_rearrange_ns: u64 = 0;
+    var bwd_input_gemm_ns: u64 = 0;
+    var bwd_input_col2im_ns: u64 = 0;
+    var bwd_kernel_im2col_ns: u64 = 0;
+    var bwd_kernel_rearrange_ns: u64 = 0;
+    var bwd_kernel_gemm_ns: u64 = 0;
+
+    for (0..cfg.bench_iters) |_| {
+        const profile = try model.g.profileExecution(.{ .loss_grad = model.loss.grad });
+        total_ns += profile.total_ns;
+        forward_ns += profile.forward_ns;
+        backward_ns += profile.backward_ns;
+        fwd_im2col_ns += profile.fused_conv_phases.fwd_im2col_ns;
+        fwd_gemm_ns += profile.fused_conv_phases.fwd_gemm_ns;
+        fwd_epilogue_ns += profile.fused_conv_phases.fwd_epilogue_ns;
+        bwd_input_rearrange_ns += profile.fused_conv_phases.bwd_input_rearrange_ns;
+        bwd_input_gemm_ns += profile.fused_conv_phases.bwd_input_gemm_ns;
+        bwd_input_col2im_ns += profile.fused_conv_phases.bwd_input_col2im_ns;
+        bwd_kernel_im2col_ns += profile.fused_conv_phases.bwd_kernel_im2col_ns;
+        bwd_kernel_rearrange_ns += profile.fused_conv_phases.bwd_kernel_rearrange_ns;
+        bwd_kernel_gemm_ns += profile.fused_conv_phases.bwd_kernel_gemm_ns;
+        sgd.step();
+    }
+
+    const iters_f = @as(f64, @floatFromInt(cfg.bench_iters));
+    try writer.print("{s}\n", .{cfg.name});
+    try writer.print("  total mean:    {d:>7.3} ms\n", .{nsToMs(total_ns) / iters_f});
+    try writer.print("  forward mean:  {d:>7.3} ms\n", .{nsToMs(forward_ns) / iters_f});
+    try writer.print("  backward mean: {d:>7.3} ms\n", .{nsToMs(backward_ns) / iters_f});
+    try writer.print("  conv fwd:      im2col={d:>7.3} gemm={d:>7.3} epilogue={d:>7.3} ms\n", .{
+        nsToMs(fwd_im2col_ns) / iters_f,
+        nsToMs(fwd_gemm_ns) / iters_f,
+        nsToMs(fwd_epilogue_ns) / iters_f,
+    });
+    try writer.print("  conv bwd-in:   rearrange={d:>7.3} gemm={d:>7.3} col2im={d:>7.3} ms\n", .{
+        nsToMs(bwd_input_rearrange_ns) / iters_f,
+        nsToMs(bwd_input_gemm_ns) / iters_f,
+        nsToMs(bwd_input_col2im_ns) / iters_f,
+    });
+    try writer.print("  conv bwd-k:    im2col={d:>7.3} rearrange={d:>7.3} gemm={d:>7.3} ms\n", .{
+        nsToMs(bwd_kernel_im2col_ns) / iters_f,
+        nsToMs(bwd_kernel_rearrange_ns) / iters_f,
+        nsToMs(bwd_kernel_gemm_ns) / iters_f,
+    });
+    try writer.print("\n", .{});
+}
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const alloc = gpa.allocator();
+
+    const stdout_file = std.fs.File.stdout();
+    var buf: [4096]u8 = undefined;
+    var w = stdout_file.writer(&buf);
+
+    try runCase(alloc, &w.interface, .{
+        .name = "MNIST-scale conv",
+        .in_w = 28,
+        .in_h = 28,
+        .kernel_size = 5,
+        .n_filters = 8,
+        .n_classes = 10,
+        .batch_size = 32,
+    });
+    try runCase(alloc, &w.interface, .{
+        .name = "Larger conv",
+        .in_w = 64,
+        .in_h = 64,
+        .kernel_size = 3,
+        .n_filters = 32,
+        .n_classes = 100,
+        .batch_size = 32,
+    });
+    w.interface.flush() catch {};
+}

--- a/src/conv_phase_bench.zig
+++ b/src/conv_phase_bench.zig
@@ -2,6 +2,10 @@ const std = @import("std");
 const zgml = @import("zgml");
 
 const ConvClassifier = zgml.models.ConvClassifier;
+const Tensor = zgml.Tensor;
+const ComputeGraph = zgml.ComputeGraph;
+const nn = zgml.nn;
+const loss = zgml.loss;
 
 const Config = struct {
     name: []const u8,
@@ -9,18 +13,99 @@ const Config = struct {
     in_h: usize,
     kernel_size: usize,
     n_filters: usize,
+    n_hidden: usize = 0,
     n_classes: usize,
     batch_size: usize,
+    deep: bool = false,
+    two_conv: bool = false,
     warmup_iters: usize = 3,
     bench_iters: usize = 30,
 };
+
+const BenchModel = struct {
+    params: []const *Tensor(f32),
+    backing_alloc: std.mem.Allocator,
+    xs_batch: *Tensor(f32),
+    ys_batch: *Tensor(f32),
+    loss: *Tensor(f32),
+    g: ComputeGraph(f32),
+
+    fn deinit(self: *BenchModel) void {
+        self.backing_alloc.free(self.params);
+        self.g.deinit();
+    }
+};
+
+fn buildTwoConvModel(alloc: std.mem.Allocator, cfg: Config) !BenchModel {
+    var g = ComputeGraph(f32).init(alloc);
+    const a = g.allocator();
+
+    const conv1_k = try g.param(&.{ 3, 3, 1, cfg.n_filters });
+    const conv1_b = try g.param(&.{cfg.n_filters});
+    const conv2_k = try g.param(&.{ 3, 3, cfg.n_filters, cfg.n_filters });
+    const conv2_b = try g.param(&.{cfg.n_filters});
+
+    const conv1_w = cfg.in_w - 3 + 1;
+    const conv1_h = cfg.in_h - 3 + 1;
+    const conv2_w = conv1_w - 3 + 1;
+    const conv2_h = conv1_h - 3 + 1;
+    const pool_w = conv2_w / 2;
+    const pool_h = conv2_h / 2;
+    const flat_dim = pool_w * pool_h * cfg.n_filters;
+
+    const fc_w = try g.param(&.{ cfg.n_classes, flat_dim });
+    const fc_b = try g.param(&.{cfg.n_classes});
+
+    nn.kaimingUniform(f32, conv1_k, 42);
+    nn.kaimingUniform(f32, conv2_k, 43);
+    nn.kaimingUniform(f32, fc_w, 44);
+
+    const params = try alloc.dupe(*Tensor(f32), &.{ conv1_k, conv1_b, conv2_k, conv2_b, fc_w, fc_b });
+
+    const xs_batch = try Tensor(f32).init(a, &.{ cfg.in_w, cfg.in_h, 1, cfg.batch_size });
+    const ys_batch = try Tensor(f32).init(a, &.{cfg.batch_size});
+
+    const conv1 = xs_batch.conv2d(conv1_k);
+    const conv1_b4 = conv1_b.reshape(&.{ 1, 1, cfg.n_filters, 1 });
+    var conv1_ne = [_]usize{ conv1.ne[0], conv1.ne[1], conv1.ne[2], conv1.ne[3] };
+    const act1 = conv1.add(conv1_b4.repeat(conv1_ne[0..])).relu();
+
+    const conv2 = act1.conv2d(conv2_k);
+    const conv2_b4 = conv2_b.reshape(&.{ 1, 1, cfg.n_filters, 1 });
+    var conv2_ne = [_]usize{ conv2.ne[0], conv2.ne[1], conv2.ne[2], conv2.ne[3] };
+    const act2 = conv2.add(conv2_b4.repeat(conv2_ne[0..])).relu();
+
+    const flat = act2.maxPool2d().reshape(&.{ flat_dim, cfg.batch_size });
+    const logits = nn.linear(f32, flat, fc_w, fc_b);
+    const loss_node = loss.crossEntropy(f32, logits, ys_batch);
+
+    try g.buildForward(loss_node);
+    try g.buildBackward(false);
+
+    return .{
+        .params = params,
+        .backing_alloc = alloc,
+        .xs_batch = xs_batch,
+        .ys_batch = ys_batch,
+        .loss = loss_node,
+        .g = g,
+    };
+}
 
 fn nsToMs(ns: u64) f64 {
     return @as(f64, @floatFromInt(ns)) / 1_000_000.0;
 }
 
 fn runCase(alloc: std.mem.Allocator, writer: anytype, cfg: Config) !void {
-    var model = try ConvClassifier(f32).build(alloc, cfg.in_w, cfg.in_h, cfg.kernel_size, cfg.n_filters, cfg.n_classes, cfg.batch_size);
+    var model = if (cfg.two_conv)
+        try buildTwoConvModel(alloc, cfg)
+    else if (cfg.deep) blk: {
+        var m = try ConvClassifier(f32).buildDeep(alloc, cfg.in_w, cfg.in_h, cfg.n_filters, cfg.n_hidden, cfg.n_classes, cfg.batch_size);
+        break :blk BenchModel{ .params = m.params(), .backing_alloc = alloc, .xs_batch = m.xs_batch, .ys_batch = m.ys_batch, .loss = m.loss, .g = m.g };
+    } else blk: {
+        var m = try ConvClassifier(f32).build(alloc, cfg.in_w, cfg.in_h, cfg.kernel_size, cfg.n_filters, cfg.n_classes, cfg.batch_size);
+        break :blk BenchModel{ .params = m.params(), .backing_alloc = alloc, .xs_batch = m.xs_batch, .ys_batch = m.ys_batch, .loss = m.loss, .g = m.g };
+    };
     defer model.deinit();
     try model.g.fusionPass();
     model.g.enableThreading() catch {};
@@ -30,8 +115,7 @@ fn runCase(alloc: std.mem.Allocator, writer: anytype, cfg: Config) !void {
     for (model.xs_batch.data) |*v| v.* = rand.float(f32);
     for (model.ys_batch.data) |*v| v.* = @floatFromInt(rand.intRangeAtMost(u32, 0, @intCast(cfg.n_classes - 1)));
 
-    const p = model.params();
-    var sgd = try zgml.optim.sgd.SGD(f32).init(alloc, p, .{ .lr = 0.01, .momentum = 0.9 });
+    var sgd = try zgml.optim.sgd.SGD(f32).init(alloc, model.params, .{ .lr = 0.01, .momentum = 0.9 });
     defer sgd.deinit();
 
     for (0..cfg.warmup_iters) |_| {
@@ -121,6 +205,16 @@ pub fn main() !void {
         .n_filters = 32,
         .n_classes = 100,
         .batch_size = 32,
+    });
+    try runCase(alloc, &w.interface, .{
+        .name = "Two-conv stack",
+        .in_w = 64,
+        .in_h = 64,
+        .kernel_size = 3,
+        .n_filters = 32,
+        .n_classes = 100,
+        .batch_size = 32,
+        .two_conv = true,
     });
     w.interface.flush() catch {};
 }

--- a/src/fusion.zig
+++ b/src/fusion.zig
@@ -85,7 +85,7 @@ pub fn FusionDetector(comptime T: type) type {
                     self.markBwdConvSkip(plan, idx);
                 } else if (self.detectMaxPool2dBwd(node, idx)) |plan| {
                     try self.fused_chains.append(alloc, plan);
-                    self.markBwdSkipChain(idx);
+                    self.markBwdMaxPoolSkip(plan, idx);
                 }
             }
 
@@ -425,7 +425,8 @@ pub fn FusionDetector(comptime T: type) type {
             const input = view.source0() orelse return null;
             if (input.n_dims != 4 or view.ne[2] != 2 or view.ne[3] != 2) return null;
 
-            const bcast = findBroadcastFromReshape(scatter.source0() orelse return null) orelse return null;
+            const contribution = scatter.source0() orelse return null;
+            const bcast = findBroadcastFromReshape(contribution) orelse return null;
             const reshape = findPastAdd(bcast.source0() orelse return null, .reshape) orelse return null;
             const output_grad = reshape.source0() orelse return null;
             if (output_grad.n_dims != 4) return null;
@@ -605,6 +606,28 @@ pub fn FusionDetector(comptime T: type) type {
                 self.fused_skip[i] = true;
                 cur = cur.source0() orelse break;
             }
+        }
+
+        fn markBwdMaxPoolSkip(self: *Self, plan: FusionPlan(T), scatter_idx: usize) void {
+            self.fused_skip[scatter_idx] = true;
+            const p = switch (plan.payload) {
+                .max_pool2d_bwd => |payload| payload,
+                else => return,
+            };
+            const root = self.nodes[scatter_idx].source0() orelse return;
+            self.markBwdAncestorsUntil(root, &.{p.output_grad});
+        }
+
+        fn markBwdAncestorsUntil(self: *Self, node: *Tensor(T), stop_nodes: []const *Tensor(T)) void {
+            for (stop_nodes) |stop| {
+                if (node == stop) return;
+            }
+            const idx = self.ptr_to_idx.get(node) orelse return;
+            if (idx < self.forward_node_count) return;
+            if (self.fused_skip[idx]) return;
+            self.fused_skip[idx] = true;
+            if (node.source0()) |s0| self.markBwdAncestorsUntil(s0, stop_nodes);
+            if (node.source1()) |s1| self.markBwdAncestorsUntil(s1, stop_nodes);
         }
     };
 }

--- a/src/fusion.zig
+++ b/src/fusion.zig
@@ -298,24 +298,13 @@ pub fn FusionDetector(comptime T: type) type {
         fn detectConv2dForward(self: *Self, node: *Tensor(T), idx: usize) ?FusionPlan(T) {
             var core = node;
             var activation: ?*Tensor(T) = null;
-            var step_node: ?*Tensor(T) = null;
             var bias: ?*Tensor(T) = null;
             var bias_node: ?*Tensor(T) = null;
-            var bias_add: ?*Tensor(T) = null;
 
-            // Peel optional relu: mul(x, step(x))
-            if (core.opTag() == .mul) {
-                const s0 = core.source0() orelse return null;
-                const s1 = core.source1() orelse return null;
-                if (s1.opTag() == .step and s1.source0() == s0) {
-                    activation = core;
-                    step_node = s1;
-                    core = s0;
-                } else if (s0.opTag() == .step and s0.source0() == s1) {
-                    activation = core;
-                    step_node = s0;
-                    core = s1;
-                }
+            // Peel optional relu.
+            if (core.opTag() == .relu) {
+                activation = core;
+                core = core.source0() orelse return null;
             }
 
             // Peel optional bias: add(core, repeat(bias))
@@ -326,7 +315,6 @@ pub fn FusionDetector(comptime T: type) type {
                 if (bias_side) |bs| {
                     const other = if (bs == s1) s0 else s1;
                     if (other.opTag() == .reshape) {
-                        bias_add = core;
                         bias = bs.source0();
                         bias_node = bs;
                         core = other;
@@ -350,20 +338,15 @@ pub fn FusionDetector(comptime T: type) type {
 
             self.markNodes(&.{ input_view, kernel_view, mul_node, sum_node, core, node });
             if (bias_node) |bn| self.markNodes(&.{bn});
-            if (bias_add) |ba| self.markNodes(&.{ba});
-            if (step_node) |sn| self.markNodes(&.{sn});
 
             return .{ .output_idx = idx, .payload = .{ .conv2d = .{
                 .input = input,
                 .kernel = kernel,
-                .conv_out = core,
                 .input_view = input_view,
                 .kernel_view = kernel_view,
                 .bias = bias,
                 .bias_node = bias_node,
-                .bias_add = bias_add,
                 .activation = activation,
-                .step_node = step_node,
                 .mul_node = mul_node,
                 .sum_node = sum_node,
                 .output = node,

--- a/src/fusion.zig
+++ b/src/fusion.zig
@@ -37,8 +37,12 @@ pub fn FusionDetector(comptime T: type) type {
             const uc = try alloc.alloc(u16, n);
             @memset(uc, 0);
             for (nodes) |node| {
-                if (node.source0()) |s| if (map.get(s)) |j| { uc[j] += 1; };
-                if (node.source1()) |s| if (map.get(s)) |j| { uc[j] += 1; };
+                if (node.source0()) |s| if (map.get(s)) |j| {
+                    uc[j] += 1;
+                };
+                if (node.source1()) |s| if (map.get(s)) |j| {
+                    uc[j] += 1;
+                };
             }
 
             return .{
@@ -100,12 +104,30 @@ pub fn FusionDetector(comptime T: type) type {
         // =================================================================
 
         fn tryForwardPattern(self: *Self, alloc: std.mem.Allocator, node: *Tensor(T), idx: usize) !bool {
-            if (self.detectCrossEntropy(node, idx)) |plan| { try self.fused_chains.append(alloc, plan); return true; }
-            if (self.detectLogSoftmax(node, idx)) |plan| { try self.fused_chains.append(alloc, plan); return true; }
-            if (self.detectSoftmax(node, idx)) |plan| { try self.fused_chains.append(alloc, plan); return true; }
-            if (self.detectLayerNorm(node, idx)) |plan| { try self.fused_chains.append(alloc, plan); return true; }
-            if (self.detectConv2dForward(node, idx)) |plan| { try self.fused_chains.append(alloc, plan); return true; }
-            if (self.detectMaxPool2dForward(node, idx)) |plan| { try self.fused_chains.append(alloc, plan); return true; }
+            if (self.detectCrossEntropy(node, idx)) |plan| {
+                try self.fused_chains.append(alloc, plan);
+                return true;
+            }
+            if (self.detectLogSoftmax(node, idx)) |plan| {
+                try self.fused_chains.append(alloc, plan);
+                return true;
+            }
+            if (self.detectSoftmax(node, idx)) |plan| {
+                try self.fused_chains.append(alloc, plan);
+                return true;
+            }
+            if (self.detectLayerNorm(node, idx)) |plan| {
+                try self.fused_chains.append(alloc, plan);
+                return true;
+            }
+            if (self.detectConv2dForward(node, idx)) |plan| {
+                try self.fused_chains.append(alloc, plan);
+                return true;
+            }
+            if (self.detectMaxPool2dForward(node, idx)) |plan| {
+                try self.fused_chains.append(alloc, plan);
+                return true;
+            }
             return false;
         }
 
@@ -126,9 +148,15 @@ pub fn FusionDetector(comptime T: type) type {
             if (max_node.source0() != input) return null;
 
             const plan = fused.SoftmaxPlan(T){
-                .input = input, .max_node = max_node, .rep_max = rep_max,
-                .neg_rep_max = neg_rep_max, .shifted = shifted, .exp_node = exp_node,
-                .sum_node = sum_node, .rep_sum = rep_sum, .recip_rep_sum = recip_rep_sum,
+                .input = input,
+                .max_node = max_node,
+                .rep_max = rep_max,
+                .neg_rep_max = neg_rep_max,
+                .shifted = shifted,
+                .exp_node = exp_node,
+                .sum_node = sum_node,
+                .rep_sum = rep_sum,
+                .recip_rep_sum = recip_rep_sum,
                 .output = node,
             };
             if (!fused.validateSoftmaxPlan(T, plan)) return null;
@@ -159,10 +187,17 @@ pub fn FusionDetector(comptime T: type) type {
             if (max_node.source0() != input) return null;
 
             const plan = fused.LogSoftmaxPlan(T){
-                .input = input, .max_node = max_node, .rep_max = rep_max,
-                .neg_rep_max = neg_rep_max, .shifted = shifted, .exp_node = exp_node,
-                .sum_node = sum_node, .log_node = log_node, .rep_log = rep_log,
-                .neg_rep_log = neg_rep_log, .output = node,
+                .input = input,
+                .max_node = max_node,
+                .rep_max = rep_max,
+                .neg_rep_max = neg_rep_max,
+                .shifted = shifted,
+                .exp_node = exp_node,
+                .sum_node = sum_node,
+                .log_node = log_node,
+                .rep_log = rep_log,
+                .neg_rep_log = neg_rep_log,
+                .output = node,
             };
             if (!fused.validateLogSoftmaxPlan(T, plan)) return null;
             if (mark) self.markNodes(&.{ max_node, rep_max, neg_rep_max, shifted, exp_node, sum_node, log_node, rep_log, neg_rep_log, node });
@@ -183,16 +218,24 @@ pub fn FusionDetector(comptime T: type) type {
 
             const ls_idx = self.ptr_to_idx.get(log_softmax_output) orelse return null;
             const ls = self.detectLogSoftmaxImpl(log_softmax_output, ls_idx, false) orelse return null;
-            const inner = switch (ls.payload) { .log_softmax => |p| p, else => return null };
+            const inner = switch (ls.payload) {
+                .log_softmax => |p| p,
+                else => return null,
+            };
 
             self.markNodes(&.{
-                inner.max_node, inner.rep_max, inner.neg_rep_max, inner.shifted,
-                inner.exp_node, inner.sum_node, inner.log_node, inner.rep_log,
-                inner.neg_rep_log, inner.output, picked, neg_picked, sum_node, node,
+                inner.max_node,    inner.rep_max,  inner.neg_rep_max, inner.shifted,
+                inner.exp_node,    inner.sum_node, inner.log_node,    inner.rep_log,
+                inner.neg_rep_log, inner.output,   picked,            neg_picked,
+                sum_node,          node,
             });
             return .{ .output_idx = idx, .payload = .{ .cross_entropy = .{
-                .log_softmax = inner, .targets = targets, .picked = picked,
-                .neg_picked = neg_picked, .sum_node = sum_node, .mean_node = node,
+                .log_softmax = inner,
+                .targets = targets,
+                .picked = picked,
+                .neg_picked = neg_picked,
+                .sum_node = sum_node,
+                .mean_node = node,
             } } };
         }
 
@@ -226,16 +269,26 @@ pub fn FusionDetector(comptime T: type) type {
             if (sum_node.source0() != input) return null;
 
             const plan = fused.LayerNormPlan(T){
-                .input = input, .sum_node = sum_node, .mean_node = mean_node,
-                .rep_mean = rep_mean, .neg_rep_mean = neg_rep_mean, .centered = centered,
-                .sqr_node = sqr_node, .var_sum = var_sum, .var_node = var_node,
-                .eps_like = eps_like, .var_eps = var_eps, .sqrt_node = sqrt_node,
-                .recip_node = recip_node, .rep_std_inv = rep_std_inv, .output = node,
+                .input = input,
+                .sum_node = sum_node,
+                .mean_node = mean_node,
+                .rep_mean = rep_mean,
+                .neg_rep_mean = neg_rep_mean,
+                .centered = centered,
+                .sqr_node = sqr_node,
+                .var_sum = var_sum,
+                .var_node = var_node,
+                .eps_like = eps_like,
+                .var_eps = var_eps,
+                .sqrt_node = sqrt_node,
+                .recip_node = recip_node,
+                .rep_std_inv = rep_std_inv,
+                .output = node,
             };
             if (!fused.validateLayerNormPlan(T, plan)) return null;
             self.markNodes(&.{
-                sum_node, mean_node, rep_mean, neg_rep_mean, centered,
-                sqr_node, var_sum, var_node, eps_like, var_eps,
+                sum_node,  mean_node,  rep_mean,    neg_rep_mean, centered,
+                sqr_node,  var_sum,    var_node,    eps_like,     var_eps,
                 sqrt_node, recip_node, rep_std_inv, node,
             });
             return .{ .output_idx = idx, .payload = .{ .layer_norm = plan } };
@@ -269,9 +322,7 @@ pub fn FusionDetector(comptime T: type) type {
             if (core.opTag() == .add) {
                 const s0 = core.source0() orelse return null;
                 const s1 = core.source1() orelse return null;
-                const bias_side = if (s1.opTag() == .repeat and !s1.isScalar()) s1
-                    else if (s0.opTag() == .repeat and !s0.isScalar()) s0
-                    else null;
+                const bias_side = if (s1.opTag() == .repeat and !s1.isScalar()) s1 else if (s0.opTag() == .repeat and !s0.isScalar()) s0 else null;
                 if (bias_side) |bs| {
                     const other = if (bs == s1) s0 else s1;
                     if (other.opTag() == .reshape) {
@@ -285,7 +336,9 @@ pub fn FusionDetector(comptime T: type) type {
 
             if (core.opTag() != .reshape or core.n_dims != 4) return null;
             // Guard: skip if core was already claimed by another fusion plan.
-            if (self.ptr_to_idx.get(core)) |ci| { if (self.fused_skip[ci]) return null; }
+            if (self.ptr_to_idx.get(core)) |ci| {
+                if (self.fused_skip[ci]) return null;
+            }
             const sum_node = expect(core.source0(), .sum) orelse return null;
             const mul_node = expect(sum_node.source0(), .mul) orelse return null;
             const input_view = expect(mul_node.source0(), .as_strided) orelse return null;
@@ -301,10 +354,19 @@ pub fn FusionDetector(comptime T: type) type {
             if (step_node) |sn| self.markNodes(&.{sn});
 
             return .{ .output_idx = idx, .payload = .{ .conv2d = .{
-                .input = input, .kernel = kernel, .input_view = input_view,
-                .kernel_view = kernel_view, .bias = bias, .bias_node = bias_node,
-                .activation = activation, .mul_node = mul_node,
-                .sum_node = sum_node, .output = node,
+                .input = input,
+                .kernel = kernel,
+                .conv_out = core,
+                .input_view = input_view,
+                .kernel_view = kernel_view,
+                .bias = bias,
+                .bias_node = bias_node,
+                .bias_add = bias_add,
+                .activation = activation,
+                .step_node = step_node,
+                .mul_node = mul_node,
+                .sum_node = sum_node,
+                .output = node,
             } } };
         }
 
@@ -319,7 +381,10 @@ pub fn FusionDetector(comptime T: type) type {
 
             self.markNodes(&.{ strided, max_node, node });
             return .{ .output_idx = idx, .payload = .{ .max_pool2d = .{
-                .input = input, .strided = strided, .max_node = max_node, .output = node,
+                .input = input,
+                .strided = strided,
+                .max_node = max_node,
+                .output = node,
             } } };
         }
 
@@ -350,15 +415,21 @@ pub fn FusionDetector(comptime T: type) type {
             const is_kernel = view_source.nElems() <= other_source.nElems();
             return if (is_kernel)
                 .{ .output_idx = scatter_idx, .payload = .{ .conv2d_bwd_kernel = .{
-                    .input = other_source, .output_grad = output_grad,
-                    .reshape_node = reshape, .repeat_node = bcast,
-                    .mul_node = mul_node, .output = scatter,
+                    .input = other_source,
+                    .output_grad = output_grad,
+                    .reshape_node = reshape,
+                    .repeat_node = bcast,
+                    .mul_node = mul_node,
+                    .output = scatter,
                 } } }
             else
                 .{ .output_idx = scatter_idx, .payload = .{ .conv2d_bwd_input = .{
-                    .output_grad = output_grad, .kernel = other_source,
-                    .reshape_node = reshape, .repeat_node = bcast,
-                    .mul_node = mul_node, .output = scatter,
+                    .output_grad = output_grad,
+                    .kernel = other_source,
+                    .reshape_node = reshape,
+                    .repeat_node = bcast,
+                    .mul_node = mul_node,
+                    .output = scatter,
                 } } };
         }
 
@@ -371,14 +442,15 @@ pub fn FusionDetector(comptime T: type) type {
             const input = view.source0() orelse return null;
             if (input.n_dims != 4 or view.ne[2] != 2 or view.ne[3] != 2) return null;
 
-            const mul_node = findPastAdd(scatter.source0() orelse return null, .mul) orelse return null;
-            const bcast = findOp(mul_node, .broadcast_to) orelse return null;
+            const bcast = findBroadcastFromReshape(scatter.source0() orelse return null) orelse return null;
             const reshape = findPastAdd(bcast.source0() orelse return null, .reshape) orelse return null;
             const output_grad = reshape.source0() orelse return null;
             if (output_grad.n_dims != 4) return null;
 
             return .{ .output_idx = scatter_idx, .payload = .{ .max_pool2d_bwd = .{
-                .input = input, .output_grad = output_grad, .output = scatter,
+                .input = input,
+                .output_grad = output_grad,
+                .output = scatter,
             } } };
         }
 
@@ -426,7 +498,9 @@ pub fn FusionDetector(comptime T: type) type {
                 try self.fused_chains.append(alloc, .{
                     .output_idx = end,
                     .payload = .{ .elementwise_chain = .{
-                        .input = input, .nodes = chain_nodes, .other_operand_roles = roles,
+                        .input = input,
+                        .nodes = chain_nodes,
+                        .other_operand_roles = roles,
                     } },
                 });
                 i = end;
@@ -472,6 +546,22 @@ pub fn FusionDetector(comptime T: type) type {
             return null;
         }
 
+        fn findBroadcastFromReshape(node: *Tensor(T)) ?*Tensor(T) {
+            if (node.opTag() == .broadcast_to) {
+                const src = node.source0() orelse return null;
+                const reshape = findPastAdd(src, .reshape) orelse return null;
+                const output_grad = reshape.source0() orelse return null;
+                if (output_grad.n_dims == 4) return node;
+            }
+            if (node.source0()) |s| {
+                if (findBroadcastFromReshape(s)) |hit| return hit;
+            }
+            if (node.source1()) |s| {
+                if (findBroadcastFromReshape(s)) |hit| return hit;
+            }
+            return null;
+        }
+
         fn markNodes(self: *Self, nodes: []const *Tensor(T)) void {
             for (nodes) |node| {
                 if (self.ptr_to_idx.get(node)) |i| self.fused_skip[i] = true;
@@ -493,7 +583,10 @@ pub fn FusionDetector(comptime T: type) type {
                 }
                 prev = node;
             }
-            if (!any_swapped) { alloc.free(roles); return &.{}; }
+            if (!any_swapped) {
+                alloc.free(roles);
+                return &.{};
+            }
             return roles;
         }
 

--- a/src/graph.zig
+++ b/src/graph.zig
@@ -129,12 +129,11 @@ pub fn ComputeGraph(comptime T: type) type {
         /// Uses all available CPU cores. Safe to call multiple times (no-op if already enabled).
         pub fn enableThreading(self: *Self) !void {
             if (self.thread_pool != null) return;
-            var pool: std.Thread.Pool = undefined;
-            try pool.init(.{
+            self.thread_pool = undefined;
+            try self.thread_pool.?.init(.{
                 .allocator = std.heap.page_allocator,
                 .track_ids = false,
             });
-            self.thread_pool = pool;
         }
 
         pub fn setBackend(self: *Self, backend: backend_mod.Backend) void {

--- a/src/graph.zig
+++ b/src/graph.zig
@@ -617,6 +617,14 @@ pub fn ComputeGraph(comptime T: type) type {
             fused_region_count: usize = 0,
             forward_step_count: usize = 0,
             backward_step_count: usize = 0,
+            fused_conv_phases: fused.ConvPhaseProfile = .{},
+
+            fn hasConvPhaseData(self: @This()) bool {
+                const p = self.fused_conv_phases;
+                return p.fwd_im2col_ns != 0 or p.fwd_gemm_ns != 0 or p.fwd_epilogue_ns != 0 or
+                    p.bwd_input_rearrange_ns != 0 or p.bwd_input_gemm_ns != 0 or p.bwd_input_col2im_ns != 0 or
+                    p.bwd_kernel_im2col_ns != 0 or p.bwd_kernel_rearrange_ns != 0 or p.bwd_kernel_gemm_ns != 0;
+            }
 
             pub fn render(self: @This(), writer: anytype) !void {
                 try writer.print(
@@ -634,6 +642,22 @@ pub fn ComputeGraph(comptime T: type) type {
                         nsToMs(self.total_ns),
                     },
                 );
+                if (self.hasConvPhaseData()) {
+                    try writer.print(
+                        "  conv_phases_ms: fwd(im2col={d:.3}, gemm={d:.3}, epilogue={d:.3}) bwd_in(rearrange={d:.3}, gemm={d:.3}, col2im={d:.3}) bwd_k(im2col={d:.3}, rearrange={d:.3}, gemm={d:.3})\n",
+                        .{
+                            nsToMs(self.fused_conv_phases.fwd_im2col_ns),
+                            nsToMs(self.fused_conv_phases.fwd_gemm_ns),
+                            nsToMs(self.fused_conv_phases.fwd_epilogue_ns),
+                            nsToMs(self.fused_conv_phases.bwd_input_rearrange_ns),
+                            nsToMs(self.fused_conv_phases.bwd_input_gemm_ns),
+                            nsToMs(self.fused_conv_phases.bwd_input_col2im_ns),
+                            nsToMs(self.fused_conv_phases.bwd_kernel_im2col_ns),
+                            nsToMs(self.fused_conv_phases.bwd_kernel_rearrange_ns),
+                            nsToMs(self.fused_conv_phases.bwd_kernel_gemm_ns),
+                        },
+                    );
+                }
             }
 
             pub fn dump(self: @This(), writer: anytype) !void {
@@ -705,12 +729,12 @@ pub fn ComputeGraph(comptime T: type) type {
             profile.seed_loss_grad_ns = timer.read();
 
             timer.reset();
-            self.computeNoGrad();
+            self.computeNoGradProfiled(&profile.fused_conv_phases);
             profile.forward_ns = timer.read();
 
             if (!options.forward_only) {
                 timer.reset();
-                self.computeBackward();
+                self.computeBackwardProfiled(&profile.fused_conv_phases);
                 profile.backward_ns = timer.read();
             }
 
@@ -1028,7 +1052,7 @@ pub fn ComputeGraph(comptime T: type) type {
                         if (pool != null and plan.kind() == .elementwise_chain) {
                             fused.executeFusedChainParallel(T, plan.payload.elementwise_chain, pool.?);
                         } else {
-                            fused.executeFusionPlan(T, plan);
+                            fused.executeFusionPlan(T, plan, null);
                         }
                         const elapsed = timer.read();
                         const out_node = self.nodes.items[plan.output_idx];
@@ -1324,33 +1348,45 @@ pub fn ComputeGraph(comptime T: type) type {
         /// If `fusionPass()` was called, fused chains execute as single-pass
         /// comptime-specialized kernels.
         pub fn compute(self: *const Self) void {
+            self.computeProfiled(null);
+        }
+
+        fn computeProfiled(self: *const Self, phase_profile: ?*fused.ConvPhaseProfile) void {
             if (self.execution_steps.items.len == 0) {
                 const pool = if (self.thread_pool) |*tp| @constCast(tp) else null;
                 for (self.nodes.items) |node| self.executeNode(node, pool);
                 return;
             }
-            self.executeGraphPlan(self.execution_steps.items);
+            self.executeGraphPlan(self.execution_steps.items, phase_profile);
         }
 
         pub fn computeNoGrad(self: *const Self) void {
+            self.computeNoGradProfiled(null);
+        }
+
+        fn computeNoGradProfiled(self: *const Self, phase_profile: ?*fused.ConvPhaseProfile) void {
             if (self.forward_execution_steps.items.len == 0) {
                 const pool = if (self.thread_pool) |*tp| @constCast(tp) else null;
                 for (self.nodes.items[0..self.forward_node_count]) |node| self.executeNode(node, pool);
                 return;
             }
-            self.executeGraphPlan(self.forward_execution_steps.items);
+            self.executeGraphPlan(self.forward_execution_steps.items, phase_profile);
         }
 
         /// Execute only the backward portion of the graph (nodes after forward_node_count).
         /// Uses fused execution plans when available.
         pub fn computeBackward(self: *const Self) void {
+            self.computeBackwardProfiled(null);
+        }
+
+        fn computeBackwardProfiled(self: *const Self, phase_profile: ?*fused.ConvPhaseProfile) void {
             if (self.execution_steps.items.len == 0) {
                 const pool = if (self.thread_pool) |*tp| @constCast(tp) else null;
                 for (self.nodes.items[self.forward_node_count..]) |node| self.executeNode(node, pool);
                 return;
             }
             // Backward steps are everything after the forward execution steps.
-            self.executeGraphPlan(self.execution_steps.items[self.forward_execution_steps.items.len..]);
+            self.executeGraphPlan(self.execution_steps.items[self.forward_execution_steps.items.len..], phase_profile);
         }
 
         // ---------------------------------------------------------------
@@ -1399,7 +1435,7 @@ pub fn ComputeGraph(comptime T: type) type {
             self.computeNoGrad();
         }
 
-        fn executeGraphPlan(self: *const Self, steps: []const ExecutionStep) void {
+        fn executeGraphPlan(self: *const Self, steps: []const ExecutionStep, phase_profile: ?*fused.ConvPhaseProfile) void {
             const pool = if (self.thread_pool) |*tp| @constCast(tp) else null;
             for (steps) |step| {
                 switch (step) {
@@ -1408,7 +1444,7 @@ pub fn ComputeGraph(comptime T: type) type {
                         if (pool != null and plan.kind() == .elementwise_chain) {
                             fused.executeFusedChainParallel(T, plan.payload.elementwise_chain, pool.?);
                         } else {
-                            fused.executeFusionPlan(T, plan);
+                            fused.executeFusionPlan(T, plan, phase_profile);
                         }
                     },
                     .node => |node| {

--- a/src/graph.zig
+++ b/src/graph.zig
@@ -787,10 +787,9 @@ pub fn ComputeGraph(comptime T: type) type {
                     "", "", "", "", "", "", "",
                 });
                 try writer.print("{s:<22} {s:>6} {d:>10.1} {s:>6} {d:>10.1} {d:>10.1}\n", .{
-                    "TOTAL", "",
+                    "TOTAL",                                              "",
                     @as(f64, @floatFromInt(self.fwd_total_ns)) / 1_000.0, "",
-                    @as(f64, @floatFromInt(self.bwd_total_ns)) / 1_000.0,
-                    @as(f64, @floatFromInt(total_ns)) / 1_000.0,
+                    @as(f64, @floatFromInt(self.bwd_total_ns)) / 1_000.0, @as(f64, @floatFromInt(total_ns)) / 1_000.0,
                 });
             }
         };
@@ -1241,8 +1240,6 @@ pub fn ComputeGraph(comptime T: type) type {
             }
             return .fusible_isolated;
         }
-
-
 
         fn addParentsThenSelf(self: *Self, cur: *Tensor(T)) Alloc.Error!void {
             const alloc = self.arena.allocator();
@@ -1930,6 +1927,27 @@ test "backward - relu" {
     try testing.expectEqualSlices(f32, &.{ 0, 0, 1, 1 }, x.grad.?.data);
 }
 
+test "backward - max splits ties evenly" {
+    var g = ComputeGraph(f32).init(tac);
+    defer g.deinit();
+    const a = g.allocator();
+
+    const x = try Tensor(f32).init(a, &.{4});
+    x.setData(&[_]f32{ 2, 5, 5, 1 });
+    x.setParam();
+    const out = x.maxAll();
+    try g.buildForward(out);
+    try g.buildBackward(false);
+    _ = out.grad.?.setAllScalar(1);
+    g.compute();
+
+    try testing.expectApproxEqAbs(@as(f32, 5.0), out.data[0], 1e-6);
+    try testing.expectApproxEqAbs(@as(f32, 0.0), x.grad.?.data[0], 1e-6);
+    try testing.expectApproxEqAbs(@as(f32, 0.5), x.grad.?.data[1], 1e-6);
+    try testing.expectApproxEqAbs(@as(f32, 0.5), x.grad.?.data[2], 1e-6);
+    try testing.expectApproxEqAbs(@as(f32, 0.0), x.grad.?.data[3], 1e-6);
+}
+
 test "backward - recip" {
     // f(x) = 1/x, f'(x) = -1/x^2
     var g = ComputeGraph(f32).init(tac);
@@ -2197,6 +2215,187 @@ test "fusion - conv2d backward fused matches unfused" {
         try testing.expectApproxEqAbs(a_out, b_out, 1e-5);
     }
     for (kf.grad.?.data, ku.grad.?.data) |a_out, b_out| {
+        try testing.expectApproxEqAbs(a_out, b_out, 1e-5);
+    }
+}
+
+test "fusion - maxpool2d backward fused matches unfused on ties" {
+    var gf = ComputeGraph(f32).init(tac);
+    defer gf.deinit();
+    var gu = ComputeGraph(f32).init(tac);
+    defer gu.deinit();
+
+    const af = gf.allocator();
+    const au = gu.allocator();
+
+    const xf = try Tensor(f32).init(af, &.{ 4, 4, 1, 1 });
+    const xu = try Tensor(f32).init(au, &.{ 4, 4, 1, 1 });
+    const input = [_]f32{
+        1, 3, 2, 2,
+        3, 0, 0, 1,
+        5, 4, 1, 1,
+        5, 5, 1, 1,
+    };
+    xf.setData(&input);
+    xu.setData(&input);
+    xf.setParam();
+    xu.setParam();
+
+    const pooled_f = xf.maxPool2d();
+    const pooled_u = xu.maxPool2d();
+    const out_f = pooled_f.sumAll();
+    const out_u = pooled_u.sumAll();
+
+    try gf.buildForward(out_f);
+    try gf.buildBackward(false);
+    try gf.fusionPass();
+    _ = out_f.grad.?.setAllScalar(1);
+
+    try gu.buildForward(out_u);
+    try gu.buildBackward(false);
+    _ = out_u.grad.?.setAllScalar(1);
+
+    var found_fwd = false;
+    var found_bwd = false;
+    for (gf.fused_chains.items) |plan| {
+        switch (plan.kind()) {
+            .max_pool2d => found_fwd = true,
+            .max_pool2d_bwd => found_bwd = true,
+            else => {},
+        }
+    }
+    try testing.expect(found_fwd);
+    try testing.expect(found_bwd);
+
+    gf.compute();
+    gu.compute();
+
+    try testing.expectEqualSlices(f32, pooled_u.data, pooled_f.data);
+    try testing.expectEqualSlices(f32, &.{ 3, 2, 5, 1 }, pooled_f.data);
+
+    try testing.expectEqualSlices(f32, xu.grad.?.data, xf.grad.?.data);
+    try testing.expectEqualSlices(f32, &.{
+        0,         0.5,       0.5,  0.5,
+        0.5,       0,         0,    0,
+        1.0 / 3.0, 0,         0.25, 0.25,
+        1.0 / 3.0, 1.0 / 3.0, 0.25, 0.25,
+    }, xf.grad.?.data);
+}
+
+test "fusion - conv2d bias relu crossEntropy backward fused matches unfused" {
+    var gf = ComputeGraph(f32).init(tac);
+    defer gf.deinit();
+    var gu = ComputeGraph(f32).init(tac);
+    defer gu.deinit();
+
+    const af = gf.allocator();
+    const au = gu.allocator();
+
+    const ks: usize = 3;
+    const n_filters: usize = 2;
+    const n_classes: usize = 3;
+    const batch_size: usize = 2;
+    const in_w: usize = 4;
+    const in_h: usize = 4;
+    const conv_w = in_w - ks + 1;
+    const conv_h = in_h - ks + 1;
+    const flat_dim = (conv_w / 2) * (conv_h / 2) * n_filters;
+
+    const conv_k_data = [_]f32{
+        0.15235855,  -0.51999205, 0.3752256,    0.47028235,  -0.9755176, -0.6510897,
+        0.0639202,   -0.1581213,  -0.008400579, -0.42652196, 0.439699,   0.38889596,
+        0.033015348, 0.5636206,   0.23375466,   -0.42964622, 0.18437539, -0.47944131,
+    };
+    const fc_w_data = [_]f32{ 0.43922514, -0.024962956, -0.09243118, -0.34046477, 0.61127067, -0.07726474 };
+    const xs_data = [_]f32{
+        -0.42832783, -0.35213354, 0.5323092,   0.36544406,
+        0.4127326,   0.430821,    2.1416476,   -0.40641502,
+        -0.51224273, -0.81377274, 0.61597943,  1.1289723,
+        -0.11394746, -0.8401565,  -0.8244812,  0.6505928,
+        0.7432542,   0.54315424,  -0.6655097,  0.23216133,
+        0.11668581,  0.21868859,  0.8714288,   0.22359554,
+        0.67891353,  0.06757907,  0.2891194,   0.63128823,
+        -1.4571558,  -0.3196712,  -0.47037265, -0.63887787,
+    };
+    const ys_data = [_]f32{ 0.0, 2.0 };
+
+    const conv_k_f = try Tensor(f32).init(af, &.{ ks, ks, 1, n_filters });
+    const conv_k_u = try Tensor(f32).init(au, &.{ ks, ks, 1, n_filters });
+    conv_k_f.setData(&conv_k_data);
+    conv_k_u.setData(&conv_k_data);
+    conv_k_f.setParam();
+    conv_k_u.setParam();
+
+    const conv_b_f = try Tensor(f32).init(af, &.{n_filters});
+    const conv_b_u = try Tensor(f32).init(au, &.{n_filters});
+    conv_b_f.setData(&.{ 0.0, 0.0 });
+    conv_b_u.setData(&.{ 0.0, 0.0 });
+    conv_b_f.setParam();
+    conv_b_u.setParam();
+
+    const fc_w_f = try Tensor(f32).init(af, &.{ n_classes, flat_dim });
+    const fc_w_u = try Tensor(f32).init(au, &.{ n_classes, flat_dim });
+    fc_w_f.setData(&fc_w_data);
+    fc_w_u.setData(&fc_w_data);
+    fc_w_f.setParam();
+    fc_w_u.setParam();
+
+    const fc_b_f = try Tensor(f32).init(af, &.{n_classes});
+    const fc_b_u = try Tensor(f32).init(au, &.{n_classes});
+    fc_b_f.setData(&.{ 0.0, 0.0, 0.0 });
+    fc_b_u.setData(&.{ 0.0, 0.0, 0.0 });
+    fc_b_f.setParam();
+    fc_b_u.setParam();
+
+    const xs_f = try Tensor(f32).init(af, &.{ in_w, in_h, 1, batch_size });
+    const xs_u = try Tensor(f32).init(au, &.{ in_w, in_h, 1, batch_size });
+    xs_f.setData(&xs_data);
+    xs_u.setData(&xs_data);
+
+    const ys_f = try Tensor(f32).init(af, &.{batch_size});
+    const ys_u = try Tensor(f32).init(au, &.{batch_size});
+    ys_f.setData(&ys_data);
+    ys_u.setData(&ys_data);
+
+    const conv_out_f = xs_f.conv2d(conv_k_f);
+    const conv_out_u = xs_u.conv2d(conv_k_u);
+    const cb4_f = conv_b_f.reshape(&.{ 1, 1, n_filters, 1 });
+    const cb4_u = conv_b_u.reshape(&.{ 1, 1, n_filters, 1 });
+    const act_f = conv_out_f.add(cb4_f.repeat(conv_out_f.ne[0..conv_out_f.n_dims])).relu();
+    const act_u = conv_out_u.add(cb4_u.repeat(conv_out_u.ne[0..conv_out_u.n_dims])).relu();
+    const flat_f = act_f.maxPool2d().reshape(&.{ flat_dim, batch_size });
+    const flat_u = act_u.maxPool2d().reshape(&.{ flat_dim, batch_size });
+    const logits_f = flat_f.matMul(false, fc_w_f, false).addBias(fc_b_f);
+    const logits_u = flat_u.matMul(false, fc_w_u, false).addBias(fc_b_u);
+    const out_f = loss.crossEntropy(f32, logits_f, ys_f);
+    const out_u = loss.crossEntropy(f32, logits_u, ys_u);
+
+    try gf.buildForward(out_f);
+    try gf.buildBackward(false);
+    try gf.fusionPass();
+    _ = out_f.grad.?.setAllScalar(1);
+
+    try gu.buildForward(out_u);
+    try gu.buildBackward(false);
+    _ = out_u.grad.?.setAllScalar(1);
+
+    gf.compute();
+    gu.compute();
+
+    try testing.expectApproxEqAbs(out_u.data[0], out_f.data[0], 1e-6);
+    for (logits_f.data, logits_u.data) |a_out, b_out| {
+        try testing.expectApproxEqAbs(a_out, b_out, 1e-6);
+    }
+    for (conv_k_f.grad.?.data, conv_k_u.grad.?.data) |a_out, b_out| {
+        try testing.expectApproxEqAbs(a_out, b_out, 1e-5);
+    }
+    for (conv_b_f.grad.?.data, conv_b_u.grad.?.data) |a_out, b_out| {
+        try testing.expectApproxEqAbs(a_out, b_out, 1e-5);
+    }
+    for (fc_w_f.grad.?.data, fc_w_u.grad.?.data) |a_out, b_out| {
+        try testing.expectApproxEqAbs(a_out, b_out, 1e-5);
+    }
+    for (fc_b_f.grad.?.data, fc_b_u.grad.?.data) |a_out, b_out| {
         try testing.expectApproxEqAbs(a_out, b_out, 1e-5);
     }
 }

--- a/src/mnist_bench.zig
+++ b/src/mnist_bench.zig
@@ -163,6 +163,7 @@ pub fn main() !void {
             model.g.resetGrads();
             if (model.loss.grad) |grad| _ = grad.setAllScalar(1);
             model.g.compute();
+
             sgd.step();
 
             epoch_loss += model.loss.data[0];

--- a/src/mnist_micro.zig
+++ b/src/mnist_micro.zig
@@ -48,7 +48,6 @@ pub fn main() !void {
     // Print graph and fusion summary
     try model.g.dumpReport(&w.interface, .{ .include_nodes = false, .include_execution = true });
 
-
     // Warmup
     for (0..warmup_iters) |_| {
         model.g.reset();
@@ -137,6 +136,17 @@ pub fn main() !void {
     try w.interface.print("  throughput: {d:.0} img/s (at p50)\n\n", .{
         @as(f64, @floatFromInt(batch_size)) / (ns_to_ms(p50) / 1000.0),
     });
+    const phase_profile = (try model.g.profileExecution(.{ .loss_grad = model.loss.grad })).fused_conv_phases;
+    try w.interface.print("Conv phases (single profiled step, ms):\n", .{});
+    try w.interface.print("  fwd im2col:      {d:>7.3}\n", .{@as(f64, @floatFromInt(phase_profile.fwd_im2col_ns)) / 1_000_000.0});
+    try w.interface.print("  fwd gemm:        {d:>7.3}\n", .{@as(f64, @floatFromInt(phase_profile.fwd_gemm_ns)) / 1_000_000.0});
+    try w.interface.print("  fwd epilogue:    {d:>7.3}\n", .{@as(f64, @floatFromInt(phase_profile.fwd_epilogue_ns)) / 1_000_000.0});
+    try w.interface.print("  bwd-in rearrange:{d:>7.3}\n", .{@as(f64, @floatFromInt(phase_profile.bwd_input_rearrange_ns)) / 1_000_000.0});
+    try w.interface.print("  bwd-in gemm:     {d:>7.3}\n", .{@as(f64, @floatFromInt(phase_profile.bwd_input_gemm_ns)) / 1_000_000.0});
+    try w.interface.print("  bwd-in col2im:   {d:>7.3}\n", .{@as(f64, @floatFromInt(phase_profile.bwd_input_col2im_ns)) / 1_000_000.0});
+    try w.interface.print("  bwd-k im2col:    {d:>7.3}\n", .{@as(f64, @floatFromInt(phase_profile.bwd_kernel_im2col_ns)) / 1_000_000.0});
+    try w.interface.print("  bwd-k rearrange: {d:>7.3}\n", .{@as(f64, @floatFromInt(phase_profile.bwd_kernel_rearrange_ns)) / 1_000_000.0});
+    try w.interface.print("  bwd-k gemm:      {d:>7.3}\n", .{@as(f64, @floatFromInt(phase_profile.bwd_kernel_gemm_ns)) / 1_000_000.0});
     try w.interface.print("  loss after bench: {d:.4}\n\n", .{model.loss.data[0]});
     w.interface.flush() catch {};
 }

--- a/src/nn.zig
+++ b/src/nn.zig
@@ -59,8 +59,17 @@ pub fn batchNorm2d(comptime T: type, x: *Tensor(T), gamma: *Tensor(T), beta: *Te
 ///
 /// Draws from U(-bound, +bound) where bound = sqrt(6 / fan_in).
 /// Standard initialization for layers followed by ReLU.
+///
+/// For 2D weights {out_features, in_features}: fan_in = in_features.
+/// For ≥3D conv kernels {kw, kh, c_in, c_out}: fan_in = kw * kh * c_in.
 pub fn kaimingUniform(comptime T: type, tensor: *Tensor(T), seed: u64) void {
-    const fan_in = tensor.ne[0];
+    const fan_in: usize = if (tensor.n_dims == 2)
+        tensor.ne[1]
+    else blk: {
+        var fi: usize = 1;
+        for (tensor.ne[0 .. tensor.n_dims - 1]) |d| fi *= d;
+        break :blk fi;
+    };
     const bound: T = @sqrt(6.0 / @as(T, @floatFromInt(fan_in)));
     var rng = std.Random.DefaultPrng.init(seed);
     var random = rng.random();
@@ -167,7 +176,6 @@ pub fn trainUnsupervised(
         }
     }
 }
-
 
 /// Inverted dropout: randomly zeroes elements during training and scales
 /// surviving elements by `1/(1-p)` so expected values are preserved.
@@ -595,7 +603,7 @@ test "kaimingUniform - values within expected bounds" {
 
     kaimingUniform(f32, t, 42);
 
-    const bound: f32 = @sqrt(6.0 / 16.0);
+    const bound: f32 = @sqrt(6.0 / 4.0);
     for (t.data) |v| {
         try testing.expect(v >= -bound and v <= bound);
     }
@@ -611,4 +619,3 @@ test "uniform - values within range" {
         try testing.expect(v >= -0.5 and v < 0.5);
     }
 }
-

--- a/src/op.zig
+++ b/src/op.zig
@@ -29,6 +29,7 @@ pub const Op = enum {
     abs,
     sgn,
     step,
+    relu,
     sqrt,
     recip,
     exp,
@@ -54,7 +55,7 @@ pub const Op = enum {
     /// True if this op is elementwise (shape-preserving) and can participate in fusion.
     pub fn isFusible(self: Self) bool {
         return switch (self) {
-            .add, .mul, .neg, .abs, .sgn, .step, .sqrt, .recip, .exp, .log, .gelu => true,
+            .add, .mul, .neg, .abs, .sgn, .step, .relu, .sqrt, .recip, .exp, .log, .gelu => true,
             else => false,
         };
     }
@@ -83,6 +84,7 @@ pub const Op = enum {
             .abs => "abs(x)",
             .sgn => "sgn(x)",
             .step => "step(x)",
+            .relu => "relu(x)",
             .sqrt => "√x",
             .recip => "1/x",
             .exp => "exp(x)",

--- a/src/tensor.zig
+++ b/src/tensor.zig
@@ -438,6 +438,7 @@ pub fn Tensor(comptime T: type) type {
         pub const computeAbs = fwd.computeAbs;
         pub const computeSgn = fwd.computeSgn;
         pub const computeStep = fwd.computeStep;
+        pub const computeRelu = fwd.computeRelu;
         pub const computeSqrt = fwd.computeSqrt;
         pub const computeRecip = fwd.computeRecip;
         pub const computeExp = fwd.computeExp;

--- a/src/tensor.zig
+++ b/src/tensor.zig
@@ -755,6 +755,40 @@ test "broadcastTo creates zero-stride view" {
     try testing.expectEqual(@as(f32, 30), b.get(&.{ 1, 2 }));
 }
 
+test "unary ops handle zero-stride broadcast views" {
+    const pos = try Tensor(f32).initScalar(tac, 7);
+    defer pos.deinit();
+    const pos_b = pos.broadcastTo(&.{ 2, 2, 1, 1 });
+    defer pos_b.deinit();
+
+    try testing.expectEqual(false, pos_b.isDenseLayout());
+
+    const neg = pos_b.neg();
+    defer neg.deinit();
+    neg.compute();
+    try testing.expectEqualSlices(f32, &.{ -7, -7, -7, -7 }, neg.data);
+
+    const step_pos = pos_b.step();
+    defer step_pos.deinit();
+    step_pos.compute();
+    try testing.expectEqualSlices(f32, &.{ 1, 1, 1, 1 }, step_pos.data);
+
+    const neg_src = try Tensor(f32).initScalar(tac, -7);
+    defer neg_src.deinit();
+    const neg_b = neg_src.broadcastTo(&.{ 2, 2, 1, 1 });
+    defer neg_b.deinit();
+
+    const abs = neg_b.abs();
+    defer abs.deinit();
+    abs.compute();
+    try testing.expectEqualSlices(f32, &.{ 7, 7, 7, 7 }, abs.data);
+
+    const step_neg = neg_b.step();
+    defer step_neg.deinit();
+    step_neg.compute();
+    try testing.expectEqualSlices(f32, &.{ 0, 0, 0, 0 }, step_neg.data);
+}
+
 test "slidingWindow2d exposes overlapping patches" {
     const t = try Tensor(f32).init(tac, &.{ 4, 4, 1, 1 });
     defer t.deinit();

--- a/src/tensor/api.zig
+++ b/src/tensor/api.zig
@@ -181,14 +181,15 @@ pub fn Api(comptime Self: type, comptime T: type) type {
         pub fn step(self: *Self) *Self {
             return unaryOp(self, .step, false);
         }
+        pub fn reluPrimitive(self: *Self) *Self {
+            return unaryOp(self, .relu, false);
+        }
         pub fn gelu(self: *Self) *Self {
             return unaryOp(self, .gelu, false);
         }
-        /// Element-wise ReLU: max(0, x). Decomposes to `mul(self, step(self))`.
+        /// Element-wise ReLU primitive.
         pub fn relu(self: *Self) *Self {
-            const mask = aux(self.step());
-            mask.grad = null;
-            return self.mul(mask);
+            return unaryOp(self, .relu, false);
         }
 
         // ---------------------------------------------------------------

--- a/src/tensor/backward.zig
+++ b/src/tensor/backward.zig
@@ -237,9 +237,15 @@ pub fn Ops(comptime Self: type) type {
                         stripGrad(zero_mask);
                         const mask = one.broadcastTo(src0.ne[0..src0.n_dims]).sub(zero_mask);
                         stripGrad(mask);
+                        const tie_count = mask.sum(tensor.ne[0..tensor.n_dims]);
+                        stripGrad(tie_count);
+                        const expanded_tie_count = tie_count.broadcastTo(src0.ne[0..src0.n_dims]);
+                        stripGrad(expanded_tie_count);
                         const expanded_out_grad = out_grad.broadcastTo(src0.ne[0..src0.n_dims]);
                         stripGrad(expanded_out_grad);
-                        const contribution = mask.mul(expanded_out_grad);
+                        const shared_out_grad = expanded_out_grad.div(expanded_tie_count);
+                        stripGrad(shared_out_grad);
+                        const contribution = mask.mul(shared_out_grad);
                         stripGrad(contribution);
                         src0.setGrad(accumGrad(grad, contribution, inplace));
                     }

--- a/src/tensor/backward.zig
+++ b/src/tensor/backward.zig
@@ -147,6 +147,20 @@ pub fn Ops(comptime Self: type) type {
                     }
                 },
 
+                // d/d(src0) [relu(src0)] = 1{tensor > 0} * out_grad
+                // Uses the forward output so backward does not depend on any
+                // decomposed step-mask subgraph.
+                .relu => {
+                    const src0 = src0_o.?;
+                    if (src0.gradOrNull()) |grad| {
+                        const mask = tensor.step();
+                        stripGrad(mask);
+                        const contribution = mask.mul(out_grad);
+                        stripGrad(contribution);
+                        src0.setGrad(accumGrad(grad, contribution, inplace));
+                    }
+                },
+
                 // d/d(src0) [abs(src0)] = sgn(src0) * out_grad
                 .abs => {
                     const src0 = src0_o.?;

--- a/src/tensor/forward.zig
+++ b/src/tensor/forward.zig
@@ -62,6 +62,35 @@ fn simdMapUnary(
     }
 }
 
+/// SIMD contiguous copy for reusable staging paths.
+pub fn simdCopy(comptime T: type, dst: []T, src: []const T) void {
+    assert(dst.len == src.len);
+    const vec_size = comptime simdVecSize(T);
+    var i: usize = 0;
+    while (i + vec_size <= src.len) : (i += vec_size) {
+        dst[i..][0..vec_size].* = src[i..][0..vec_size].*;
+    }
+    while (i < src.len) : (i += 1) {
+        dst[i] = src[i];
+    }
+}
+
+/// SIMD contiguous accumulate: dst += src.
+pub fn simdAccumulate(comptime T: type, dst: []T, src: []const T) void {
+    assert(dst.len == src.len);
+    const vec_size = comptime simdVecSize(T);
+    const Vec = @Vector(vec_size, T);
+    var i: usize = 0;
+    while (i + vec_size <= src.len) : (i += vec_size) {
+        const dv: Vec = dst[i..][0..vec_size].*;
+        const sv: Vec = src[i..][0..vec_size].*;
+        dst[i..][0..vec_size].* = dv + sv;
+    }
+    while (i < src.len) : (i += 1) {
+        dst[i] += src[i];
+    }
+}
+
 /// Generic stride-aware unary map for non-contiguous tensors.
 /// dst must be dense (contiguous); src0 may have arbitrary strides.
 fn computeUnaryStrided(comptime Self: type, dst: *Self, src0: *const Self, comptime scalarFn: anytype) void {

--- a/src/tensor/forward.zig
+++ b/src/tensor/forward.zig
@@ -62,6 +62,19 @@ fn simdMapUnary(
     }
 }
 
+/// Generic stride-aware unary map for non-contiguous tensors.
+/// dst must be dense (contiguous); src0 may have arbitrary strides.
+fn computeUnaryStrided(comptime Self: type, dst: *Self, src0: *const Self, comptime scalarFn: anytype) void {
+    var coords: [max_dims]usize = [_]usize{0} ** max_dims;
+    var dst_i: usize = 0;
+    while (true) {
+        const src_idx = offsetFor(Self, src0, coords[0..src0.n_dims]);
+        dst.data[dst_i] = scalarFn(src0.data[src_idx]);
+        dst_i += 1;
+        if (!nextCoord(coords[0..dst.n_dims], dst.ne[0..dst.n_dims])) break;
+    }
+}
+
 /// How the two operands of a binary op are supplied.
 const BinaryMode = enum { vec_vec, scalar_lhs, scalar_rhs };
 
@@ -735,44 +748,74 @@ pub fn Ops(comptime Self: type, comptime T: type) type {
 
         pub fn computeSqrt(dst: *Self, src0: *const Self) void {
             assert(dst.isSameShape(src0));
-            simdMapUnary(T, src0.data, dst.data, sqrtVec, sqrtScalar);
+            if (src0.isDenseLayout()) {
+                simdMapUnary(T, src0.denseSliceConst(), dst.denseSlice(), sqrtVec, sqrtScalar);
+            } else {
+                computeUnaryStrided(Self, dst, src0, sqrtScalar);
+            }
         }
 
         /// Element-wise reciprocal: dst[i] = 1 / src0[i].
         pub fn computeRecip(dst: *Self, src0: *const Self) void {
             assert(dst.isSameShape(src0));
-            simdMapUnary(T, src0.data, dst.data, recipVec, recipScalar);
+            if (src0.isDenseLayout()) {
+                simdMapUnary(T, src0.denseSliceConst(), dst.denseSlice(), recipVec, recipScalar);
+            } else {
+                computeUnaryStrided(Self, dst, src0, recipScalar);
+            }
         }
 
         pub fn computeExp(dst: *Self, src0: *const Self) void {
             assert(dst.isSameShape(src0));
-            var i: usize = 0;
-            while (i < src0.data.len) : (i += 1) {
-                dst.data[i] = expScalar(src0.data[i]);
+            if (src0.isDenseLayout()) {
+                const slice = src0.denseSliceConst();
+                const d = dst.denseSlice();
+                for (slice, 0..) |v, i| d[i] = expScalar(v);
+            } else {
+                computeUnaryStrided(Self, dst, src0, expScalar);
             }
         }
 
         pub fn computeLog(dst: *Self, src0: *const Self) void {
             assert(dst.isSameShape(src0));
-            var i: usize = 0;
-            while (i < src0.data.len) : (i += 1) {
-                dst.data[i] = logScalar(src0.data[i]);
+            if (src0.isDenseLayout()) {
+                const slice = src0.denseSliceConst();
+                const d = dst.denseSlice();
+                for (slice, 0..) |v, i| d[i] = logScalar(v);
+            } else {
+                computeUnaryStrided(Self, dst, src0, logScalar);
             }
         }
 
         pub fn computeAbs(dst: *Self, src0: *const Self) void {
             assert(dst.isSameShape(src0));
-            simdMapUnary(T, src0.data, dst.data, absVec, absScalar);
+            if (src0.isDenseLayout()) {
+                simdMapUnary(T, src0.denseSliceConst(), dst.denseSlice(), absVec, absScalar);
+            } else {
+                computeUnaryStrided(Self, dst, src0, absScalar);
+            }
         }
 
         pub fn computeNeg(dst: *Self, src0: *const Self) void {
             assert(dst.isSameShape(src0));
-            simdMapUnary(T, src0.data, dst.data, negVec, negScalar);
+            if (src0.isDenseLayout()) {
+                simdMapUnary(T, src0.denseSliceConst(), dst.denseSlice(), negVec, negScalar);
+            } else {
+                computeUnaryStrided(Self, dst, src0, negScalar);
+            }
         }
 
         /// Element-wise sign: -1, 0, or 1.  Uses @select for branchless SIMD.
         pub fn computeSgn(dst: *Self, src0: *const Self) void {
             assert(dst.isSameShape(src0));
+            if (!src0.isDenseLayout()) {
+                computeUnaryStrided(Self, dst, src0, struct {
+                    fn f(s: T) T {
+                        return if (s > 0) 1 else if (s < 0) @as(T, -1) else 0;
+                    }
+                }.f);
+                return;
+            }
             const zero: Vec = @splat(0);
             const one: Vec = @splat(1);
             const neg_one: Vec = @splat(-1);
@@ -792,6 +835,14 @@ pub fn Ops(comptime Self: type, comptime T: type) type {
         /// Element-wise step function: 1 if positive, 0 otherwise.
         pub fn computeStep(dst: *Self, src0: *const Self) void {
             assert(dst.isSameShape(src0));
+            if (!src0.isDenseLayout()) {
+                computeUnaryStrided(Self, dst, src0, struct {
+                    fn f(s: T) T {
+                        return if (s > 0) 1 else 0;
+                    }
+                }.f);
+                return;
+            }
             const zero: Vec = @splat(0);
             const one: Vec = @splat(1);
             const len = src0.data.len;

--- a/src/tensor/forward.zig
+++ b/src/tensor/forward.zig
@@ -856,6 +856,30 @@ pub fn Ops(comptime Self: type, comptime T: type) type {
             }
         }
 
+        /// Element-wise ReLU: max(src0, 0).
+        pub fn computeRelu(dst: *Self, src0: *const Self) void {
+            assert(dst.isSameShape(src0));
+            if (!src0.isDenseLayout()) {
+                computeUnaryStrided(Self, dst, src0, struct {
+                    fn f(s: T) T {
+                        return if (s > 0) s else 0;
+                    }
+                }.f);
+                return;
+            }
+            const zero: Vec = @splat(0);
+            const len = src0.data.len;
+            var i: usize = 0;
+            while (i + vec_size <= len) : (i += vec_size) {
+                const v: Vec = src0.data[i..][0..vec_size].*;
+                dst.data[i..][0..vec_size].* = @max(v, zero);
+            }
+            while (i < len) : (i += 1) {
+                const v = src0.data[i];
+                dst.data[i] = if (v > 0) v else 0;
+            }
+        }
+
         /// Element-wise GeLU with vectorized tanh approximation.
         pub fn computeGelu(dst: *Self, src0: *const Self) void {
             assert(dst.isSameShape(src0));
@@ -1399,6 +1423,7 @@ pub fn Ops(comptime Self: type, comptime T: type) type {
                 .abs => tensor.computeAbs(src0.?),
                 .sgn => tensor.computeSgn(src0.?),
                 .step => tensor.computeStep(src0.?),
+                .relu => tensor.computeRelu(src0.?),
                 .sqrt => tensor.computeSqrt(src0.?),
                 .recip => tensor.computeRecip(src0.?),
                 .exp => tensor.computeExp(src0.?),

--- a/src/tensor/fused.zig
+++ b/src/tensor/fused.zig
@@ -14,6 +14,24 @@ const Op = @import("../op.zig").Op;
 const Tensor = @import("../tensor.zig").Tensor;
 const forward = @import("forward.zig");
 
+pub const ConvPhaseProfile = struct {
+    fwd_im2col_ns: u64 = 0,
+    fwd_gemm_ns: u64 = 0,
+    fwd_epilogue_ns: u64 = 0,
+    bwd_input_rearrange_ns: u64 = 0,
+    bwd_input_gemm_ns: u64 = 0,
+    bwd_input_col2im_ns: u64 = 0,
+    bwd_kernel_im2col_ns: u64 = 0,
+    bwd_kernel_rearrange_ns: u64 = 0,
+    bwd_kernel_gemm_ns: u64 = 0,
+};
+
+fn addConvPhase(dst: ?*ConvPhaseProfile, comptime field: []const u8, ns: u64) void {
+    if (dst) |profile| {
+        @field(profile, field) += ns;
+    }
+}
+
 const GELU_COEF_A: comptime_float = 0.044715;
 const SQRT_2_OVER_PI: comptime_float = @sqrt(2.0 / std.math.pi);
 
@@ -1032,7 +1050,7 @@ fn selectConvMatMul(comptime T: type) forward.MatMulFnType(T) {
 // Conv2d execution: forward, backward-input, backward-kernel
 // ---------------------------------------------------------------------------
 
-fn executeConv2dPlan(comptime T: type, plan: Conv2dPlan(T)) void {
+fn executeConv2dPlan(comptime T: type, plan: Conv2dPlan(T), phase_profile: ?*ConvPhaseProfile) void {
     const d = Conv2dDims(T).fromForward(plan);
     const NB = d.N * d.batch;
     const total_scratch = (d.K + d.c_out) * NB;
@@ -1044,21 +1062,27 @@ fn executeConv2dPlan(comptime T: type, plan: Conv2dPlan(T)) void {
 
     const col_buf = scratch[0 .. d.K * NB];
     const mm_temp = scratch[d.K * NB ..][0 .. d.c_out * NB];
+    var timer = std.time.Timer.start() catch @panic("timer");
 
     // 1. Batched im2col: all samples into [K, N*batch].
+    timer.reset();
     for (0..d.batch) |n| {
         im2col(T, d, col_buf, n, NB, n * d.N);
     }
+    addConvPhase(phase_profile, "fwd_im2col_ns", timer.read());
 
     // 2. Single matmul: kernel[c_out, K] @ col_buf[K, NB] → mm_temp[c_out, NB]
     const mm = selectConvMatMul(T);
+    timer.reset();
     mm(mm_temp, d.kernel_data, col_buf.ptr[0..col_buf.len], d.c_out, NB, d.K, d.K, 1, NB, 1, 0, 0, 0, NB);
+    addConvPhase(phase_profile, "fwd_gemm_ns", timer.read());
 
     // 3. Rearrange [c_out, NB] → [batch, c_out, N] with optional fused bias
     // and relu applied directly into the final output tensor.
     const output = plan.output.data;
     const has_bias = plan.bias != null;
     const has_relu = plan.activation != null;
+    timer.reset();
     for (0..d.batch) |n| {
         for (0..d.c_out) |oc| {
             const src = mm_temp[oc * NB + n * d.N ..][0..d.N];
@@ -1071,6 +1095,7 @@ fn executeConv2dPlan(comptime T: type, plan: Conv2dPlan(T)) void {
             }
         }
     }
+    addConvPhase(phase_profile, "fwd_epilogue_ns", timer.read());
 }
 
 /// SIMD copy with fused bias add + optional ReLU.
@@ -1094,7 +1119,7 @@ fn rearrangeSimd(comptime T: type, dst: []T, src: []const T, bias: T, relu: bool
     }
 }
 
-fn executeConv2dBwdInputPlan(comptime T: type, plan: Conv2dBwdInputPlan(T)) void {
+fn executeConv2dBwdInputPlan(comptime T: type, plan: Conv2dBwdInputPlan(T), phase_profile: ?*ConvPhaseProfile) void {
     const d = Conv2dDims(T).fromBwdInput(plan);
     const NB = d.N * d.batch;
     const total_scratch = (d.K + d.c_out) * NB;
@@ -1106,8 +1131,10 @@ fn executeConv2dBwdInputPlan(comptime T: type, plan: Conv2dBwdInputPlan(T)) void
 
     const col_buf = scratch[0 .. d.K * NB];
     const grad_buf = scratch[d.K * NB ..][0 .. d.c_out * NB];
+    var timer = std.time.Timer.start() catch @panic("timer");
 
     // 1. Rearrange output_grad from [N, c_out, batch] to [c_out, N*batch]
+    timer.reset();
     for (0..d.c_out) |oc| {
         for (0..d.batch) |n| {
             @memcpy(
@@ -1116,19 +1143,24 @@ fn executeConv2dBwdInputPlan(comptime T: type, plan: Conv2dBwdInputPlan(T)) void
             );
         }
     }
+    addConvPhase(phase_profile, "bwd_input_rearrange_ns", timer.read());
 
     // 2. Single GEMM: kernel^T[K, c_out] @ grad_buf[c_out, NB] → col_buf[K, NB]
     const mm = selectConvMatMul(T);
+    timer.reset();
     mm(col_buf, d.kernel_data, grad_buf, d.K, NB, d.c_out, 1, d.K, NB, 1, 0, 0, 0, NB);
+    addConvPhase(phase_profile, "bwd_input_gemm_ns", timer.read());
 
     // 3. col2im per batch from batched col_buf
+    timer.reset();
     @memset(plan.output.data, 0);
     for (0..d.batch) |n| {
         col2im(T, d, plan.output.data, plan.output.strides, col_buf, n, NB, n * d.N);
     }
+    addConvPhase(phase_profile, "bwd_input_col2im_ns", timer.read());
 }
 
-fn executeConv2dBwdKernelPlan(comptime T: type, plan: Conv2dBwdKernelPlan(T)) void {
+fn executeConv2dBwdKernelPlan(comptime T: type, plan: Conv2dBwdKernelPlan(T), phase_profile: ?*ConvPhaseProfile) void {
     const d = Conv2dDims(T).fromBwdKernel(plan);
     const NB = d.N * d.batch;
     const total_scratch = (d.K + d.c_out) * NB;
@@ -1141,13 +1173,17 @@ fn executeConv2dBwdKernelPlan(comptime T: type, plan: Conv2dBwdKernelPlan(T)) vo
 
     const col_buf = scratch[0 .. d.K * NB];
     const grad_buf = scratch[d.K * NB ..][0 .. d.c_out * NB];
+    var timer = std.time.Timer.start() catch @panic("timer");
 
     // 1. Build batched im2col: [K, N*batch] — all samples concatenated.
+    timer.reset();
     for (0..d.batch) |n| {
         im2col(T, d, col_buf, n, NB, n * d.N);
     }
+    addConvPhase(phase_profile, "bwd_kernel_im2col_ns", timer.read());
 
     // 2. Rearrange output_grad from [N, c_out, batch] to [c_out, N*batch]
+    timer.reset();
     for (0..d.c_out) |oc| {
         for (0..d.batch) |n| {
             @memcpy(
@@ -1156,11 +1192,14 @@ fn executeConv2dBwdKernelPlan(comptime T: type, plan: Conv2dBwdKernelPlan(T)) vo
             );
         }
     }
+    addConvPhase(phase_profile, "bwd_kernel_rearrange_ns", timer.read());
 
     // 3. Single GEMM: grad_buf[c_out, NB] @ col_buf^T[NB, K] → output[c_out, K]
     //    Inner dim NB inherently sums across all batches.
     const mm = selectConvMatMul(T);
+    timer.reset();
     mm(plan.output.data, grad_buf, col_buf, d.c_out, d.K, NB, NB, 1, 1, NB, 0, 0, 0, d.K);
+    addConvPhase(phase_profile, "bwd_kernel_gemm_ns", timer.read());
 }
 
 // ---------------------------------------------------------------------------
@@ -1382,12 +1421,12 @@ fn executeLayerNormPlan(comptime T: type, plan: LayerNormPlan(T)) void {
     }
 }
 
-pub fn executeFusionPlan(comptime T: type, plan: FusionPlan(T)) void {
+pub fn executeFusionPlan(comptime T: type, plan: FusionPlan(T), phase_profile: ?*ConvPhaseProfile) void {
     switch (plan.payload) {
         .elementwise_chain => |chain_plan| executeFusedChain(T, chain_plan),
-        .conv2d => |conv2d_plan| executeConv2dPlan(T, conv2d_plan),
-        .conv2d_bwd_input => |conv2d_plan| executeConv2dBwdInputPlan(T, conv2d_plan),
-        .conv2d_bwd_kernel => |conv2d_plan| executeConv2dBwdKernelPlan(T, conv2d_plan),
+        .conv2d => |conv2d_plan| executeConv2dPlan(T, conv2d_plan, phase_profile),
+        .conv2d_bwd_input => |conv2d_plan| executeConv2dBwdInputPlan(T, conv2d_plan, phase_profile),
+        .conv2d_bwd_kernel => |conv2d_plan| executeConv2dBwdKernelPlan(T, conv2d_plan, phase_profile),
         .max_pool2d => |pool_plan| executeMaxPool2d(T, pool_plan),
         .max_pool2d_bwd => |pool_plan| executeMaxPool2dBwd(T, pool_plan),
         .softmax => |softmax_plan| executeSoftmaxPlan(T, softmax_plan),

--- a/src/tensor/fused.zig
+++ b/src/tensor/fused.zig
@@ -111,15 +111,23 @@ pub fn Conv2dPlan(comptime T: type) type {
     return struct {
         input: *Tensor(T),
         kernel: *Tensor(T),
+        conv_out: *Tensor(T),
         input_view: *Tensor(T),
         kernel_view: *Tensor(T),
         bias: ?*Tensor(T),
         bias_node: ?*Tensor(T),
+        bias_add: ?*Tensor(T),
         activation: ?*Tensor(T),
+        step_node: ?*Tensor(T),
         mul_node: *Tensor(T),
         sum_node: *Tensor(T),
         output: *Tensor(T),
         scratch: ?[]T = null, // pre-allocated im2col buffer [K, N]
+
+        fn activationBase(self: @This()) ?*Tensor(T) {
+            if (self.activation == null) return null;
+            return self.bias_add orelse self.conv_out;
+        }
     };
 }
 
@@ -334,7 +342,6 @@ pub fn validateLayerNormPlan(comptime T: type, plan: LayerNormPlan(T)) bool {
     return true;
 }
 
-
 fn fusedOpForNode(comptime T: type, plan: ElementwiseFusionPlan(T), idx: usize) ?FusedOp {
     const node = plan.nodes[idx];
     return switch (node.op) {
@@ -499,7 +506,9 @@ fn executeFusedGenericRange(comptime T: type, plan: ElementwiseFusionPlan(T), st
             var val: VecT = input_data[i + input_off ..][0..V].*;
             for (nodes, 0..) |node, node_idx| {
                 const fop = fusedOpForNode(T, plan, node_idx).?;
-                inline for (fusible_ops) |c| if (fop == c) { val = applyOpVec(T, V, c, val, node, i); };
+                inline for (fusible_ops) |c| if (fop == c) {
+                    val = applyOpVec(T, V, c, val, node, i);
+                };
                 node.data[i + node.storage_offset ..][0..V].* = val;
             }
         }
@@ -507,7 +516,9 @@ fn executeFusedGenericRange(comptime T: type, plan: ElementwiseFusionPlan(T), st
             var val: T = input_data[i + input_off];
             for (nodes, 0..) |node, node_idx| {
                 const fop = fusedOpForNode(T, plan, node_idx).?;
-                inline for (fusible_ops) |c| if (fop == c) { val = applyOp(T, c, val, node, i); };
+                inline for (fusible_ops) |c| if (fop == c) {
+                    val = applyOp(T, c, val, node, i);
+                };
                 node.data[i + node.storage_offset] = val;
             }
         }
@@ -532,7 +543,9 @@ fn executeFusedGenericRange(comptime T: type, plan: ElementwiseFusionPlan(T), st
             }
             for (nodes, 0..) |node, node_idx| {
                 const fop = fusedOpForNode(T, plan, node_idx).?;
-                inline for (fusible_ops) |c| if (fop == c) { val = applyOpVec(T, V, c, val, node, i); };
+                inline for (fusible_ops) |c| if (fop == c) {
+                    val = applyOpVec(T, V, c, val, node, i);
+                };
                 node.data[i + node.storage_offset ..][0..V].* = val;
             }
         }
@@ -541,7 +554,9 @@ fn executeFusedGenericRange(comptime T: type, plan: ElementwiseFusionPlan(T), st
             _ = nextCoord(coords[0..n_dims], input.ne[0..n_dims]);
             for (nodes, 0..) |node, node_idx| {
                 const fop = fusedOpForNode(T, plan, node_idx).?;
-                inline for (fusible_ops) |c| if (fop == c) { val = applyOp(T, c, val, node, i); };
+                inline for (fusible_ops) |c| if (fop == c) {
+                    val = applyOp(T, c, val, node, i);
+                };
                 node.data[i + node.storage_offset] = val;
             }
         }
@@ -794,18 +809,25 @@ fn executeMaxPool2dBwd(comptime T: type, plan: MaxPool2dBwdPlan(T)) void {
                     const ix = ox * 2;
                     const iy = oy * 2;
                     const base = ix + iy * in_stride_h + ch * in_stride_c + n * in_stride_n;
-                    // Find argmax in 2x2 window
-                    var best = base;
-                    var val = input.data[base];
-                    const offsets = [_]usize{ 1, in_stride_h, in_stride_h + 1 };
-                    for (offsets) |off| {
-                        if (input.data[base + off] > val) {
-                            val = input.data[base + off];
-                            best = base + off;
-                        }
-                    }
-                    // Scatter gradient to argmax position
-                    dst.data[best] += out_grad.data[ox + oy * out_stride_h + ch * out_stride_c + n * out_stride_n];
+                    const grad = out_grad.data[ox + oy * out_stride_h + ch * out_stride_c + n * out_stride_n];
+                    const v00 = input.data[base];
+                    const v10 = input.data[base + 1];
+                    const v01 = input.data[base + in_stride_h];
+                    const v11 = input.data[base + in_stride_h + 1];
+                    const max_val = @max(@max(v00, v10), @max(v01, v11));
+                    const tie_count_usize: usize =
+                        @as(usize, @intFromBool(v00 == max_val)) +
+                        @as(usize, @intFromBool(v10 == max_val)) +
+                        @as(usize, @intFromBool(v01 == max_val)) +
+                        @as(usize, @intFromBool(v11 == max_val));
+                    const share = grad / @as(T, @floatFromInt(tie_count_usize));
+
+                    // Symmetric subgradient for max: split upstream gradient
+                    // evenly across all tied maxima in the pooling window.
+                    if (v00 == max_val) dst.data[base] += share;
+                    if (v10 == max_val) dst.data[base + 1] += share;
+                    if (v01 == max_val) dst.data[base + in_stride_h] += share;
+                    if (v11 == max_val) dst.data[base + in_stride_h + 1] += share;
                 }
             }
         }
@@ -1035,41 +1057,74 @@ fn executeConv2dPlan(comptime T: type, plan: Conv2dPlan(T)) void {
     const mm = selectConvMatMul(T);
     mm(mm_temp, d.kernel_data, col_buf.ptr[0..col_buf.len], d.c_out, NB, d.K, d.K, 1, NB, 1, 0, 0, 0, NB);
 
-    // 3. Rearrange [c_out, NB] → [batch, c_out, N] with fused bias + activation.
-    const output = plan.output.data;
+    // 3. Rearrange [c_out, NB] → [batch, c_out, N], materializing the raw
+    // conv output plus any fused bias/relu intermediates needed later.
+    const conv_out = plan.conv_out.data;
     const has_bias = plan.bias != null;
-    const has_relu = plan.activation != null;
     for (0..d.batch) |n| {
         for (0..d.c_out) |oc| {
             const src = mm_temp[oc * NB + n * d.N ..][0..d.N];
-            const dst = output[n * d.N * d.c_out + oc * d.N ..][0..d.N];
-            if (has_bias or has_relu) {
-                const b = if (plan.bias) |bv| bv.data[oc] else 0;
-                if (has_relu) rearrangeSimd(T, dst, src, b, true) else rearrangeSimd(T, dst, src, b, false);
+            const conv_dst = conv_out[n * d.N * d.c_out + oc * d.N ..][0..d.N];
+            if (has_bias) {
+                const b = plan.bias.?.data[oc];
+                const bias_dst = plan.bias_add.?.data[n * d.N * d.c_out + oc * d.N ..][0..d.N];
+                copyAndAddBiasSimd(T, conv_dst, bias_dst, src, b);
             } else {
-                @memcpy(dst, src);
+                @memcpy(conv_dst, src);
             }
         }
     }
+
+    if (plan.activation) |activation| {
+        const pre_relu = plan.activationBase().?;
+        const step_node = plan.step_node.?;
+        executeActivationMulRelu(T, pre_relu, step_node, activation);
+    }
 }
 
-/// SIMD copy with fused bias add + optional ReLU.
-fn rearrangeSimd(comptime T: type, dst: []T, src: []const T, bias: T, comptime relu: bool) void {
+/// SIMD copy that materializes both the raw conv output and the biased output.
+fn copyAndAddBiasSimd(comptime T: type, raw_dst: []T, bias_dst: []T, src: []const T, bias: T) void {
     const vl = comptime forward.simdVecSize(T);
     const V = @Vector(vl, T);
     const bv: V = @splat(bias);
-    const len = dst.len;
+    const len = raw_dst.len;
 
     var i: usize = 0;
     while (i + vl <= len) : (i += vl) {
-        var v: V = src[i..][0..vl].* + bv;
-        if (relu) v = @max(v, @as(V, @splat(0)));
-        dst[i..][0..vl].* = v;
+        const v = src[i..][0..vl].*;
+        raw_dst[i..][0..vl].* = v;
+        bias_dst[i..][0..vl].* = v + bv;
     }
     while (i < len) : (i += 1) {
-        var v = src[i] + bias;
-        if (relu) v = @max(v, 0);
-        dst[i] = v;
+        const v = src[i];
+        raw_dst[i] = v;
+        bias_dst[i] = v + bias;
+    }
+}
+
+fn executeActivationMulRelu(comptime T: type, pre_relu: *Tensor(T), step_node: *Tensor(T), activation: *Tensor(T)) void {
+    const vl = comptime forward.simdVecSize(T);
+    const V = @Vector(vl, T);
+    const zero: V = @splat(0);
+    const one: V = @splat(1);
+    const len = pre_relu.data.len;
+
+    var i: usize = 0;
+    while (i + vl <= len) : (i += vl) {
+        const v: V = pre_relu.data[i..][0..vl].*;
+        const mask: @Vector(vl, bool) = v > zero;
+        step_node.data[i..][0..vl].* = @select(T, mask, one, zero);
+        activation.data[i..][0..vl].* = @select(T, mask, v, zero);
+    }
+    while (i < len) : (i += 1) {
+        const v = pre_relu.data[i];
+        if (v > 0) {
+            step_node.data[i] = 1;
+            activation.data[i] = v;
+        } else {
+            step_node.data[i] = 0;
+            activation.data[i] = 0;
+        }
     }
 }
 
@@ -1273,7 +1328,6 @@ fn findNodeAfter(comptime T: type, nodes: []const *Tensor(T), start_idx: usize, 
 /// dependency that exists in the node list, bounded by the output index.
 /// Used to determine the start of a fused region that replaces an entire
 /// backward chain (e.g., conv2d backward: reshape → broadcast → mul → scatter).
-
 pub fn indexOfNodeMaybe(comptime T: type, nodes: []const *Tensor(T), needle: *Tensor(T)) ?usize {
     for (nodes, 0..) |node, i| {
         if (node == needle) return i;
@@ -1376,7 +1430,6 @@ pub fn executeFusionPlan(comptime T: type, plan: FusionPlan(T)) void {
         .layer_norm => |layer_norm_plan| executeLayerNormPlan(T, layer_norm_plan),
     }
 }
-
 
 test "fused - swapped commutative 2-op chain" {
     const T = f32;

--- a/src/tensor/fused.zig
+++ b/src/tensor/fused.zig
@@ -22,6 +22,7 @@ const FusedOp = enum {
     abs,
     sgn,
     step,
+    relu,
     sqrt,
     recip,
     exp,
@@ -39,6 +40,7 @@ pub const fusible_ops = [_]FusedOp{
     .abs,
     .sgn,
     .step,
+    .relu,
     .sqrt,
     .recip,
     .exp,
@@ -111,23 +113,15 @@ pub fn Conv2dPlan(comptime T: type) type {
     return struct {
         input: *Tensor(T),
         kernel: *Tensor(T),
-        conv_out: *Tensor(T),
         input_view: *Tensor(T),
         kernel_view: *Tensor(T),
         bias: ?*Tensor(T),
         bias_node: ?*Tensor(T),
-        bias_add: ?*Tensor(T),
         activation: ?*Tensor(T),
-        step_node: ?*Tensor(T),
         mul_node: *Tensor(T),
         sum_node: *Tensor(T),
         output: *Tensor(T),
         scratch: ?[]T = null, // pre-allocated im2col buffer [K, N]
-
-        fn activationBase(self: @This()) ?*Tensor(T) {
-            if (self.activation == null) return null;
-            return self.bias_add orelse self.conv_out;
-        }
     };
 }
 
@@ -349,6 +343,7 @@ fn fusedOpForNode(comptime T: type, plan: ElementwiseFusionPlan(T), idx: usize) 
         .abs => .abs,
         .sgn => .sgn,
         .step => .step,
+        .relu => .relu,
         .sqrt => .sqrt,
         .recip => .recip,
         .exp => .exp,
@@ -410,6 +405,7 @@ fn applyOp(comptime T: type, comptime op: FusedOp, val: T, node: anytype, i: usi
         .abs => @abs(val),
         .sgn => if (val > 0) 1 else if (val < 0) @as(T, -1) else 0,
         .step => if (val > 0) @as(T, 1) else 0,
+        .relu => if (val > 0) val else 0,
         .sqrt => @sqrt(val),
         .recip => 1.0 / val,
         .exp => @exp(val),
@@ -435,6 +431,7 @@ fn applyOpVec(comptime T: type, comptime V: comptime_int, comptime op: FusedOp, 
             break :blk @select(T, val > zero, @as(VecT, @splat(@as(T, 1))), @select(T, val < zero, @as(VecT, @splat(@as(T, -1))), zero));
         },
         .step => @select(T, val > @as(VecT, @splat(@as(T, 0))), @as(VecT, @splat(@as(T, 1))), @as(VecT, @splat(@as(T, 0)))),
+        .relu => @max(val, @as(VecT, @splat(@as(T, 0)))),
         .sqrt => @sqrt(val),
         .recip => @as(VecT, @splat(@as(T, 1))) / val,
         .exp => @exp(val),
@@ -1057,74 +1054,43 @@ fn executeConv2dPlan(comptime T: type, plan: Conv2dPlan(T)) void {
     const mm = selectConvMatMul(T);
     mm(mm_temp, d.kernel_data, col_buf.ptr[0..col_buf.len], d.c_out, NB, d.K, d.K, 1, NB, 1, 0, 0, 0, NB);
 
-    // 3. Rearrange [c_out, NB] → [batch, c_out, N], materializing the raw
-    // conv output plus any fused bias/relu intermediates needed later.
-    const conv_out = plan.conv_out.data;
+    // 3. Rearrange [c_out, NB] → [batch, c_out, N] with optional fused bias
+    // and relu applied directly into the final output tensor.
+    const output = plan.output.data;
     const has_bias = plan.bias != null;
+    const has_relu = plan.activation != null;
     for (0..d.batch) |n| {
         for (0..d.c_out) |oc| {
             const src = mm_temp[oc * NB + n * d.N ..][0..d.N];
-            const conv_dst = conv_out[n * d.N * d.c_out + oc * d.N ..][0..d.N];
-            if (has_bias) {
-                const b = plan.bias.?.data[oc];
-                const bias_dst = plan.bias_add.?.data[n * d.N * d.c_out + oc * d.N ..][0..d.N];
-                copyAndAddBiasSimd(T, conv_dst, bias_dst, src, b);
+            const dst = output[n * d.N * d.c_out + oc * d.N ..][0..d.N];
+            const b = if (has_bias) plan.bias.?.data[oc] else 0;
+            if (has_bias or has_relu) {
+                rearrangeSimd(T, dst, src, b, has_relu);
             } else {
-                @memcpy(conv_dst, src);
+                @memcpy(dst, src);
             }
         }
     }
-
-    if (plan.activation) |activation| {
-        const pre_relu = plan.activationBase().?;
-        const step_node = plan.step_node.?;
-        executeActivationMulRelu(T, pre_relu, step_node, activation);
-    }
 }
 
-/// SIMD copy that materializes both the raw conv output and the biased output.
-fn copyAndAddBiasSimd(comptime T: type, raw_dst: []T, bias_dst: []T, src: []const T, bias: T) void {
+/// SIMD copy with fused bias add + optional ReLU.
+fn rearrangeSimd(comptime T: type, dst: []T, src: []const T, bias: T, relu: bool) void {
     const vl = comptime forward.simdVecSize(T);
     const V = @Vector(vl, T);
     const bv: V = @splat(bias);
-    const len = raw_dst.len;
-
-    var i: usize = 0;
-    while (i + vl <= len) : (i += vl) {
-        const v = src[i..][0..vl].*;
-        raw_dst[i..][0..vl].* = v;
-        bias_dst[i..][0..vl].* = v + bv;
-    }
-    while (i < len) : (i += 1) {
-        const v = src[i];
-        raw_dst[i] = v;
-        bias_dst[i] = v + bias;
-    }
-}
-
-fn executeActivationMulRelu(comptime T: type, pre_relu: *Tensor(T), step_node: *Tensor(T), activation: *Tensor(T)) void {
-    const vl = comptime forward.simdVecSize(T);
-    const V = @Vector(vl, T);
+    const len = dst.len;
     const zero: V = @splat(0);
-    const one: V = @splat(1);
-    const len = pre_relu.data.len;
 
     var i: usize = 0;
     while (i + vl <= len) : (i += vl) {
-        const v: V = pre_relu.data[i..][0..vl].*;
-        const mask: @Vector(vl, bool) = v > zero;
-        step_node.data[i..][0..vl].* = @select(T, mask, one, zero);
-        activation.data[i..][0..vl].* = @select(T, mask, v, zero);
+        var v = src[i..][0..vl].* + bv;
+        if (relu) v = @max(v, zero);
+        dst[i..][0..vl].* = v;
     }
     while (i < len) : (i += 1) {
-        const v = pre_relu.data[i];
-        if (v > 0) {
-            step_node.data[i] = 1;
-            activation.data[i] = v;
-        } else {
-            step_node.data[i] = 0;
-            activation.data[i] = 0;
-        }
+        var v = src[i] + bias;
+        if (relu and v < 0) v = 0;
+        dst[i] = v;
     }
 }
 

--- a/src/tensor/fused.zig
+++ b/src/tensor/fused.zig
@@ -14,6 +14,9 @@ const Op = @import("../op.zig").Op;
 const Tensor = @import("../tensor.zig").Tensor;
 const forward = @import("forward.zig");
 
+const conv_workspace_target_bytes: usize = 16 * 1024 * 1024;
+const conv_workspace_min_tiled_k: usize = 64;
+
 pub const ConvPhaseProfile = struct {
     fwd_im2col_ns: u64 = 0,
     fwd_gemm_ns: u64 = 0,
@@ -274,19 +277,18 @@ pub fn FusionPlan(comptime T: type) type {
             switch (self.payload) {
                 .conv2d => |*p| {
                     const d = Conv2dDims(T).fromForward(p.*);
-                    const NB = d.N * d.batch;
-                    // im2col [K, NB] + matmul temp [c_out, NB]
-                    p.scratch = try alloc.alloc(T, (d.K + d.c_out) * NB);
+                    const ws = ConvWorkspacePlan(T).init(.forward, d);
+                    p.scratch = try alloc.alloc(T, ws.total_elems);
                 },
                 .conv2d_bwd_input => |*p| {
                     const d = Conv2dDims(T).fromBwdInput(p.*);
-                    const NB = d.N * d.batch;
-                    p.scratch = try alloc.alloc(T, (d.K + d.c_out) * NB);
+                    const ws = ConvWorkspacePlan(T).init(.bwd_input, d);
+                    p.scratch = try alloc.alloc(T, ws.total_elems);
                 },
                 .conv2d_bwd_kernel => |*p| {
                     const d = Conv2dDims(T).fromBwdKernel(p.*);
-                    const NB = d.N * d.batch;
-                    p.scratch = try alloc.alloc(T, (d.K + d.c_out) * NB);
+                    const ws = ConvWorkspacePlan(T).init(.bwd_kernel, d);
+                    p.scratch = try alloc.alloc(T, ws.total_elems);
                 },
                 else => {},
             }
@@ -941,6 +943,63 @@ fn Conv2dDims(comptime T: type) type {
     };
 }
 
+const ConvWorkspaceKind = enum {
+    forward,
+    bwd_input,
+    bwd_kernel,
+};
+
+fn ConvWorkspacePlan(comptime T: type) type {
+    return struct {
+        batch_tile: usize,
+        col_stride: usize,
+        col_elems: usize,
+        aux_elems: usize,
+        partial_elems: usize,
+        total_elems: usize,
+
+        fn chooseBatchTile(batch: usize, per_batch_elems: usize, k: usize) usize {
+            if (k < conv_workspace_min_tiled_k) return batch;
+            if (!(T == f32 and @import("zgml_options").use_blas)) return batch;
+            const target_elems = conv_workspace_target_bytes / @sizeOf(T);
+            var tile = batch;
+            while (tile > 1 and per_batch_elems * tile > target_elems) {
+                tile = (tile + 1) / 2;
+            }
+            return tile;
+        }
+
+        fn init(kind: ConvWorkspaceKind, d: Conv2dDims(T)) @This() {
+            const partial_elems = if (kind == .bwd_kernel) d.c_out * d.K else 0;
+            const per_batch_elems = (d.K + d.c_out) * d.N;
+            const batch_tile = chooseBatchTile(d.batch, per_batch_elems, d.K);
+            const col_stride = d.N * batch_tile;
+            const col_elems = d.K * col_stride;
+            const aux_elems = d.c_out * col_stride;
+            return .{
+                .batch_tile = batch_tile,
+                .col_stride = col_stride,
+                .col_elems = col_elems,
+                .aux_elems = aux_elems,
+                .partial_elems = if (batch_tile < d.batch) partial_elems else 0,
+                .total_elems = col_elems + aux_elems + if (batch_tile < d.batch) partial_elems else 0,
+            };
+        }
+
+        fn colBuf(self: @This(), scratch: []T) []T {
+            return scratch[0..self.col_elems];
+        }
+
+        fn auxBuf(self: @This(), scratch: []T) []T {
+            return scratch[self.col_elems..][0..self.aux_elems];
+        }
+
+        fn partialBuf(self: @This(), scratch: []T) []T {
+            return scratch[self.col_elems + self.aux_elems ..][0..self.partial_elems];
+        }
+    };
+}
+
 /// Extract sliding-window patches into a column matrix.
 ///
 /// Writes to col_buf with row stride `col_stride` (number of columns per row).
@@ -1048,50 +1107,58 @@ fn selectConvMatMul(comptime T: type) forward.MatMulFnType(T) {
 
 fn executeConv2dPlan(comptime T: type, plan: Conv2dPlan(T), phase_profile: ?*ConvPhaseProfile) void {
     const d = Conv2dDims(T).fromForward(plan);
-    const NB = d.N * d.batch;
-    const total_scratch = (d.K + d.c_out) * NB;
+    const ws = ConvWorkspacePlan(T).init(.forward, d);
+    const total_scratch = ws.total_elems;
     const scratch = plan.scratch orelse allocScratch(T, total_scratch) orelse {
         conv2dNaive(T, d, plan.output.data);
         return;
     };
     defer if (plan.scratch == null) freeScratch(T, scratch);
 
-    const col_buf = scratch[0 .. d.K * NB];
-    const mm_temp = scratch[d.K * NB ..][0 .. d.c_out * NB];
+    const col_buf = ws.colBuf(scratch);
+    const mm_temp = ws.auxBuf(scratch);
     var timer = std.time.Timer.start() catch @panic("timer");
 
     // 1. Batched im2col: all samples into [K, N*batch].
     timer.reset();
-    for (0..d.batch) |n| {
-        im2col(T, d, col_buf, n, NB, n * d.N);
-    }
-    addConvPhase(phase_profile, "fwd_im2col_ns", timer.read());
-
-    // 2. Single matmul: kernel[c_out, K] @ col_buf[K, NB] → mm_temp[c_out, NB]
     const mm = selectConvMatMul(T);
-    timer.reset();
-    mm(mm_temp, d.kernel_data, col_buf.ptr[0..col_buf.len], d.c_out, NB, d.K, d.K, 1, NB, 1, 0, 0, 0, NB);
-    addConvPhase(phase_profile, "fwd_gemm_ns", timer.read());
-
-    // 3. Rearrange [c_out, NB] → [batch, c_out, N] with optional fused bias
-    // and relu applied directly into the final output tensor.
     const output = plan.output.data;
     const has_bias = plan.bias != null;
     const has_relu = plan.activation != null;
-    timer.reset();
-    for (0..d.batch) |n| {
-        for (0..d.c_out) |oc| {
-            const src = mm_temp[oc * NB + n * d.N ..][0..d.N];
-            const dst = output[n * d.N * d.c_out + oc * d.N ..][0..d.N];
-            const b = if (has_bias) plan.bias.?.data[oc] else 0;
-            if (has_bias or has_relu) {
-                rearrangeSimd(T, dst, src, b, has_relu);
-            } else {
-                forward.simdCopy(T, dst, src);
+    var batch_start: usize = 0;
+    while (batch_start < d.batch) {
+        const tile_batch = @min(ws.batch_tile, d.batch - batch_start);
+        const tile_cols = d.N * tile_batch;
+
+        timer.reset();
+        for (0..tile_batch) |local_n| {
+            const n = batch_start + local_n;
+            im2col(T, d, col_buf, n, tile_cols, local_n * d.N);
+        }
+        addConvPhase(phase_profile, "fwd_im2col_ns", timer.read());
+
+        timer.reset();
+        mm(mm_temp[0 .. d.c_out * tile_cols], d.kernel_data, col_buf[0 .. d.K * tile_cols], d.c_out, tile_cols, d.K, d.K, 1, tile_cols, 1, 0, 0, 0, tile_cols);
+        addConvPhase(phase_profile, "fwd_gemm_ns", timer.read());
+
+        timer.reset();
+        for (0..tile_batch) |local_n| {
+            const n = batch_start + local_n;
+            for (0..d.c_out) |oc| {
+                const src = mm_temp[oc * tile_cols + local_n * d.N ..][0..d.N];
+                const dst = output[n * d.N * d.c_out + oc * d.N ..][0..d.N];
+                const b = if (has_bias) plan.bias.?.data[oc] else 0;
+                if (has_bias or has_relu) {
+                    rearrangeSimd(T, dst, src, b, has_relu);
+                } else {
+                    forward.simdCopy(T, dst, src);
+                }
             }
         }
+        addConvPhase(phase_profile, "fwd_epilogue_ns", timer.read());
+
+        batch_start += tile_batch;
     }
-    addConvPhase(phase_profile, "fwd_epilogue_ns", timer.read());
 }
 
 /// SIMD copy with fused bias add + optional ReLU.
@@ -1117,46 +1184,56 @@ fn rearrangeSimd(comptime T: type, dst: []T, src: []const T, bias: T, relu: bool
 
 fn executeConv2dBwdInputPlan(comptime T: type, plan: Conv2dBwdInputPlan(T), phase_profile: ?*ConvPhaseProfile) void {
     const d = Conv2dDims(T).fromBwdInput(plan);
-    const NB = d.N * d.batch;
-    const total_scratch = (d.K + d.c_out) * NB;
+    const ws = ConvWorkspacePlan(T).init(.bwd_input, d);
+    const total_scratch = ws.total_elems;
     const scratch = plan.scratch orelse allocScratch(T, total_scratch) orelse {
         conv2dBwdInputNaive(T, d, plan);
         return;
     };
     defer if (plan.scratch == null) freeScratch(T, scratch);
 
-    const col_buf = scratch[0 .. d.K * NB];
-    const grad_buf = scratch[d.K * NB ..][0 .. d.c_out * NB];
+    const col_buf = ws.colBuf(scratch);
+    const grad_buf = ws.auxBuf(scratch);
     var timer = std.time.Timer.start() catch @panic("timer");
     @memset(plan.output.data, 0);
-
-    // 1. Rearrange output_grad from [N, c_out, batch] to [c_out, N*batch]
-    timer.reset();
-    for (0..d.c_out) |oc| {
-        for (0..d.batch) |n| {
-            forward.simdCopy(T, grad_buf[oc * NB + n * d.N ..][0..d.N], plan.output_grad.data[n * d.N * d.c_out + oc * d.N ..][0..d.N]);
-        }
-    }
-    addConvPhase(phase_profile, "bwd_input_rearrange_ns", timer.read());
-
-    // 2. Single GEMM: kernel^T[K, c_out] @ grad_buf[c_out, NB] → col_buf[K, NB]
     const mm = selectConvMatMul(T);
-    timer.reset();
-    mm(col_buf, d.kernel_data, grad_buf, d.K, NB, d.c_out, 1, d.K, NB, 1, 0, 0, 0, NB);
-    addConvPhase(phase_profile, "bwd_input_gemm_ns", timer.read());
+    var batch_start: usize = 0;
 
-    // 3. col2im per batch from batched col_buf
-    timer.reset();
-    for (0..d.batch) |n| {
-        col2im(T, d, plan.output.data, plan.output.strides, col_buf, n, NB, n * d.N);
+    while (batch_start < d.batch) {
+        const tile_batch = @min(ws.batch_tile, d.batch - batch_start);
+        const tile_cols = d.N * tile_batch;
+
+        // 1. Rearrange output_grad from [N, c_out, batch] to [c_out, N*tile]
+        timer.reset();
+        for (0..d.c_out) |oc| {
+            for (0..tile_batch) |local_n| {
+                const n = batch_start + local_n;
+                forward.simdCopy(T, grad_buf[oc * tile_cols + local_n * d.N ..][0..d.N], plan.output_grad.data[n * d.N * d.c_out + oc * d.N ..][0..d.N]);
+            }
+        }
+        addConvPhase(phase_profile, "bwd_input_rearrange_ns", timer.read());
+
+        // 2. GEMM: kernel^T[K, c_out] @ grad_buf[c_out, N*tile] → col_buf[K, N*tile]
+        timer.reset();
+        mm(col_buf[0 .. d.K * tile_cols], d.kernel_data, grad_buf[0 .. d.c_out * tile_cols], d.K, tile_cols, d.c_out, 1, d.K, tile_cols, 1, 0, 0, 0, tile_cols);
+        addConvPhase(phase_profile, "bwd_input_gemm_ns", timer.read());
+
+        // 3. col2im back into the original input layout for each batch slice.
+        timer.reset();
+        for (0..tile_batch) |local_n| {
+            const n = batch_start + local_n;
+            col2im(T, d, plan.output.data, plan.output.strides, col_buf[0 .. d.K * tile_cols], n, tile_cols, local_n * d.N);
+        }
+        addConvPhase(phase_profile, "bwd_input_col2im_ns", timer.read());
+
+        batch_start += tile_batch;
     }
-    addConvPhase(phase_profile, "bwd_input_col2im_ns", timer.read());
 }
 
 fn executeConv2dBwdKernelPlan(comptime T: type, plan: Conv2dBwdKernelPlan(T), phase_profile: ?*ConvPhaseProfile) void {
     const d = Conv2dDims(T).fromBwdKernel(plan);
-    const NB = d.N * d.batch;
-    const total_scratch = (d.K + d.c_out) * NB;
+    const ws = ConvWorkspacePlan(T).init(.bwd_kernel, d);
+    const total_scratch = ws.total_elems;
 
     const scratch = plan.scratch orelse allocScratch(T, total_scratch) orelse {
         conv2dBwdKernelNaive(T, d, plan);
@@ -1164,32 +1241,48 @@ fn executeConv2dBwdKernelPlan(comptime T: type, plan: Conv2dBwdKernelPlan(T), ph
     };
     defer if (plan.scratch == null) freeScratch(T, scratch);
 
-    const col_buf = scratch[0 .. d.K * NB];
-    const grad_buf = scratch[d.K * NB ..][0 .. d.c_out * NB];
+    const col_buf = ws.colBuf(scratch);
+    const grad_buf = ws.auxBuf(scratch);
+    const partial = ws.partialBuf(scratch);
     var timer = std.time.Timer.start() catch @panic("timer");
+    @memset(plan.output.data, 0);
+    const use_partial = ws.batch_tile < d.batch;
 
-    // 1. Build batched im2col: [K, N*batch] — all samples concatenated.
-    timer.reset();
-    for (0..d.batch) |n| {
-        im2col(T, d, col_buf, n, NB, n * d.N);
-    }
-    addConvPhase(phase_profile, "bwd_kernel_im2col_ns", timer.read());
-
-    // 2. Rearrange output_grad from [N, c_out, batch] to [c_out, N*batch]
-    timer.reset();
-    for (0..d.c_out) |oc| {
-        for (0..d.batch) |n| {
-            forward.simdCopy(T, grad_buf[oc * NB + n * d.N ..][0..d.N], plan.output_grad.data[n * d.N * d.c_out + oc * d.N ..][0..d.N]);
-        }
-    }
-    addConvPhase(phase_profile, "bwd_kernel_rearrange_ns", timer.read());
-
-    // 3. Single GEMM: grad_buf[c_out, NB] @ col_buf^T[NB, K] → output[c_out, K]
-    //    Inner dim NB inherently sums across all batches.
     const mm = selectConvMatMul(T);
-    timer.reset();
-    mm(plan.output.data, grad_buf, col_buf, d.c_out, d.K, NB, NB, 1, 1, NB, 0, 0, 0, d.K);
-    addConvPhase(phase_profile, "bwd_kernel_gemm_ns", timer.read());
+    var batch_start: usize = 0;
+    while (batch_start < d.batch) {
+        const tile_batch = @min(ws.batch_tile, d.batch - batch_start);
+        const tile_cols = d.N * tile_batch;
+
+        timer.reset();
+        for (0..tile_batch) |local_n| {
+            const n = batch_start + local_n;
+            im2col(T, d, col_buf, n, tile_cols, local_n * d.N);
+        }
+        addConvPhase(phase_profile, "bwd_kernel_im2col_ns", timer.read());
+
+        timer.reset();
+        for (0..d.c_out) |oc| {
+            for (0..tile_batch) |local_n| {
+                const n = batch_start + local_n;
+                forward.simdCopy(T, grad_buf[oc * tile_cols + local_n * d.N ..][0..d.N], plan.output_grad.data[n * d.N * d.c_out + oc * d.N ..][0..d.N]);
+            }
+        }
+        addConvPhase(phase_profile, "bwd_kernel_rearrange_ns", timer.read());
+
+        const gemm_dst = if (use_partial) partial[0 .. d.c_out * d.K] else plan.output.data;
+        timer.reset();
+        mm(gemm_dst, grad_buf[0 .. d.c_out * tile_cols], col_buf[0 .. d.K * tile_cols], d.c_out, d.K, tile_cols, tile_cols, 1, 1, tile_cols, 0, 0, 0, d.K);
+        addConvPhase(phase_profile, "bwd_kernel_gemm_ns", timer.read());
+
+        if (use_partial) {
+            timer.reset();
+            forward.simdAccumulate(T, plan.output.data, partial[0 .. d.c_out * d.K]);
+            addConvPhase(phase_profile, "bwd_kernel_rearrange_ns", timer.read());
+        }
+
+        batch_start += tile_batch;
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/tensor/fused.zig
+++ b/src/tensor/fused.zig
@@ -281,13 +281,11 @@ pub fn FusionPlan(comptime T: type) type {
                 .conv2d_bwd_input => |*p| {
                     const d = Conv2dDims(T).fromBwdInput(p.*);
                     const NB = d.N * d.batch;
-                    // Batched: col_buf[K, NB] + rearranged grad[c_out, NB]
                     p.scratch = try alloc.alloc(T, (d.K + d.c_out) * NB);
                 },
                 .conv2d_bwd_kernel => |*p| {
                     const d = Conv2dDims(T).fromBwdKernel(p.*);
                     const NB = d.N * d.batch;
-                    // Batched: col_buf[K, NB] + rearranged grad[c_out, NB]
                     p.scratch = try alloc.alloc(T, (d.K + d.c_out) * NB);
                 },
                 else => {},
@@ -959,7 +957,7 @@ fn im2col(comptime T: type, d: Conv2dDims(T), col_buf: []T, n: usize, col_stride
                     const row = (kx + ky * d.kw + ic * d.kw * d.kh) * col_stride + col_offset;
                     for (0..d.out_h) |oy| {
                         const src = kx + (oy + ky) * d.in_w + ic * d.input_strides[2] + n * d.input_strides[3];
-                        @memcpy(col_buf[row + oy * d.out_w ..][0..d.out_w], d.input_data[src..][0..d.out_w]);
+                        forward.simdCopy(T, col_buf[row + oy * d.out_w ..][0..d.out_w], d.input_data[src..][0..d.out_w]);
                     }
                 }
             }
@@ -999,9 +997,7 @@ fn col2im(comptime T: type, d: Conv2dDims(T), dst_data: []T, dst_strides: [@impo
                     for (0..d.out_h) |oy| {
                         const dst_base = kx + (oy + ky) * d.in_w + ic * dst_strides[2] + n * dst_strides[3];
                         const src_base = row + oy * d.out_w;
-                        for (0..d.out_w) |ox| {
-                            dst_data[dst_base + ox] += col_buf[src_base + ox];
-                        }
+                        forward.simdAccumulate(T, dst_data[dst_base..][0..d.out_w], col_buf[src_base..][0..d.out_w]);
                     }
                 }
             }
@@ -1091,7 +1087,7 @@ fn executeConv2dPlan(comptime T: type, plan: Conv2dPlan(T), phase_profile: ?*Con
             if (has_bias or has_relu) {
                 rearrangeSimd(T, dst, src, b, has_relu);
             } else {
-                @memcpy(dst, src);
+                forward.simdCopy(T, dst, src);
             }
         }
     }
@@ -1132,15 +1128,13 @@ fn executeConv2dBwdInputPlan(comptime T: type, plan: Conv2dBwdInputPlan(T), phas
     const col_buf = scratch[0 .. d.K * NB];
     const grad_buf = scratch[d.K * NB ..][0 .. d.c_out * NB];
     var timer = std.time.Timer.start() catch @panic("timer");
+    @memset(plan.output.data, 0);
 
     // 1. Rearrange output_grad from [N, c_out, batch] to [c_out, N*batch]
     timer.reset();
     for (0..d.c_out) |oc| {
         for (0..d.batch) |n| {
-            @memcpy(
-                grad_buf[oc * NB + n * d.N ..][0..d.N],
-                plan.output_grad.data[n * d.N * d.c_out + oc * d.N ..][0..d.N],
-            );
+            forward.simdCopy(T, grad_buf[oc * NB + n * d.N ..][0..d.N], plan.output_grad.data[n * d.N * d.c_out + oc * d.N ..][0..d.N]);
         }
     }
     addConvPhase(phase_profile, "bwd_input_rearrange_ns", timer.read());
@@ -1153,7 +1147,6 @@ fn executeConv2dBwdInputPlan(comptime T: type, plan: Conv2dBwdInputPlan(T), phas
 
     // 3. col2im per batch from batched col_buf
     timer.reset();
-    @memset(plan.output.data, 0);
     for (0..d.batch) |n| {
         col2im(T, d, plan.output.data, plan.output.strides, col_buf, n, NB, n * d.N);
     }
@@ -1186,10 +1179,7 @@ fn executeConv2dBwdKernelPlan(comptime T: type, plan: Conv2dBwdKernelPlan(T), ph
     timer.reset();
     for (0..d.c_out) |oc| {
         for (0..d.batch) |n| {
-            @memcpy(
-                grad_buf[oc * NB + n * d.N ..][0..d.N],
-                plan.output_grad.data[n * d.N * d.c_out + oc * d.N ..][0..d.N],
-            );
+            forward.simdCopy(T, grad_buf[oc * NB + n * d.N ..][0..d.N], plan.output_grad.data[n * d.N * d.c_out + oc * d.N ..][0..d.N]);
         }
     }
     addConvPhase(phase_profile, "bwd_kernel_rearrange_ns", timer.read());


### PR DESCRIPTION
## Summary
- fix fused conv and broadcast-unary correctness issues by making `relu` primitive, preserving the right fused backward dependencies, and skipping decomposed maxpool backward chains under fusion
- fix graph thread-pool lifetime and add reusable conv phase profiling plus scalable conv benchmarks to measure fused conv forward/backward staging costs
- add reusable SIMD staging helpers and backend-aware fused conv workspace tiling to reduce staging overhead on backend/BLAS paths without regressing the fallback CPU path

## Validation
- `zig build test --summary all`
- `zig build grad-check`
- `zig build mnist-micro`
- `zig build conv-phase-bench`
- `zig build -Duse-blas=false conv-phase-bench`