### PR TITLE
Cleanup: addExe helper, dedup MNIST loader, remove dead API

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -102,6 +102,60 @@ pub fn package(
     };
 }
 
+// ---------------------------------------------------------------
+// Executable helper — eliminates per-target boilerplate
+// ---------------------------------------------------------------
+
+const ExeConfig = struct {
+    name: []const u8,
+    src: []const u8,
+    step_name: []const u8,
+    step_desc: []const u8,
+    /// null = use the user's optimize option (for debug/test targets)
+    optimize: ?std.builtin.OptimizeMode = .ReleaseFast,
+    /// install-only targets don't get a run step
+    install_only: bool = false,
+    /// extra linkMetal call (bench-metal, generate-llama, etc.)
+    extra_metal: bool = false,
+    /// skip BLAS linking (bench-reduce)
+    skip_blas: bool = false,
+};
+
+fn addExe(
+    b: *std.Build,
+    target: std.Build.ResolvedTarget,
+    optimize: std.builtin.OptimizeMode,
+    use_blas: bool,
+    cfg: ExeConfig,
+) *std.Build.Step.Compile {
+    const opt = cfg.optimize orelse optimize;
+    const pkg = package(b, target, opt, .{ .options = .{ .use_blas = use_blas } });
+    const mod = b.createModule(.{
+        .root_source_file = b.path(cfg.src),
+        .target = target,
+        .optimize = opt,
+        .imports = &.{
+            .{ .name = "zgml", .module = pkg.zgml },
+            .{ .name = "zgml_options", .module = pkg.zgml_options },
+        },
+    });
+    const exe = b.addExecutable(.{ .name = cfg.name, .root_module = mod });
+    if (use_blas and !cfg.skip_blas) {
+        linkBlas(target, exe);
+        exe.root_module.addSystemIncludePath(.{ .cwd_relative = "/usr/include/openblas" });
+    }
+    if (cfg.extra_metal) linkMetal(b, target, exe);
+    b.installArtifact(exe);
+
+    const step = b.step(cfg.step_name, cfg.step_desc);
+    if (cfg.install_only) {
+        step.dependOn(&b.addInstallArtifact(exe, .{}).step);
+    } else {
+        step.dependOn(&b.addRunArtifact(exe).step);
+    }
+    return exe;
+}
+
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
@@ -114,372 +168,122 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(runTests(b, optimize, target, .{ .use_blas = use_blas }));
     test_step.dependOn(runInferenceTests(b, optimize, target, .{ .use_blas = use_blas }));
 
-    // Benchmark — always built with ReleaseFast
-    const zgml_bench_pkg = package(b, target, .ReleaseFast, .{ .options = .{ .use_blas = use_blas } });
-    const bench_mod = b.createModule(.{
-        .root_source_file = b.path("src/bench.zig"),
-        .target = target,
-        .optimize = .ReleaseFast,
-        .imports = &.{
-            .{ .name = "zgml", .module = zgml_bench_pkg.zgml },
-            .{ .name = "zgml_options", .module = zgml_bench_pkg.zgml_options },
-        },
-    });
-    const bench_exe = b.addExecutable(.{
-        .name = "zgml-bench",
-        .root_module = bench_mod,
-    });
-    if (use_blas) {
-        linkBlas(target, bench_exe);
-        bench_exe.root_module.addSystemIncludePath(.{ .cwd_relative = "/usr/include/openblas" });
-    }
-    b.installArtifact(bench_exe);
+    // -- Benchmarks --
 
+    const bench_exe = addExe(b, target, optimize, use_blas, .{
+        .name = "zgml-bench",
+        .src = "src/bench.zig",
+        .step_name = "bench",
+        .step_desc = "Build and run zgml benchmarks",
+    });
     const bench_build_step = b.step("bench-build", "Build zgml benchmarks");
     bench_build_step.dependOn(&bench_exe.step);
 
-    const bench_step = b.step("bench", "Build and run zgml benchmarks");
-    bench_step.dependOn(&b.addRunArtifact(bench_exe).step);
-
-    // MNIST benchmark — always built with ReleaseFast
-    const zgml_mnist_pkg = package(b, target, .ReleaseFast, .{ .options = .{ .use_blas = use_blas } });
-    const mnist_mod = b.createModule(.{
-        .root_source_file = b.path("src/mnist_bench.zig"),
-        .target = target,
-        .optimize = .ReleaseFast,
-        .imports = &.{
-            .{ .name = "zgml", .module = zgml_mnist_pkg.zgml },
-            .{ .name = "zgml_options", .module = zgml_mnist_pkg.zgml_options },
-        },
-    });
-    const mnist_exe = b.addExecutable(.{
+    _ = addExe(b, target, optimize, use_blas, .{
         .name = "mnist-bench",
-        .root_module = mnist_mod,
+        .src = "src/mnist_bench.zig",
+        .step_name = "mnist-bench",
+        .step_desc = "Build and run MNIST CNN training benchmark",
     });
-    if (use_blas) {
-        linkBlas(target, mnist_exe);
-        mnist_exe.root_module.addSystemIncludePath(.{ .cwd_relative = "/usr/include/openblas" });
-    }
-    b.installArtifact(mnist_exe);
-
-    const mnist_step = b.step("mnist-bench", "Build and run MNIST CNN training benchmark");
-    mnist_step.dependOn(&b.addRunArtifact(mnist_exe).step);
-
-    // MNIST micro-benchmark — isolates the training hotloop
-    const zgml_micro_pkg = package(b, target, .ReleaseFast, .{ .options = .{ .use_blas = use_blas } });
-    const micro_mod = b.createModule(.{
-        .root_source_file = b.path("src/mnist_micro.zig"),
-        .target = target,
-        .optimize = .ReleaseFast,
-        .imports = &.{
-            .{ .name = "zgml", .module = zgml_micro_pkg.zgml },
-            .{ .name = "zgml_options", .module = zgml_micro_pkg.zgml_options },
-        },
-    });
-    const micro_exe = b.addExecutable(.{
+    _ = addExe(b, target, optimize, use_blas, .{
         .name = "mnist-micro",
-        .root_module = micro_mod,
+        .src = "src/mnist_micro.zig",
+        .step_name = "mnist-micro",
+        .step_desc = "Build and run MNIST CNN training micro-benchmark",
     });
-    if (use_blas) {
-        linkBlas(target, micro_exe);
-        micro_exe.root_module.addSystemIncludePath(.{ .cwd_relative = "/usr/include/openblas" });
-    }
-    b.installArtifact(micro_exe);
-
-    const micro_step = b.step("mnist-micro", "Build and run MNIST CNN training micro-benchmark");
-    micro_step.dependOn(&b.addRunArtifact(micro_exe).step);
-
-    const zgml_conv_phase_pkg = package(b, target, .ReleaseFast, .{ .options = .{ .use_blas = use_blas } });
-    const conv_phase_mod = b.createModule(.{
-        .root_source_file = b.path("src/conv_phase_bench.zig"),
-        .target = target,
-        .optimize = .ReleaseFast,
-        .imports = &.{
-            .{ .name = "zgml", .module = zgml_conv_phase_pkg.zgml },
-            .{ .name = "zgml_options", .module = zgml_conv_phase_pkg.zgml_options },
-        },
-    });
-    const conv_phase_exe = b.addExecutable(.{
+    _ = addExe(b, target, optimize, use_blas, .{
         .name = "conv-phase-bench",
-        .root_module = conv_phase_mod,
+        .src = "src/conv_phase_bench.zig",
+        .step_name = "conv-phase-bench",
+        .step_desc = "Run parameterized conv phase benchmark",
     });
-    if (use_blas) {
-        linkBlas(target, conv_phase_exe);
-        conv_phase_exe.root_module.addSystemIncludePath(.{ .cwd_relative = "/usr/include/openblas" });
-    }
-    b.installArtifact(conv_phase_exe);
-    const conv_phase_step = b.step("conv-phase-bench", "Run parameterized conv phase benchmark");
-    conv_phase_step.dependOn(&b.addRunArtifact(conv_phase_exe).step);
-
-    // Gradient check — compare zgml vs PyTorch reference
-    const zgml_gc_pkg = package(b, target, optimize, .{ .options = .{ .use_blas = use_blas } });
-    const gc_mod = b.createModule(.{
-        .root_source_file = b.path("benchmarks/grad_check.zig"),
-        .target = target,
-        .optimize = optimize,
-        .imports = &.{
-            .{ .name = "zgml", .module = zgml_gc_pkg.zgml },
-            .{ .name = "zgml_options", .module = zgml_gc_pkg.zgml_options },
-        },
-    });
-    const gc_exe = b.addExecutable(.{
-        .name = "grad-check",
-        .root_module = gc_mod,
-    });
-    if (use_blas) {
-        linkBlas(target, gc_exe);
-        gc_exe.root_module.addSystemIncludePath(.{ .cwd_relative = "/usr/include/openblas" });
-    }
-    b.installArtifact(gc_exe);
-    const gc_step = b.step("grad-check", "Compare gradients with PyTorch reference");
-    gc_step.dependOn(&b.addRunArtifact(gc_exe).step);
-
-    // Per-op backward profiler
-    const zgml_prof_pkg = package(b, target, .ReleaseFast, .{ .options = .{ .use_blas = use_blas } });
-    const prof_mod = b.createModule(.{
-        .root_source_file = b.path("src/profile_backward.zig"),
-        .target = target,
-        .optimize = .ReleaseFast,
-        .imports = &.{
-            .{ .name = "zgml", .module = zgml_prof_pkg.zgml },
-            .{ .name = "zgml_options", .module = zgml_prof_pkg.zgml_options },
-        },
-    });
-    const prof_exe = b.addExecutable(.{
-        .name = "profile-bwd",
-        .root_module = prof_mod,
-    });
-    if (use_blas) {
-        linkBlas(target, prof_exe);
-        prof_exe.root_module.addSystemIncludePath(.{ .cwd_relative = "/usr/include/openblas" });
-    }
-    b.installArtifact(prof_exe);
-    const prof_step = b.step("profile-bwd", "Profile backward pass per-op timing");
-    prof_step.dependOn(&b.addRunArtifact(prof_exe).step);
-
-    // Reduction microbenchmark
-    const zgml_rbench_pkg = package(b, target, .ReleaseFast, .{ .options = .{ .use_blas = use_blas } });
-    const rbench_mod = b.createModule(.{
-        .root_source_file = b.path("src/bench_reduce.zig"),
-        .target = target,
-        .optimize = .ReleaseFast,
-        .imports = &.{
-            .{ .name = "zgml", .module = zgml_rbench_pkg.zgml },
-            .{ .name = "zgml_options", .module = zgml_rbench_pkg.zgml_options },
-        },
-    });
-    const rbench_exe = b.addExecutable(.{
-        .name = "bench-reduce",
-        .root_module = rbench_mod,
-    });
-    b.installArtifact(rbench_exe);
-    const rbench_step = b.step("bench-reduce", "Benchmark reduction and broadcast ops");
-    rbench_step.dependOn(&b.addRunArtifact(rbench_exe).step);
-
-    // Inference benchmark
-    {
-        const pkg = package(b, target, .ReleaseFast, .{ .options = .{ .use_blas = use_blas } });
-        const mod = b.createModule(.{
-            .root_source_file = b.path("bench/inference.zig"),
-            .target = target,
-            .optimize = .ReleaseFast,
-            .imports = &.{
-                .{ .name = "zgml", .module = pkg.zgml },
-                .{ .name = "zgml_options", .module = pkg.zgml_options },
-            },
-        });
-        const exe = b.addExecutable(.{ .name = "bench-inference", .root_module = mod });
-        if (use_blas) {
-            linkBlas(target, exe);
-            exe.root_module.addSystemIncludePath(.{ .cwd_relative = "/usr/include/openblas" });
-        }
-        b.installArtifact(exe);
-        const step = b.step("bench-inference", "Benchmark inference session (f32 vs int8)");
-        step.dependOn(&b.addRunArtifact(exe).step);
-    }
-
-    // Per-op microbenchmark
-    const zgml_opbench_pkg = package(b, target, .ReleaseFast, .{ .options = .{ .use_blas = use_blas } });
-    const opbench_mod = b.createModule(.{
-        .root_source_file = b.path("benchmarks/op_bench.zig"),
-        .target = target,
-        .optimize = .ReleaseFast,
-        .imports = &.{
-            .{ .name = "zgml", .module = zgml_opbench_pkg.zgml },
-            .{ .name = "zgml_options", .module = zgml_opbench_pkg.zgml_options },
-        },
-    });
-    const opbench_exe = b.addExecutable(.{
+    _ = addExe(b, target, optimize, use_blas, .{
         .name = "op-bench",
-        .root_module = opbench_mod,
+        .src = "benchmarks/op_bench.zig",
+        .step_name = "op-bench",
+        .step_desc = "Per-op microbenchmark for MNIST CNN ops",
     });
-    if (use_blas) {
-        linkBlas(target, opbench_exe);
-        opbench_exe.root_module.addSystemIncludePath(.{ .cwd_relative = "/usr/include/openblas" });
-    }
-    b.installArtifact(opbench_exe);
-    const opbench_step = b.step("op-bench", "Per-op microbenchmark for MNIST CNN ops");
-    opbench_step.dependOn(&b.addRunArtifact(opbench_exe).step);
-
-    // Metal backend benchmark
-    {
-        const pkg = package(b, target, .ReleaseFast, .{ .options = .{ .use_blas = use_blas } });
-        const mod = b.createModule(.{
-            .root_source_file = b.path("benchmarks/metal_bench.zig"),
-            .target = target,
-            .optimize = .ReleaseFast,
-            .imports = &.{
-                .{ .name = "zgml", .module = pkg.zgml },
-                .{ .name = "zgml_options", .module = pkg.zgml_options },
-            },
-        });
-        const exe = b.addExecutable(.{ .name = "bench-metal", .root_module = mod });
-        if (use_blas) {
-            linkBlas(target, exe);
-            exe.root_module.addSystemIncludePath(.{ .cwd_relative = "/usr/include/openblas" });
-        }
-        linkMetal(b, target, exe);
-        b.installArtifact(exe);
-        const step = b.step("bench-metal", "Benchmark Metal GPU vs CPU BLAS matmul");
-        step.dependOn(&b.addRunArtifact(exe).step);
-    }
-
-    // Metal inference benchmark
-    {
-        const pkg = package(b, target, .ReleaseFast, .{ .options = .{ .use_blas = use_blas } });
-        const mod = b.createModule(.{
-            .root_source_file = b.path("benchmarks/metal_inference_bench.zig"),
-            .target = target,
-            .optimize = .ReleaseFast,
-            .imports = &.{
-                .{ .name = "zgml", .module = pkg.zgml },
-                .{ .name = "zgml_options", .module = pkg.zgml_options },
-            },
-        });
-        const exe = b.addExecutable(.{ .name = "bench-metal-inference", .root_module = mod });
-        if (use_blas) {
-            linkBlas(target, exe);
-            exe.root_module.addSystemIncludePath(.{ .cwd_relative = "/usr/include/openblas" });
-        }
-        linkMetal(b, target, exe);
-        b.installArtifact(exe);
-        const step = b.step("bench-metal-inference", "Benchmark CPU vs Metal inference tok/s");
-        step.dependOn(&b.addRunArtifact(exe).step);
-    }
-
-    // SmolLM LLaMA benchmark
-    {
-        const pkg = package(b, target, .ReleaseFast, .{ .options = .{ .use_blas = use_blas } });
-        const mod = b.createModule(.{
-            .root_source_file = b.path("benchmarks/llama_smollm_bench.zig"),
-            .target = target,
-            .optimize = .ReleaseFast,
-            .imports = &.{
-                .{ .name = "zgml", .module = pkg.zgml },
-                .{ .name = "zgml_options", .module = pkg.zgml_options },
-            },
-        });
-        const exe = b.addExecutable(.{ .name = "bench-llama-smollm", .root_module = mod });
-        if (use_blas) {
-            linkBlas(target, exe);
-            exe.root_module.addSystemIncludePath(.{ .cwd_relative = "/usr/include/openblas" });
-        }
-        b.installArtifact(exe);
-        const step = b.step("bench-llama-smollm", "Benchmark SmolLM LLaMA inference throughput");
-        step.dependOn(&b.addRunArtifact(exe).step);
-    }
-
-    // Text generation binary
-    const zgml_gen_pkg = package(b, target, .ReleaseFast, .{ .options = .{ .use_blas = use_blas } });
-    const gen_mod = b.createModule(.{
-        .root_source_file = b.path("scripts/generate.zig"),
-        .target = target,
-        .optimize = .ReleaseFast,
-        .imports = &.{
-            .{ .name = "zgml", .module = zgml_gen_pkg.zgml },
-            .{ .name = "zgml_options", .module = zgml_gen_pkg.zgml_options },
-        },
+    _ = addExe(b, target, optimize, use_blas, .{
+        .name = "bench-reduce",
+        .src = "src/bench_reduce.zig",
+        .step_name = "bench-reduce",
+        .step_desc = "Benchmark reduction and broadcast ops",
+        .skip_blas = true,
     });
-    const gen_exe = b.addExecutable(.{
+    _ = addExe(b, target, optimize, use_blas, .{
+        .name = "bench-inference",
+        .src = "bench/inference.zig",
+        .step_name = "bench-inference",
+        .step_desc = "Benchmark inference session (f32 vs int8)",
+    });
+    _ = addExe(b, target, optimize, use_blas, .{
+        .name = "bench-metal",
+        .src = "benchmarks/metal_bench.zig",
+        .step_name = "bench-metal",
+        .step_desc = "Benchmark Metal GPU vs CPU BLAS matmul",
+        .extra_metal = true,
+    });
+    _ = addExe(b, target, optimize, use_blas, .{
+        .name = "bench-metal-inference",
+        .src = "benchmarks/metal_inference_bench.zig",
+        .step_name = "bench-metal-inference",
+        .step_desc = "Benchmark CPU vs Metal inference tok/s",
+        .extra_metal = true,
+    });
+    _ = addExe(b, target, optimize, use_blas, .{
+        .name = "bench-llama-smollm",
+        .src = "benchmarks/llama_smollm_bench.zig",
+        .step_name = "bench-llama-smollm",
+        .step_desc = "Benchmark SmolLM LLaMA inference throughput",
+    });
+
+    // -- Profiling & grad check --
+
+    _ = addExe(b, target, optimize, use_blas, .{
+        .name = "profile-bwd",
+        .src = "src/profile_backward.zig",
+        .step_name = "profile-bwd",
+        .step_desc = "Profile backward pass per-op timing",
+    });
+    _ = addExe(b, target, optimize, use_blas, .{
+        .name = "grad-check",
+        .src = "benchmarks/grad_check.zig",
+        .step_name = "grad-check",
+        .step_desc = "Compare gradients with PyTorch reference",
+        .optimize = null, // use user's optimize setting
+    });
+
+    // -- Scripts --
+
+    _ = addExe(b, target, optimize, use_blas, .{
         .name = "generate",
-        .root_module = gen_mod,
+        .src = "scripts/generate.zig",
+        .step_name = "generate",
+        .step_desc = "Build text generation binary",
+        .install_only = true,
     });
-    if (use_blas) {
-        linkBlas(target, gen_exe);
-        gen_exe.root_module.addSystemIncludePath(.{ .cwd_relative = "/usr/include/openblas" });
-    }
-    b.installArtifact(gen_exe);
-    const gen_step = b.step("generate", "Build text generation binary");
-    gen_step.dependOn(&b.addInstallArtifact(gen_exe, .{}).step);
-
-    // Training script
-    const zgml_train_pkg = package(b, target, .ReleaseFast, .{ .options = .{ .use_blas = use_blas } });
-    const train_mod = b.createModule(.{
-        .root_source_file = b.path("scripts/train_tiny.zig"),
-        .target = target,
-        .optimize = .ReleaseFast,
-        .imports = &.{
-            .{ .name = "zgml", .module = zgml_train_pkg.zgml },
-            .{ .name = "zgml_options", .module = zgml_train_pkg.zgml_options },
-        },
-    });
-    const train_exe = b.addExecutable(.{
+    _ = addExe(b, target, optimize, use_blas, .{
         .name = "train-tiny",
-        .root_module = train_mod,
+        .src = "scripts/train_tiny.zig",
+        .step_name = "train-tiny",
+        .step_desc = "Train a tiny GPT and save checkpoint",
+        .install_only = true,
     });
-    if (use_blas) {
-        linkBlas(target, train_exe);
-        train_exe.root_module.addSystemIncludePath(.{ .cwd_relative = "/usr/include/openblas" });
-    }
-    const train_step = b.step("train-tiny", "Train a tiny GPT and save checkpoint");
-    train_step.dependOn(&b.addInstallArtifact(train_exe, .{}).step);
-
-    // Pretrained model generation
-    const zgml_pt_pkg = package(b, target, .ReleaseFast, .{ .options = .{ .use_blas = use_blas } });
-    const pt_mod = b.createModule(.{
-        .root_source_file = b.path("scripts/generate_pretrained.zig"),
-        .target = target,
-        .optimize = .ReleaseFast,
-        .imports = &.{
-            .{ .name = "zgml", .module = zgml_pt_pkg.zgml },
-            .{ .name = "zgml_options", .module = zgml_pt_pkg.zgml_options },
-        },
-    });
-    const pt_exe = b.addExecutable(.{
+    _ = addExe(b, target, optimize, use_blas, .{
         .name = "generate-pretrained",
-        .root_module = pt_mod,
+        .src = "scripts/generate_pretrained.zig",
+        .step_name = "generate-pretrained",
+        .step_desc = "Generate text from a pretrained HF model",
+        .install_only = true,
     });
-    if (use_blas) {
-        linkBlas(target, pt_exe);
-        pt_exe.root_module.addSystemIncludePath(.{ .cwd_relative = "/usr/include/openblas" });
-    }
-    b.installArtifact(pt_exe);
-    const pt_step = b.step("generate-pretrained", "Generate text from a pretrained HF model");
-    pt_step.dependOn(&b.addInstallArtifact(pt_exe, .{}).step);
-
-    // LLaMA model generation
-    const zgml_llama_pkg = package(b, target, .ReleaseFast, .{ .options = .{ .use_blas = use_blas } });
-    const llama_mod = b.createModule(.{
-        .root_source_file = b.path("scripts/generate_llama.zig"),
-        .target = target,
-        .optimize = .ReleaseFast,
-        .imports = &.{
-            .{ .name = "zgml", .module = zgml_llama_pkg.zgml },
-            .{ .name = "zgml_options", .module = zgml_llama_pkg.zgml_options },
-        },
-    });
-    const llama_exe = b.addExecutable(.{
+    _ = addExe(b, target, optimize, use_blas, .{
         .name = "generate-llama",
-        .root_module = llama_mod,
+        .src = "scripts/generate_llama.zig",
+        .step_name = "generate-llama",
+        .step_desc = "Generate text from a pretrained LLaMA model",
+        .install_only = true,
+        .extra_metal = true,
     });
-    if (use_blas) {
-        linkBlas(target, llama_exe);
-        llama_exe.root_module.addSystemIncludePath(.{ .cwd_relative = "/usr/include/openblas" });
-    }
-    linkMetal(b, target, llama_exe);
-    b.installArtifact(llama_exe);
-    const llama_step = b.step("generate-llama", "Generate text from a pretrained LLaMA model");
-    llama_step.dependOn(&b.addInstallArtifact(llama_exe, .{}).step);
 }
 
 pub fn runTests(

--- a/src/mnist_bench.zig
+++ b/src/mnist_bench.zig
@@ -10,88 +10,7 @@ const IndexTensor = zgml.IndexTensor;
 const loss_mod = zgml.loss;
 const nn = zgml.nn;
 const ConvClassifier = zgml.models.ConvClassifier;
-
-const Alloc = std.mem.Allocator;
-
-fn readFileAlloc(alloc: Alloc, path: []const u8, io: std.Io, max_bytes: usize) ![]u8 {
-    const file = try std.Io.Dir.cwd().openFile(io, path, .{});
-    defer file.close(io);
-    const stat = try file.stat(io);
-    if (stat.size > max_bytes) return error.FileTooBig;
-    const size: usize = @intCast(stat.size);
-    const buf = try alloc.alloc(u8, size);
-    errdefer alloc.free(buf);
-    const bytes_read = try file.readPositionalAll(io, buf, 0);
-    if (bytes_read != size) return error.UnexpectedEof;
-    return buf;
-}
-
-// ---------------------------------------------------------------------------
-// MNIST IDX file loading
-// ---------------------------------------------------------------------------
-
-fn readU32Big(buf: []const u8) u32 {
-    return std.mem.readInt(u32, buf[0..4], .big);
-}
-
-const MnistImages = struct {
-    data: []f32,
-    n: usize,
-    rows: usize,
-    cols: usize,
-
-    fn load(alloc: Alloc, path: []const u8, io: std.Io) !MnistImages {
-        const raw = try readFileAlloc(alloc, path, io, 128 * 1024 * 1024);
-        defer alloc.free(raw);
-
-        const magic = readU32Big(raw[0..]);
-        if (magic != 2051) return error.BadMagic;
-        const n = readU32Big(raw[4..]);
-        const rows = readU32Big(raw[8..]);
-        const cols = readU32Big(raw[12..]);
-        const pixels = raw[16..];
-
-        const total = n * rows * cols;
-        const data = try alloc.alloc(f32, total);
-        for (0..total) |i| {
-            data[i] = @as(f32, @floatFromInt(pixels[i])) / 255.0;
-        }
-        return .{ .data = data, .n = n, .rows = rows, .cols = cols };
-    }
-
-    fn deinit(self: *MnistImages, alloc: Alloc) void {
-        alloc.free(self.data);
-    }
-};
-
-const MnistLabels = struct {
-    data: []f32,
-    n: usize,
-
-    fn load(alloc: Alloc, path: []const u8, io: std.Io) !MnistLabels {
-        const raw = try readFileAlloc(alloc, path, io, 16 * 1024 * 1024);
-        defer alloc.free(raw);
-
-        const magic = readU32Big(raw[0..]);
-        if (magic != 2049) return error.BadMagic;
-        const n = readU32Big(raw[4..]);
-        const labels = raw[8..];
-
-        const data = try alloc.alloc(f32, n);
-        for (0..n) |i| {
-            data[i] = @floatFromInt(labels[i]);
-        }
-        return .{ .data = data, .n = n };
-    }
-
-    fn deinit(self: *MnistLabels, alloc: Alloc) void {
-        alloc.free(self.data);
-    }
-};
-
-// ---------------------------------------------------------------------------
-// Main
-// ---------------------------------------------------------------------------
+const MnistDataset = zgml.data.mnist.MnistDataset;
 
 pub fn main(init: std.process.Init) !void {
     const io = init.io;
@@ -108,22 +27,18 @@ pub fn main(init: std.process.Init) !void {
     try w.interface.print("Loading MNIST data...\n", .{});
     w.interface.flush() catch {};
 
-    var train_images = try MnistImages.load(alloc, "data/train-images-idx3-ubyte", io);
-    defer train_images.deinit(alloc);
-    var train_labels = try MnistLabels.load(alloc, "data/train-labels-idx1-ubyte", io);
-    defer train_labels.deinit(alloc);
-    var test_images = try MnistImages.load(alloc, "data/t10k-images-idx3-ubyte", io);
-    defer test_images.deinit(alloc);
-    var test_labels = try MnistLabels.load(alloc, "data/t10k-labels-idx1-ubyte", io);
-    defer test_labels.deinit(alloc);
+    var train = try MnistDataset.load(alloc, "data/train-images-idx3-ubyte", "data/train-labels-idx1-ubyte", io);
+    defer train.deinit(alloc);
+    var test_data = try MnistDataset.load(alloc, "data/t10k-images-idx3-ubyte", "data/t10k-labels-idx1-ubyte", io);
+    defer test_data.deinit(alloc);
 
-    try w.interface.print("  Train: {} images, Test: {} images\n", .{ train_images.n, test_images.n });
-    try w.interface.print("  Image size: {}x{}\n\n", .{ train_images.cols, train_images.rows });
+    try w.interface.print("  Train: {} images, Test: {} images\n", .{ train.n_samples, test_data.n_samples });
+    try w.interface.print("  Image size: {}x{}\n\n", .{ train.cols, train.rows });
 
     const batch_size: usize = 32;
     const n_epochs: usize = 10;
-    const train_batches = train_images.n / batch_size;
-    const pixels_per_image = train_images.rows * train_images.cols;
+    const train_batches = train.n_samples / batch_size;
+    const pixels_per_image = train.pixelsPerImage();
 
     try w.interface.print("Architecture: Conv(5x5, 1->8) -> ReLU -> MaxPool(2x2) -> FC(1152->10)\n", .{});
     try w.interface.print("Optimizer: Adam (lr=1e-3)\n", .{});
@@ -163,9 +78,9 @@ pub fn main(init: std.process.Init) !void {
 
             // Copy batch data
             const img_off = batch_idx * batch_size * pixels_per_image;
-            @memcpy(model.xs_batch.data, train_images.data[img_off..][0 .. batch_size * pixels_per_image]);
+            @memcpy(model.xs_batch.data, train.images[img_off..][0 .. batch_size * pixels_per_image]);
             const lbl_off = batch_idx * batch_size;
-            @memcpy(model.ys_batch.data, train_labels.data[lbl_off..][0..batch_size]);
+            @memcpy(model.ys_batch.data, train.labels[lbl_off..][0..batch_size]);
 
             model.g.reset();
             model.g.resetGrads();
@@ -179,7 +94,7 @@ pub fn main(init: std.process.Init) !void {
             // Track accuracy
             model.predict(&preds);
             for (0..batch_size) |i| {
-                if (preds[i] == @as(usize, @intFromFloat(train_labels.data[lbl_off + i]))) {
+                if (preds[i] == @as(usize, @intFromFloat(train.labels[lbl_off + i]))) {
                     epoch_correct += 1;
                 }
             }
@@ -213,20 +128,20 @@ pub fn main(init: std.process.Init) !void {
     try w.interface.print("\nEvaluating on test set...\n", .{});
     w.interface.flush() catch {};
 
-    const test_batches = test_images.n / batch_size;
+    const test_batches = test_data.n_samples / batch_size;
     var test_correct: usize = 0;
     var preds_test: [32]usize = undefined;
 
     for (0..test_batches) |batch_idx| {
         const img_off = batch_idx * batch_size * pixels_per_image;
-        @memcpy(model.xs_batch.data, test_images.data[img_off..][0 .. batch_size * pixels_per_image]);
+        @memcpy(model.xs_batch.data, test_data.images[img_off..][0 .. batch_size * pixels_per_image]);
 
         model.g.reset();
         model.g.compute();
 
         model.predict(&preds_test);
         for (0..batch_size) |i| {
-            if (preds_test[i] == @as(usize, @intFromFloat(test_labels.data[batch_idx * batch_size + i]))) {
+            if (preds_test[i] == @as(usize, @intFromFloat(test_data.labels[batch_idx * batch_size + i]))) {
                 test_correct += 1;
             }
         }

--- a/src/tensor.zig
+++ b/src/tensor.zig
@@ -428,14 +428,9 @@ pub fn Tensor(comptime T: type) type {
         pub const rmsNorm = api.rmsNorm;
         pub const attention = api.attention;
         pub const layerNorm = api.layerNorm;
-        pub const meanInto = api.meanInto;
         pub const repeat = api.repeat;
         pub const repeatLike = api.repeatLike;
         pub const matMul = api.matMul;
-        pub const mm = api.mm;
-        pub const Tmm = api.Tmm;
-        pub const mmT = api.mmT;
-        pub const TmmT = api.TmmT;
         pub const gatherRows = api.gatherRows;
         pub const scatterAddRows = api.scatterAddRows; // Internal: used by backward pass only
         pub const pickRows = api.pickRows;
@@ -443,7 +438,6 @@ pub fn Tensor(comptime T: type) type {
         pub const gatherRowsIdx = api.gatherRowsIdx;
         pub const pickRowsIdx = api.pickRowsIdx;
         pub const addBias = api.addBias;
-        pub const scale = api.scale;
         pub const scaleByVal = api.scaleByVal;
         pub const conv2d = api.conv2d;
         pub const maxPool2d = api.maxPool2d;
@@ -460,7 +454,6 @@ pub fn Tensor(comptime T: type) type {
         pub const ropeRotate = api.ropeRotate;
         pub const sliceColumns = api.sliceColumns;
         pub const sliceRows = api.sliceRows;
-        pub const slidingWindow2d = api.slidingWindow2d;
 
         // ---------------------------------------------------------------
         // Forward compute — delegated to tensor/forward.zig
@@ -832,26 +825,6 @@ test "unary ops handle zero-stride broadcast views" {
     defer step_neg.deinit();
     step_neg.compute();
     try testing.expectEqualSlices(f32, &.{ 0, 0, 0, 0 }, step_neg.data);
-}
-
-test "slidingWindow2d exposes overlapping patches" {
-    const t = try Tensor(f32).init(tac, &.{ 4, 4, 1, 1 });
-    defer t.deinit();
-    for (t.data, 0..) |*d, i| d.* = @floatFromInt(i);
-
-    const w = t.slidingWindow2d(2, 2);
-    defer w.deinit();
-
-    try testing.expectEqual(@as(u8, 6), w.n_dims);
-    try testing.expectEqual(@as(usize, 3), w.ne[0]);
-    try testing.expectEqual(@as(usize, 3), w.ne[1]);
-    try testing.expectEqual(@as(usize, 2), w.ne[2]);
-    try testing.expectEqual(@as(usize, 2), w.ne[3]);
-    try testing.expectEqual(@as(f32, 0), w.get(&.{ 0, 0, 0, 0, 0, 0 }));
-    try testing.expectEqual(@as(f32, 1), w.get(&.{ 0, 0, 1, 0, 0, 0 }));
-    try testing.expectEqual(@as(f32, 4), w.get(&.{ 0, 0, 0, 1, 0, 0 }));
-    try testing.expectEqual(@as(f32, 5), w.get(&.{ 0, 0, 1, 1, 0, 0 }));
-    try testing.expectEqual(@as(f32, 10), w.get(&.{ 1, 1, 1, 1, 0, 0 }));
 }
 
 test "compute conv2d composite view path" {

--- a/src/tensor/api.zig
+++ b/src/tensor/api.zig
@@ -231,18 +231,6 @@ pub fn Api(comptime Self: type, comptime T: type) type {
             return res;
         }
 
-        pub fn maxInto(self: *Self, other: *Self) *Self {
-            const alloc = a(self);
-            assert(self.canSumTo(other));
-            const is_node: bool = self.grad != null;
-            if (self.isSameShape(other) and !is_node) return self;
-            const res = other.view();
-            res.op = .max;
-            res.grad = if (is_node) Self.initHelper(alloc, &res.ne, null) catch unreachable else null;
-            res.src0 = self;
-            return res;
-        }
-
         /// Sum into another tensor's shape.
         pub fn sumInto(self: *Self, other: *Self) *Self {
             const alloc = a(self);
@@ -259,12 +247,6 @@ pub fn Api(comptime Self: type, comptime T: type) type {
         /// Mean (reduce). Decomposes to `sum * (1/count)`.
         pub fn mean(self: *Self, ne: []const usize) *Self {
             const s = aux(self.sum(ne));
-            const count: T = @floatFromInt(self.nElems() / s.nElems());
-            return s.mul(scalarRepeatLike(self, 1.0 / count, s));
-        }
-
-        pub fn meanInto(self: *Self, other: *Self) *Self {
-            const s = aux(self.sumInto(other));
             const count: T = @floatFromInt(self.nElems() / s.nElems());
             return s.mul(scalarRepeatLike(self, 1.0 / count, s));
         }
@@ -408,11 +390,6 @@ pub fn Api(comptime Self: type, comptime T: type) type {
             return self.add(aux(bias.repeatLike(self)));
         }
 
-        pub fn scale(self: *Self, other: *Self) *Self {
-            assert(other.isScalar());
-            return self.mul(aux(other.repeatLike(self)));
-        }
-
         /// Scale every element by a scalar value.
         pub fn scaleByVal(self: *Self, val: T) *Self {
             return self.mul(scalarRepeatLike(self, val, self));
@@ -445,23 +422,6 @@ pub fn Api(comptime Self: type, comptime T: type) type {
             res.src1 = other;
             res.assertValidMatMulDims(self, trans_self, other, trans_other);
             return res;
-        }
-
-        /// `self @ other` (no transpose).
-        pub fn mm(self: *Self, other: *Self) *Self {
-            return self.matMul(false, other, false);
-        }
-        /// `self^T @ other`.
-        pub fn Tmm(self: *Self, other: *Self) *Self {
-            return self.matMul(true, other, false);
-        }
-        /// `self @ other^T`.
-        pub fn mmT(self: *Self, other: *Self) *Self {
-            return self.matMul(false, other, true);
-        }
-        /// `self^T @ other^T`.
-        pub fn TmmT(self: *Self, other: *Self) *Self {
-            return self.matMul(true, other, true);
         }
 
         // ---------------------------------------------------------------
@@ -555,32 +515,6 @@ pub fn Api(comptime Self: type, comptime T: type) type {
             return structuralView(self, ne, out_strides, self.storage_offset + storage_offset, .as_strided);
         }
 
-        /// Backward pass for as_strided: accumulate gradients back into the
-        /// original tensor's shape by scatter-adding from the strided view.
-        pub fn asStridedBackward(self: *Self, src: *Self) *Self {
-            const alloc = a(self);
-            const res = Self.init(alloc, src.ne[0..src.n_dims]) catch unreachable;
-            _ = res.setAllScalar(0);
-            // Accumulate self's gradient into res using src's strides
-            const n = self.nElems();
-            for (0..n) |i| {
-                // Map flat index i through self's strides back to src's flat index
-                var remaining = i;
-                var src_idx: usize = src.storage_offset;
-                var dim: usize = self.n_dims;
-                while (dim > 0) {
-                    dim -= 1;
-                    const coord = remaining / self.strides[dim];
-                    remaining %= self.strides[dim];
-                    src_idx += coord * src.strides[dim];
-                }
-                if (src_idx < res.nElems()) {
-                    res.data[src_idx] += self.data[i];
-                }
-            }
-            return res;
-        }
-
         pub fn scatterAddView(self: *Self, view_tensor: *Self) *Self {
             const alloc = a(self);
             const base = view_tensor.source0().?;
@@ -589,19 +523,6 @@ pub fn Api(comptime Self: type, comptime T: type) type {
             res.src0 = self;
             res.src1 = view_tensor;
             return res;
-        }
-
-        pub fn slidingWindow2d(self: *Self, kw: usize, kh: usize) *Self {
-            assert(self.n_dims == 4);
-            assert(kw <= self.ne[0]);
-            assert(kh <= self.ne[1]);
-            const out_w = self.ne[0] - kw + 1;
-            const out_h = self.ne[1] - kh + 1;
-            return self.asStrided(
-                &.{ out_w, out_h, kw, kh, self.ne[2], self.ne[3] },
-                &.{ self.strides[0], self.strides[1], self.strides[0], self.strides[1], self.strides[2], self.strides[3] },
-                0,
-            );
         }
 
         // ---------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **build.zig**: Introduce `addExe()` helper that eliminates copy-pasted boilerplate across 16 executable targets (545 → 270 lines, -51%)
- **mnist_bench.zig**: Replace inline `MnistImages`/`MnistLabels` structs with shared `MnistDataset` from `src/data/mnist.zig`
- **tensor API**: Remove 9 dead methods with zero call sites — `mm`/`Tmm`/`mmT`/`TmmT` (aliases for `matMul`), `scale` (superseded by `scaleByVal`), `maxInto`/`meanInto`, `asStridedBackward` (superseded by `scatterAddView`), `slidingWindow2d` (unused, `conv2d` uses `asStrided` directly)

Net: **-387 lines** across 4 files. All tests pass.

## Test plan
- [x] `zig build test` — all unit tests pass
- [x] `zig build bench-build` — benchmark targets compile
- [x] Verified each removed method has zero call sites via grep

🤖 Generated with [Claude Code](https://claude.com/claude-code)