### PR TITLE
Advance Metal command stream fusion

### DIFF
--- a/benchmarks/llama_smollm_bench.zig
+++ b/benchmarks/llama_smollm_bench.zig
@@ -414,6 +414,7 @@ fn runDevicePrefillVariant(
     );
     try profile.printAnchorNeighborhoodSummary(2, alloc, "prefill qmatmul", schedule, backend_program.RegionPolicy.qmatmulCluster(), 8);
     profile.printQMatmulSliceSidecarSummary("prefill", program.ops);
+    profile.printAttentionStoreSidecarSummary("prefill", program.ops);
 
     _ = try prefill.executeAt(prompt, 0);
     session.reset();

--- a/benchmarks/llama_smollm_bench.zig
+++ b/benchmarks/llama_smollm_bench.zig
@@ -404,6 +404,9 @@ fn runDevicePrefillVariant(
     const projection_groups = try backend_program.buildProjectionGroups(alloc, program.ops, backend_program.ProjectionGroupPolicy.prefillQMatmul(4));
     defer alloc.free(projection_groups);
     profile.printProjectionGroupSummary("prefill qmatmul", backend_program.summarizeProjectionGroups(projection_groups));
+    const program_commands = try backend_program.buildProgramCommands(alloc, program.ops, backend_program.CommandStreamPolicy.metal(4, 4));
+    defer alloc.free(program_commands);
+    profile.printProgramCommandSummary("prefill", backend_program.summarizeProgramCommands(program_commands));
     const lowered_prefill_stages = [_]u32{0};
     profile.printRegionExecutionSummary(
         "prefill-layer stages lowered",

--- a/benchmarks/llama_smollm_bench.zig
+++ b/benchmarks/llama_smollm_bench.zig
@@ -415,6 +415,7 @@ fn runDevicePrefillVariant(
     try profile.printAnchorNeighborhoodSummary(2, alloc, "prefill qmatmul", schedule, backend_program.RegionPolicy.qmatmulCluster(), 8);
     profile.printQMatmulSliceSidecarSummary("prefill", program.ops);
     profile.printAttentionStoreSidecarSummary("prefill", program.ops);
+    profile.printAttentionStoreGroupCandidateSummary("prefill", program.ops, backend_program.CommandStreamPolicy.metal(4, 4));
     profile.printAttentionStoreRegionSummary("prefill-layer stages", program.ops, prefill_stage_schedule);
     try profile.printRegionProgramCommandSummary(
         "prefill-layer stages",

--- a/benchmarks/llama_smollm_bench.zig
+++ b/benchmarks/llama_smollm_bench.zig
@@ -416,6 +416,8 @@ fn runDevicePrefillVariant(
     profile.printQMatmulSliceSidecarSummary("prefill", program.ops);
     profile.printAttentionStoreSidecarSummary("prefill", program.ops);
     profile.printAttentionStoreGroupCandidateSummary("prefill", program.ops, backend_program.CommandStreamPolicy.metal(4, 4));
+    profile.printEarlyRopeAttentionStoreGroupCandidateSummary("prefill", program.ops, backend_program.CommandStreamPolicy.metal(4, 4));
+    profile.printRopeAttentionStoreGroupCandidateSummary("prefill", program.ops, backend_program.CommandStreamPolicy.metal(4, 4));
     profile.printAttentionStoreRegionSummary("prefill-layer stages", program.ops, prefill_stage_schedule);
     try profile.printRegionProgramCommandSummary(
         "prefill-layer stages",

--- a/benchmarks/llama_smollm_bench.zig
+++ b/benchmarks/llama_smollm_bench.zig
@@ -9,6 +9,7 @@
 //!   ./zig-out/bin/bench-llama-smollm model.gguf 4 200 3 --metal-fine
 //!   ./zig-out/bin/bench-llama-smollm model.gguf 4 200 3 --metal-region
 //!   ./zig-out/bin/bench-llama-smollm model.gguf 128 200 3 --metal-prefill-device
+//!   ./zig-out/bin/bench-llama-smollm model.gguf 128 200 3 --metal-rope-cache-sidecars
 //!   ./zig-out/bin/bench-llama-smollm model.gguf 4 200 3 --print-stage-plan
 //!   ./zig-out/bin/bench-llama-smollm model.gguf 4 200 3 --stage-plan-only
 
@@ -364,6 +365,7 @@ fn runDevicePrefillVariant(
     writer: anytype,
     io: std.Io,
     alloc: std.mem.Allocator,
+    command_policy: backend_program.CommandStreamPolicy,
 ) !BenchResult {
     if (cfg.prompt_tokens == 0 or cfg.prompt_tokens > config.max_seq_len) return error.InvalidPromptLength;
 
@@ -393,7 +395,7 @@ fn runDevicePrefillVariant(
     const schedule = try backend_program.buildKernelSchedule(alloc, program.ops, schedule_policy);
     defer alloc.free(schedule);
     const prefill_stages = [_]backend_program.StagePolicy{
-        backend_program.StagePolicy.anchored("prefill-layer", 0, backend_program.RegionPolicy.qmatmulCluster(), 7),
+        zgml.backend_metal.MetalRegionPattern.prefill_layer_stage.stagePolicy(),
     };
     const prefill_stage_schedule = try backend_program.buildStageRegionSchedule(alloc, schedule, &prefill_stages);
     defer alloc.free(prefill_stage_schedule);
@@ -401,14 +403,15 @@ fn runDevicePrefillVariant(
     const stage_commands = try backend_program.buildStageCommands(alloc, program.ops);
     defer alloc.free(stage_commands);
     profile.printStageCommandSummary("prefill", backend_program.summarizeStageCommands(stage_commands));
-    const projection_groups = try backend_program.buildProjectionGroups(alloc, program.ops, backend_program.ProjectionGroupPolicy.prefillQMatmul(4));
+    const projection_groups = try backend_program.buildProjectionGroups(alloc, program.ops, backend_program.ProjectionGroupPolicy.prefillQMatmul(command_policy.qmatmul_group_size));
     defer alloc.free(projection_groups);
     profile.printProjectionGroupSummary("prefill qmatmul", backend_program.summarizeProjectionGroups(projection_groups));
     profile.printProjectionSidecarSummary("prefill", program.ops);
-    const program_commands = try backend_program.buildProgramCommands(alloc, program.ops, backend_program.CommandStreamPolicy.metal(4, 4));
+    profile.printProjectionRopeCacheSummary("prefill", program.ops, 32);
+    const program_commands = try backend_program.buildProgramCommands(alloc, program.ops, command_policy);
     defer alloc.free(program_commands);
     profile.printProgramCommandSummary("prefill", backend_program.summarizeProgramCommands(program_commands));
-    const lowered_prefill_stages = [_]u32{0};
+    const lowered_prefill_stages = [_]u32{zgml.backend_metal.MetalRegionPattern.prefill_layer_stage.index()};
     profile.printRegionExecutionSummary(
         "prefill-layer stages lowered",
         backend_program.summarizeRegionExecution(prefill_stage_schedule, schedule, &lowered_prefill_stages),
@@ -416,17 +419,17 @@ fn runDevicePrefillVariant(
     try profile.printAnchorNeighborhoodSummary(2, alloc, "prefill qmatmul", schedule, backend_program.RegionPolicy.qmatmulCluster(), 8);
     profile.printQMatmulSliceSidecarSummary("prefill", program.ops);
     profile.printAttentionStoreSidecarSummary("prefill", program.ops);
-    profile.printAttentionStoreGroupCandidateSummary("prefill", program.ops, backend_program.CommandStreamPolicy.metal(4, 4));
-    profile.printEarlyRopeAttentionStoreGroupCandidateSummary("prefill", program.ops, backend_program.CommandStreamPolicy.metal(4, 4));
-    profile.printRopeStoreGroupCandidateSummary("prefill", program.ops, backend_program.CommandStreamPolicy.metal(4, 4));
-    profile.printRopeAttentionStoreGroupCandidateSummary("prefill", program.ops, backend_program.CommandStreamPolicy.metal(4, 4));
+    profile.printAttentionStoreGroupCandidateSummary("prefill", program.ops, command_policy);
+    profile.printEarlyRopeAttentionStoreGroupCandidateSummary("prefill", program.ops, command_policy);
+    profile.printRopeStoreGroupCandidateSummary("prefill", program.ops, command_policy);
+    profile.printRopeAttentionStoreGroupCandidateSummary("prefill", program.ops, command_policy);
     profile.printAttentionStoreRegionSummary("prefill-layer stages", program.ops, prefill_stage_schedule);
     try profile.printRegionProgramCommandSummary(
         "prefill-layer stages",
         alloc,
         program.ops,
         prefill_stage_schedule,
-        backend_program.CommandStreamPolicy.metal(4, 4),
+        command_policy,
     );
 
     _ = try prefill.executeAt(prompt, 0);
@@ -489,6 +492,7 @@ pub fn main(init: std.process.Init) !void {
     const run_metal_fine = hasFlag(args, "--metal-fine");
     const run_metal_region = hasFlag(args, "--metal-region");
     const run_metal_prefill_device = hasFlag(args, "--metal-prefill-device");
+    const run_metal_rope_cache_sidecars = hasFlag(args, "--metal-rope-cache-sidecars");
     const stage_plan_only = hasFlag(args, "--stage-plan-only");
     const print_stage_plan = stage_plan_only or hasFlag(args, "--print-stage-plan");
     const model_is_gguf = isGGUF(cfg.model_path);
@@ -542,7 +546,9 @@ pub fn main(init: std.process.Init) !void {
         if (!model_is_gguf) _ = try runVariant("metal int8       ", metal_be.backend(), true, false, cfg, &stdout.interface, io, alloc);
         if (run_metal_prefill_device and model_is_gguf) {
             metal_be.setRegionProgramDispatch(true);
-            _ = try runDevicePrefillVariant("metal prefill q", metal_be.backend(), cfg, &stdout.interface, io, alloc);
+            metal_be.setProjectionRopeCacheSidecars(run_metal_rope_cache_sidecars);
+            _ = try runDevicePrefillVariant(if (run_metal_rope_cache_sidecars) "metal prefill r" else "metal prefill q", metal_be.backend(), cfg, &stdout.interface, io, alloc, metal_be.commandStreamPolicy());
+            metal_be.setProjectionRopeCacheSidecars(false);
             metal_be.setRegionProgramDispatch(false);
         }
         _ = try runDeviceVariant(if (model_is_gguf) "metal device q  " else "metal device f16", metal_be.backend(), cfg, &stdout.interface, io, alloc);
@@ -554,6 +560,13 @@ pub fn main(init: std.process.Init) !void {
         if (run_metal_region) {
             metal_be.setRegionProgramDispatch(true);
             _ = try runDeviceVariant(if (model_is_gguf) "metal region q  " else "metal region f16", metal_be.backend(), cfg, &stdout.interface, io, alloc);
+            metal_be.setRegionProgramDispatch(false);
+        }
+        if (run_metal_rope_cache_sidecars and model_is_gguf) {
+            metal_be.setRegionProgramDispatch(true);
+            metal_be.setProjectionRopeCacheSidecars(true);
+            _ = try runDeviceVariant("metal rope q    ", metal_be.backend(), cfg, &stdout.interface, io, alloc);
+            metal_be.setProjectionRopeCacheSidecars(false);
             metal_be.setRegionProgramDispatch(false);
         }
     }

--- a/benchmarks/llama_smollm_bench.zig
+++ b/benchmarks/llama_smollm_bench.zig
@@ -404,6 +404,7 @@ fn runDevicePrefillVariant(
     const projection_groups = try backend_program.buildProjectionGroups(alloc, program.ops, backend_program.ProjectionGroupPolicy.prefillQMatmul(4));
     defer alloc.free(projection_groups);
     profile.printProjectionGroupSummary("prefill qmatmul", backend_program.summarizeProjectionGroups(projection_groups));
+    profile.printProjectionSidecarSummary("prefill", program.ops);
     const program_commands = try backend_program.buildProgramCommands(alloc, program.ops, backend_program.CommandStreamPolicy.metal(4, 4));
     defer alloc.free(program_commands);
     profile.printProgramCommandSummary("prefill", backend_program.summarizeProgramCommands(program_commands));

--- a/benchmarks/llama_smollm_bench.zig
+++ b/benchmarks/llama_smollm_bench.zig
@@ -417,6 +417,7 @@ fn runDevicePrefillVariant(
     profile.printAttentionStoreSidecarSummary("prefill", program.ops);
     profile.printAttentionStoreGroupCandidateSummary("prefill", program.ops, backend_program.CommandStreamPolicy.metal(4, 4));
     profile.printEarlyRopeAttentionStoreGroupCandidateSummary("prefill", program.ops, backend_program.CommandStreamPolicy.metal(4, 4));
+    profile.printRopeStoreGroupCandidateSummary("prefill", program.ops, backend_program.CommandStreamPolicy.metal(4, 4));
     profile.printRopeAttentionStoreGroupCandidateSummary("prefill", program.ops, backend_program.CommandStreamPolicy.metal(4, 4));
     profile.printAttentionStoreRegionSummary("prefill-layer stages", program.ops, prefill_stage_schedule);
     try profile.printRegionProgramCommandSummary(

--- a/benchmarks/llama_smollm_bench.zig
+++ b/benchmarks/llama_smollm_bench.zig
@@ -415,6 +415,14 @@ fn runDevicePrefillVariant(
     try profile.printAnchorNeighborhoodSummary(2, alloc, "prefill qmatmul", schedule, backend_program.RegionPolicy.qmatmulCluster(), 8);
     profile.printQMatmulSliceSidecarSummary("prefill", program.ops);
     profile.printAttentionStoreSidecarSummary("prefill", program.ops);
+    profile.printAttentionStoreRegionSummary("prefill-layer stages", program.ops, prefill_stage_schedule);
+    try profile.printRegionProgramCommandSummary(
+        "prefill-layer stages",
+        alloc,
+        program.ops,
+        prefill_stage_schedule,
+        backend_program.CommandStreamPolicy.metal(4, 4),
+    );
 
     _ = try prefill.executeAt(prompt, 0);
     session.reset();

--- a/docs/perf-targets.md
+++ b/docs/perf-targets.md
@@ -35,7 +35,7 @@ Current prefill work has a first real device-only path:
 | Path | Prompt/prefill | Runtime placement | Dispatches |
 | --- | ---: | --- | ---: |
 | Current GGUF session path | ~0.9k tok/s | CPU/Accelerate quant path | n/a |
-| Experimental Metal device prefill Q8_0 | ~2.0-2.7k tok/s | 100% backend | ~1,292/call |
+| Experimental Metal device prefill Q8_0 | ~2.6-2.8k tok/s | 100% backend | ~1,142/call |
 
 Measured with
 `./zig-out/bin/bench-llama-smollm data/smollm/SmolLM-135M.Q8_0.gguf 128 1 3 --metal-prefill-device`.
@@ -74,9 +74,10 @@ share a buffer and still batch if their read/write spans do not overlap.
 
 The first unified command stream now combines those pure stage commands and
 projection groups into a single ordered view. On SmolLM prefill it currently
-emits 1,262 commands for 1,714 ops, including 61 row chains, 90 RoPE/cache
-chains, 30 movement groups, 120 projection sidecar chains, and 30 projection
-groups covering 90 anchors plus 30 sidecars. Metal can consume this stream for
+emits 932 commands for 1,654 ops, including 61 row chains, 90 RoPE/cache
+chains, 30 movement groups, 270 attention output-store chains, 120 projection
+sidecar chains, and 30 projection groups covering 90 anchors plus 30 sidecars.
+Metal can consume this stream for
 those command classes while still falling back to existing local lowering for
 commands that are not first-class yet. The stream
 also has first-class contiguous batch commands for RoPE, movement/slice-assign,
@@ -99,6 +100,14 @@ single projection feeds an immediate elementwise, fused-elementwise, or cache
 write sidecar. This lifts Metal's local pair fusers into the same pure command
 stream and gives the next batching pass a clear target: teach projection batch
 kernels to carry those sidecars without losing the multi-anchor dispatch win.
+
+Attention output assembly now follows the same rule: the cached LLaMA forward
+uses a scratch concat buffer that is fully overwritten by per-head stores instead
+of emitting a fake zero-fill dependency. The command stream can therefore attach
+270 delayed attention output stores to their producer attention ops. The current
+runtime still executes ~1,142 dispatches/call because region windows only realize
+the immediate subset today; the pure command target is ~932 dispatches before
+the next region-execution cleanup.
 
 ## Acceptance Thresholds
 

--- a/docs/perf-targets.md
+++ b/docs/perf-targets.md
@@ -67,6 +67,13 @@ predicates for its batched projection kernels, so future movement, RoPE/KV, and
 attention commands can follow the same path before adding more backend-specific
 pattern code.
 
+The first unified command stream now combines those pure stage commands and
+projection groups into a single ordered view. On SmolLM prefill it currently
+emits 1,412 commands for 1,714 ops, including 61 row chains, 90 RoPE/cache
+chains, and 30 projection groups covering 90 anchors plus 30 sidecars. Metal can
+consume this stream for those command classes while still falling back to
+existing local lowering for commands that are not first-class yet.
+
 ## Acceptance Thresholds
 
 SmolLM-135M:

--- a/docs/perf-targets.md
+++ b/docs/perf-targets.md
@@ -67,6 +67,11 @@ predicates for its batched projection kernels, so future movement, RoPE/KV, and
 attention commands can follow the same path before adding more backend-specific
 pattern code.
 
+That legality layer now reasons in terms of buffer spans instead of whole-buffer
+touches. This keeps the command stream pure while making future fusion more
+precise for shared workspaces, KV caches, and head-sliced tensors: two ops can
+share a buffer and still batch if their read/write spans do not overlap.
+
 The first unified command stream now combines those pure stage commands and
 projection groups into a single ordered view. On SmolLM prefill it currently
 emits 1,412 commands for 1,714 ops, including 61 row chains, 90 RoPE/cache

--- a/docs/perf-targets.md
+++ b/docs/perf-targets.md
@@ -35,22 +35,23 @@ Current prefill work has a first real device-only path:
 | Path | Prompt/prefill | Runtime placement | Dispatches |
 | --- | ---: | --- | ---: |
 | Current GGUF session path | ~0.9k tok/s | CPU/Accelerate quant path | n/a |
-| Experimental Metal device prefill Q8_0 | ~1.7-2.1k tok/s | 100% backend | ~932/call |
+| Experimental Metal device prefill Q8_0 | ~2.7k tok/s | 100% backend | ~542/call |
 
 Measured with
 `./zig-out/bin/bench-llama-smollm data/smollm/SmolLM-135M.Q8_0.gguf 128 1 3 --metal-prefill-device`.
-This roughly doubles `pp128` while eliminating fallback for the prefill graph,
-but it is still not parity. QMatmul batching, qmatmul sidecar fusion, movement
-groups, and attention output-store chains now remove about 722 dispatches/call.
-The next target is reusable layer-stage lowering that cuts dispatch count by at
-least an order of magnitude without adding model special cases to the public API.
+This is roughly 3x the default GGUF path while eliminating fallback for the
+prefill graph, but it is still not parity. QMatmul batching, producer-sidecar
+fusion, movement groups, attention output-store chains, and RoPE-store grouping
+now remove about 1,112 dispatches/call. The next target is reusable layer-stage
+lowering that cuts dispatch count by at least another order of magnitude without
+adding model special cases to the public API.
 
 The stage planning abstraction now lives in `src/backend/program.zig` as a pure
 `StagePolicy`: a named anchored region plus a backend pattern id. Metal uses it
 for `decode-layer` and `prefill-layer` schedules with seven projection anchors.
 This is a structural cleanup, not a claimed speedup by itself; the current
-SmolLM Metal prefill smoke is roughly `1,292` dispatches/call after batched
-qmatmul partial-slice cache-store sidecars.
+SmolLM Metal prefill smoke is roughly `542` dispatches/call after command-stream
+lowering, RoPE-store grouping, and projection sidecar kernels.
 
 The next layer of the same abstraction is `StageCommand`: a pure, model-agnostic
 lowering view over the ops inside a stage. Today it names `row_chain` commands
@@ -74,18 +75,20 @@ share a buffer and still batch if their read/write spans do not overlap.
 
 The first unified command stream now combines those pure stage commands and
 projection groups into a single ordered view. On SmolLM prefill it currently
-emits 932 commands for 1,654 ops, including 61 row chains, 90 RoPE/cache
-chains, 30 movement groups, 270 attention output-store chains, 120 projection
-sidecar chains, and 30 projection groups covering 90 anchors plus 30 sidecars.
-Metal can consume this stream for
-those command classes while still falling back to existing local lowering for
-commands that are not first-class yet. The stream
-also has first-class contiguous batch commands for RoPE, movement/slice-assign,
-and attention; SmolLM prefill does not currently expose those as contiguous
-runs, but decode and future lowering passes can share the same command shape.
-Movement/slice-assign now also has an indexed `movement_group` command for
-non-contiguous independent copies that share source/destination buffers; SmolLM
-prefill currently finds 30 such groups covering 60 copy ops.
+emits 542 commands for 1,654 ops, including 61 row chains, 30 movement groups,
+60 attention output-store chains, 120 projection sidecar chains, and 30
+projection groups covering 90 anchors plus 30 sidecars. Additional
+producer-sidecar commands cover 30 RoPE-store groups, 30 RoPE-attention-store
+chains, and 60 RoPE-attention-store groups.
+Metal can consume this stream for those command classes while still falling
+back to existing local lowering for commands that are not first-class yet. The
+stream also has first-class contiguous batch commands for RoPE,
+movement/slice-assign, and attention; SmolLM prefill does not currently expose
+those as contiguous runs, but decode and future lowering passes can share the
+same command shape. Movement/slice-assign now also has an indexed
+`movement_group` command for non-contiguous independent copies that share
+source/destination buffers; SmolLM prefill currently finds 30 such groups
+covering 60 copy ops.
 It can also represent non-contiguous attention groups when all attention inputs
 are already available; the current SmolLM prefill trace still reports `0`, which
 means attention batching must include the producer movement/slice work rather
@@ -107,9 +110,46 @@ of emitting a fake zero-fill dependency. The command stream can therefore attach
 270 delayed attention output stores to their producer attention ops. Dynamic
 slice-store patching now only applies to KV-cache writes, so static
 `slice_assign_rows` output stores keep their row offsets after refresh. Metal's
-runtime command stream now matches the pure prefill target at ~932
+runtime command stream now matches the pure prefill target at ~542
 dispatches/call with no backend fallback; the next step is coarser layer command
 realization, not more local pair fusers.
+
+The current SmolLM Metal prefill command stream is now materially smaller:
+`rope_store_group` batches the remaining RoPE-to-KV-store chains and elides the
+intermediate scratch write when the scratch is only live until the store. The
+profile reports roughly 542 dispatches/call, 100% backend placement, and no
+fallback for the device prefill path. This is still not parity, but it confirms
+the durable rule: producer-sidecar lowerings should prove side-effect legality
+in the pure planner, then let Metal write the final side effect directly instead
+of materializing scratch tensors.
+
+The next projection target should follow that rule rather than growing
+model-specific kernels. SmolLM prefill has 210 qmatmul anchors and 150 immediate
+compatible projection sidecars: 30 slice stores, 90 simple elementwise tails, and
+30 fused-elementwise tails. Today only the slice-store sidecars ride with
+batched projection groups; the 120 elementwise/fused tails remain
+`projection_chain` commands. The long-term fix is a reusable
+producer-sidecar-group abstraction with explicit scratch liveness and optional
+primary-output elision, so qmatmul batches can write final elementwise/fused
+outputs directly without racing on reused scratch buffers.
+
+The first slice of that direction lets qmatmul projection groups carry simple
+elementwise sidecars in the same batched Metal kernel. This is a reusable
+producer-sidecar capability, but it does not reduce the current SmolLM dispatch
+count because the remaining elementwise/fused projection tails are
+dependency-adjacent `projection_chain` commands rather than independent
+projection-group members. That is an important boundary: further prefill wins
+come from stage-level lowering of producer-consumer subgraphs such as FFN
+gate/up/SwiGLU/down and attention assembly, not from endlessly expanding local
+pair fusers.
+
+The second slice makes that producer-sidecar rule cheaper in memory and visible
+in profiles: qmatmul sidecar kernels now receive a pure planner liveness bit and
+can skip writing the primary scratch output when only the fused sidecar observes
+it. Current SmolLM prefill reports 90 primary-elidable projection sidecars and
+60 that still require the primary output. The dispatch count is unchanged, but
+projection groups and projection chains now share the same dead-scratch elision
+rule as RoPE-store groups.
 
 ## Acceptance Thresholds
 

--- a/docs/perf-targets.md
+++ b/docs/perf-targets.md
@@ -82,6 +82,10 @@ are not first-class yet. The stream
 also has first-class contiguous batch commands for RoPE, movement/slice-assign,
 and attention; SmolLM prefill does not currently expose those as contiguous
 runs, but decode and future lowering passes can share the same command shape.
+It can also represent non-contiguous attention groups when all attention inputs
+are already available; the current SmolLM prefill trace still reports `0`, which
+means attention batching must include the producer movement/slice work rather
+than only grouping ready attention ops.
 It also has a non-contiguous `elementwise_batch` command backed by pure
 dependency checks; this is a reusable command-stream primitive, though the
 current SmolLM prefill trace reports `0` such batches because its elementwise ops

--- a/docs/perf-targets.md
+++ b/docs/perf-targets.md
@@ -35,23 +35,28 @@ Current prefill work has a first real device-only path:
 | Path | Prompt/prefill | Runtime placement | Dispatches |
 | --- | ---: | --- | ---: |
 | Current GGUF session path | ~0.9k tok/s | CPU/Accelerate quant path | n/a |
-| Experimental Metal device prefill Q8_0 | ~2.7k tok/s | 100% backend | ~542/call |
+| Experimental Metal device prefill Q8_0 | ~2.2k tok/s | 100% backend | ~242/call |
 
 Measured with
 `./zig-out/bin/bench-llama-smollm data/smollm/SmolLM-135M.Q8_0.gguf 128 1 3 --metal-prefill-device`.
-This is roughly 3x the default GGUF path while eliminating fallback for the
-prefill graph, but it is still not parity. QMatmul batching, producer-sidecar
-fusion, movement groups, attention output-store chains, and RoPE-store grouping
-now remove about 1,112 dispatches/call. The next target is reusable layer-stage
-lowering that cuts dispatch count by at least another order of magnitude without
-adding model special cases to the public API.
+This is roughly 2.4x the default GGUF path while eliminating fallback for the
+prefill graph, but it is still not parity. QMatmul batching, projection-owned
+cache stores, producer-sidecar fusion, attention output-store grouping, and
+RoPE-store grouping now remove about 1,412 dispatches/call. The next target is
+reusable layer-stage lowering that cuts dispatch count by at least another order
+of magnitude without adding model special cases to the public API.
 
 The stage planning abstraction now lives in `src/backend/program.zig` as a pure
 `StagePolicy`: a named anchored region plus a backend pattern id. Metal uses it
 for `decode-layer` and `prefill-layer` schedules with seven projection anchors.
+The runtime profile now reports total and per-pattern schedule-region attempts,
+lowered regions, refused regions, and covered/refused op counts, so a fast path
+cannot silently fall back to tiny dispatches while still looking "device backed".
 This is a structural cleanup, not a claimed speedup by itself; the current
-SmolLM Metal prefill smoke is roughly `542` dispatches/call after command-stream
-lowering, RoPE-store grouping, and projection sidecar kernels.
+SmolLM Metal prefill smoke is roughly `242` dispatches/call after command-stream
+lowering, RoPE-store grouping, projection sidecar kernels, projection activation
+fusion, projection-owned cache stores, and shared-offset RoPE-attention-store
+grouping.
 
 The next layer of the same abstraction is `StageCommand`: a pure, model-agnostic
 lowering view over the ops inside a stage. Today it names `row_chain` commands
@@ -75,11 +80,11 @@ share a buffer and still batch if their read/write spans do not overlap.
 
 The first unified command stream now combines those pure stage commands and
 projection groups into a single ordered view. On SmolLM prefill it currently
-emits 542 commands for 1,654 ops, including 61 row chains, 30 movement groups,
-60 attention output-store chains, 120 projection sidecar chains, and 30
-projection groups covering 90 anchors plus 30 sidecars. Additional
-producer-sidecar commands cover 30 RoPE-store groups, 30 RoPE-attention-store
-chains, and 60 RoPE-attention-store groups.
+emits 242 commands for 1,654 ops, including 61 row chains, 30 projection-owned
+cache groups covering 90 anchors plus 90 sidecars, 30 projection
+pair/fused-elementwise chains, and 60 projection sidecar chains. Additional
+producer-sidecar commands cover 30 RoPE-store groups and 30 wide
+RoPE-attention-store groups covering all 270 attention output stores.
 Metal can consume this stream for those command classes while still falling
 back to existing local lowering for commands that are not first-class yet. The
 stream also has first-class contiguous batch commands for RoPE,
@@ -87,8 +92,15 @@ movement/slice-assign, and attention; SmolLM prefill does not currently expose
 those as contiguous runs, but decode and future lowering passes can share the
 same command shape. Movement/slice-assign now also has an indexed
 `movement_group` command for non-contiguous independent copies that share
-source/destination buffers; SmolLM prefill currently finds 30 such groups
-covering 60 copy ops.
+source/destination buffers. SmolLM prefill now has `0` movement groups because
+the V-cache stores ride with the owning projection batch.
+Metal now compiles the command stream for each scheduled region alongside the
+region schedule and reuses that cached command plan while the command-stream
+policy remains unchanged. If a backend knob changes after compile, Metal falls
+back to dynamic command planning for correctness. This does not claim a dispatch
+count reduction by itself, but it is the first real stage-execution step: the
+`prefill-layer`/`decode-layer` lowerer executes a compiled region command plan
+instead of rediscovering commands on every region execution.
 It can also represent non-contiguous attention groups when all attention inputs
 are already available; the current SmolLM prefill trace still reports `0`, which
 means attention batching must include the producer movement/slice work rather
@@ -110,18 +122,59 @@ of emitting a fake zero-fill dependency. The command stream can therefore attach
 270 delayed attention output stores to their producer attention ops. Dynamic
 slice-store patching now only applies to KV-cache writes, so static
 `slice_assign_rows` output stores keep their row offsets after refresh. Metal's
-runtime command stream now matches the pure prefill target at ~542
+runtime command stream now matches the pure prefill target at ~242
 dispatches/call with no backend fallback; the next step is coarser layer command
 realization, not more local pair fusers.
 
 The current SmolLM Metal prefill command stream is now materially smaller:
 `rope_store_group` batches the remaining RoPE-to-KV-store chains and elides the
 intermediate scratch write when the scratch is only live until the store. The
-profile reports roughly 542 dispatches/call, 100% backend placement, and no
+profile reports roughly 242 dispatches/call, 100% backend placement, and no
 fallback for the device prefill path. This is still not parity, but it confirms
 the durable rule: producer-sidecar lowerings should prove side-effect legality
 in the pure planner, then let Metal write the final side effect directly instead
 of materializing scratch tensors.
+
+Projection cache stores now follow that same durable rule. The pure planner
+emits `projection_cache_group` for batched projections plus the direct slice
+stores they own, and Metal's qmatmul batch kernel supports multiple slice
+sidecars per projection when they share a sink buffer. On SmolLM prefill this
+removes the remaining V-cache movement dispatches: 30 projection-cache groups
+cover 90 projection anchors and 90 cache-store sidecars.
+
+The planner also has an opt-in legality rule for projection-owned K-cache stores
+that pass through RoPE (`qmatmul -> rope -> slice_assign`). This is intentionally
+not enabled in the default Metal policy yet: scalar and shared-kernel tile-pair
+prototypes reduced the visible dispatch count to 212/call, but slowed prefill.
+Metal now has that separate qmatmul/RoPE/cache-store lowering target behind
+`setProjectionRopeCacheSidecars(true)` and the benchmark flag
+`--metal-rope-cache-sidecars`. The common qmatmul batch kernel stays lean; the
+new path is only selected for tile-pair-compatible projection/RoPE/store
+sidecars and remains opt-in until model benchmarks prove it is a default win.
+Profiles count projection-owned RoPE cache candidates and tile-pair-shaped
+opportunities explicitly, so tuning can happen against that target without
+turning a speculative kernel on by default.
+Command-stream fusion knobs are now declared in backend capability metadata and
+the pure planner derives its default policy from that metadata. This keeps the
+long-term rule sharp: the planner may know a general pattern is legal, but a
+backend only advertises the pattern as default when it has a lowering that is
+actually fast.
+
+Decode-side qmatvec projection groups can also carry RoPE sidecars, but the
+planner now leaves Q-RoPE materialization alone when the same RoPE can feed a
+RoPE-attention-store command. This avoids a local dispatch-count win that would
+block the better attention-side fusion. Profiles report both projection/RoPE
+materialization opportunities and how many were intentionally left for
+attention fusion, which is the finish-line rule for new fusions: prefer the
+producer-sidecar placement that keeps the largest downstream semantic command
+available.
+
+Decode qmatvec projection groups now carry simple add/mul sidecars too. This is
+the same producer-sidecar concept applied to M=1 projections, so down-projection
+plus residual-style tails can ride with a batched qmatvec group without adding a
+model-specific FFN op. Metal lowers the sidecar in the qmatvec batch kernel by
+using the sidecar source as a per-anchor secondary buffer, keeping the public IR
+as plain `qmatmul` plus `elementwise`.
 
 The next projection target should follow that rule rather than growing
 model-specific kernels. SmolLM prefill has 210 qmatmul anchors and 150 immediate
@@ -150,6 +203,15 @@ it. Current SmolLM prefill reports 90 primary-elidable projection sidecars and
 60 that still require the primary output. The dispatch count is unchanged, but
 projection groups and projection chains now share the same dead-scratch elision
 rule as RoPE-store groups.
+
+The current RoPE-attention-store lowering extends that rule across head batches:
+when heads share Q source, RoPE tables, K/V/mask bases, and the final concat
+destination, the pure command stream can batch more than the old four-buffer
+Metal limit by carrying per-head offsets. SmolLM prefill now emits one
+RoPE-attention-store command per layer instead of split groups plus singleton
+chains: 30 commands cover 540 producer ops and 270 output-store sidecars.
+This is the right kind of win: it keeps the IR general for LLaMA/Qwen-style GQA
+layouts while hiding backend buffer-slot constraints inside Metal lowering.
 
 ## Acceptance Thresholds
 

--- a/docs/perf-targets.md
+++ b/docs/perf-targets.md
@@ -35,15 +35,15 @@ Current prefill work has a first real device-only path:
 | Path | Prompt/prefill | Runtime placement | Dispatches |
 | --- | ---: | --- | ---: |
 | Current GGUF session path | ~0.9k tok/s | CPU/Accelerate quant path | n/a |
-| Experimental Metal device prefill Q8_0 | ~2.6-2.8k tok/s | 100% backend | ~1,142/call |
+| Experimental Metal device prefill Q8_0 | ~1.7-2.1k tok/s | 100% backend | ~932/call |
 
 Measured with
 `./zig-out/bin/bench-llama-smollm data/smollm/SmolLM-135M.Q8_0.gguf 128 1 3 --metal-prefill-device`.
 This roughly doubles `pp128` while eliminating fallback for the prefill graph,
-but it is still not parity. QMatmul batching plus qmatmul sidecar fusion
-removed about 210 dispatches/call. The next target is reusable layer-stage
-lowering that cuts dispatch count by at least an order of magnitude without
-adding model special cases to the public API.
+but it is still not parity. QMatmul batching, qmatmul sidecar fusion, movement
+groups, and attention output-store chains now remove about 722 dispatches/call.
+The next target is reusable layer-stage lowering that cuts dispatch count by at
+least an order of magnitude without adding model special cases to the public API.
 
 The stage planning abstraction now lives in `src/backend/program.zig` as a pure
 `StagePolicy`: a named anchored region plus a backend pattern id. Metal uses it
@@ -104,10 +104,12 @@ kernels to carry those sidecars without losing the multi-anchor dispatch win.
 Attention output assembly now follows the same rule: the cached LLaMA forward
 uses a scratch concat buffer that is fully overwritten by per-head stores instead
 of emitting a fake zero-fill dependency. The command stream can therefore attach
-270 delayed attention output stores to their producer attention ops. The current
-runtime still executes ~1,142 dispatches/call because region windows only realize
-the immediate subset today; the pure command target is ~932 dispatches before
-the next region-execution cleanup.
+270 delayed attention output stores to their producer attention ops. Dynamic
+slice-store patching now only applies to KV-cache writes, so static
+`slice_assign_rows` output stores keep their row offsets after refresh. Metal's
+runtime command stream now matches the pure prefill target at ~932
+dispatches/call with no backend fallback; the next step is coarser layer command
+realization, not more local pair fusers.
 
 ## Acceptance Thresholds
 

--- a/docs/perf-targets.md
+++ b/docs/perf-targets.md
@@ -74,10 +74,11 @@ share a buffer and still batch if their read/write spans do not overlap.
 
 The first unified command stream now combines those pure stage commands and
 projection groups into a single ordered view. On SmolLM prefill it currently
-emits 1,412 commands for 1,714 ops, including 61 row chains, 90 RoPE/cache
-chains, and 30 projection groups covering 90 anchors plus 30 sidecars. Metal can
-consume this stream for those command classes while still falling back to
-existing local lowering for commands that are not first-class yet. The stream
+emits 1,292 commands for 1,714 ops, including 61 row chains, 90 RoPE/cache
+chains, 120 projection sidecar chains, and 30 projection groups covering 90
+anchors plus 30 sidecars. Metal can consume this stream for those command
+classes while still falling back to existing local lowering for commands that
+are not first-class yet. The stream
 also has first-class contiguous batch commands for RoPE, movement/slice-assign,
 and attention; SmolLM prefill does not currently expose those as contiguous
 runs, but decode and future lowering passes can share the same command shape.
@@ -85,6 +86,12 @@ It also has a non-contiguous `elementwise_batch` command backed by pure
 dependency checks; this is a reusable command-stream primitive, though the
 current SmolLM prefill trace reports `0` such batches because its elementwise ops
 are dependency-adjacent rather than independent.
+
+QMatmul side effects are now represented as `projection_chain` commands when a
+single projection feeds an immediate elementwise, fused-elementwise, or cache
+write sidecar. This lifts Metal's local pair fusers into the same pure command
+stream and gives the next batching pass a clear target: teach projection batch
+kernels to carry those sidecars without losing the multi-anchor dispatch win.
 
 ## Acceptance Thresholds
 

--- a/docs/perf-targets.md
+++ b/docs/perf-targets.md
@@ -74,14 +74,17 @@ share a buffer and still batch if their read/write spans do not overlap.
 
 The first unified command stream now combines those pure stage commands and
 projection groups into a single ordered view. On SmolLM prefill it currently
-emits 1,292 commands for 1,714 ops, including 61 row chains, 90 RoPE/cache
-chains, 120 projection sidecar chains, and 30 projection groups covering 90
-anchors plus 30 sidecars. Metal can consume this stream for those command
-classes while still falling back to existing local lowering for commands that
-are not first-class yet. The stream
+emits 1,262 commands for 1,714 ops, including 61 row chains, 90 RoPE/cache
+chains, 30 movement groups, 120 projection sidecar chains, and 30 projection
+groups covering 90 anchors plus 30 sidecars. Metal can consume this stream for
+those command classes while still falling back to existing local lowering for
+commands that are not first-class yet. The stream
 also has first-class contiguous batch commands for RoPE, movement/slice-assign,
 and attention; SmolLM prefill does not currently expose those as contiguous
 runs, but decode and future lowering passes can share the same command shape.
+Movement/slice-assign now also has an indexed `movement_group` command for
+non-contiguous independent copies that share source/destination buffers; SmolLM
+prefill currently finds 30 such groups covering 60 copy ops.
 It can also represent non-contiguous attention groups when all attention inputs
 are already available; the current SmolLM prefill trace still reports `0`, which
 means attention batching must include the producer movement/slice work rather

--- a/docs/perf-targets.md
+++ b/docs/perf-targets.md
@@ -76,6 +76,10 @@ existing local lowering for commands that are not first-class yet. The stream
 also has first-class contiguous batch commands for RoPE, movement/slice-assign,
 and attention; SmolLM prefill does not currently expose those as contiguous
 runs, but decode and future lowering passes can share the same command shape.
+It also has a non-contiguous `elementwise_batch` command backed by pure
+dependency checks; this is a reusable command-stream primitive, though the
+current SmolLM prefill trace reports `0` such batches because its elementwise ops
+are dependency-adjacent rather than independent.
 
 ## Acceptance Thresholds
 

--- a/docs/perf-targets.md
+++ b/docs/perf-targets.md
@@ -72,7 +72,10 @@ projection groups into a single ordered view. On SmolLM prefill it currently
 emits 1,412 commands for 1,714 ops, including 61 row chains, 90 RoPE/cache
 chains, and 30 projection groups covering 90 anchors plus 30 sidecars. Metal can
 consume this stream for those command classes while still falling back to
-existing local lowering for commands that are not first-class yet.
+existing local lowering for commands that are not first-class yet. The stream
+also has first-class contiguous batch commands for RoPE, movement/slice-assign,
+and attention; SmolLM prefill does not currently expose those as contiguous
+runs, but decode and future lowering passes can share the same command shape.
 
 ## Acceptance Thresholds
 

--- a/src/backend.zig
+++ b/src/backend.zig
@@ -25,6 +25,7 @@ pub const Capabilities = struct {
     decode_attention: bool = false,
     quantized_kv: bool = false,
     command_buffer_execution: bool = false,
+    command_stream: CommandStream = .{},
     attention: Attention = .{},
 
     pub const Attention = struct {
@@ -38,6 +39,22 @@ pub const Capabilities = struct {
             if (self.max_d_head) |max| if (d_head > max) return false;
             return true;
         }
+    };
+
+    pub const CommandStream = struct {
+        stage_commands: bool = false,
+        qmatvec_group_size: u32 = 1,
+        qmatmul_group_size: u32 = 1,
+        qmatmul_sidecars: bool = false,
+        qmatmul_cache_sidecars_per_anchor: u32 = 1,
+        projection_rope_cache_sidecars: bool = false,
+        max_rope_batch: u32 = 1,
+        max_movement_batch: u32 = 1,
+        max_attention_batch: u32 = 1,
+        max_attention_store_batch: u32 = 1,
+        max_rope_attention_store_batch: u32 = 1,
+        max_elementwise_batch: u32 = 1,
+        fuse_repeat_fused_elementwise: bool = false,
     };
 
     pub const reference_cpu = Capabilities{
@@ -64,6 +81,20 @@ pub const Capabilities = struct {
         .prefill_attention = true,
         .decode_attention = true,
         .command_buffer_execution = true,
+        .command_stream = .{
+            .stage_commands = true,
+            .qmatvec_group_size = 4,
+            .qmatmul_group_size = 4,
+            .qmatmul_sidecars = true,
+            .qmatmul_cache_sidecars_per_anchor = 8,
+            .max_rope_batch = 16,
+            .max_movement_batch = 16,
+            .max_attention_batch = 16,
+            .max_attention_store_batch = 4,
+            .max_rope_attention_store_batch = 16,
+            .max_elementwise_batch = 8,
+            .fuse_repeat_fused_elementwise = true,
+        },
         .attention = .{ .supported = true, .max_d_head = 512 },
     };
 

--- a/src/backend/metal.zig
+++ b/src/backend/metal.zig
@@ -2967,8 +2967,34 @@ const CompiledProgram = struct {
         return n;
     }
 
+    fn canEncodeAttentionBatchIndices(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, indices: []const usize) bool {
+        _ = self;
+        if (indices.len < 2 or indices.len > MAX_ATTENTION_BATCH_HEADS) return false;
+        if (indices[0] >= ops.len) return false;
+        const first = switch (ops[indices[0]]) {
+            .attention => |att| att,
+            else => return false,
+        };
+        if (!canEncodeAttention(first)) return false;
+        for (indices[1..]) |idx| {
+            if (idx >= ops.len) return false;
+            const next = switch (ops[idx]) {
+                .attention => |att| att,
+                else => return false,
+            };
+            if (!canEncodeAttention(next) or !attentionBatchCompatible(first, next)) return false;
+        }
+        return true;
+    }
+
     fn encodeAttentionBatch(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, n: usize) void {
-        const first = ops[0].attention;
+        var indices: [MAX_ATTENTION_BATCH_HEADS]usize = undefined;
+        for (0..n) |i| indices[i] = i;
+        self.encodeAttentionBatchIndices(ops, indices[0..n]);
+    }
+
+    fn encodeAttentionBatchIndices(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, indices: []const usize) void {
+        const first = ops[indices[0]].attention;
         const buffers = [_]DeviceBuffer{
             self.device_bufs[first.q],
             self.device_bufs[first.k],
@@ -2977,7 +3003,7 @@ const CompiledProgram = struct {
             self.device_bufs[first.dst],
         };
         var params = std.mem.zeroes(AttentionBatchParams);
-        params.n_heads = @intCast(n);
+        params.n_heads = @intCast(indices.len);
         params.d_head = first.d_head;
         params.seq_q = first.seq_q;
         params.seq_kv = first.seq_kv;
@@ -2992,15 +3018,15 @@ const CompiledProgram = struct {
         params.mask_cs = first.mask_cs;
         params.dst_rs = first.dst_rs;
         params.dst_cs = first.dst_cs;
-        for (ops[0..n], 0..) |op, i| {
-            const att = op.attention;
+        for (indices, 0..) |idx, i| {
+            const att = ops[idx].attention;
             params.q_off[i] = att.q_off;
             params.k_off[i] = att.k_off;
             params.v_off[i] = att.v_off;
             params.mask_off[i] = att.mask_off;
             params.dst_off[i] = att.dst_off;
         }
-        self.encodeTyped(AttentionBatchParams, self.backend.attention_batch_pipeline, &buffers, params, 5, .{ .gx = first.seq_q, .gy = @intCast(n) }, WG_SIZE);
+        self.encodeTyped(AttentionBatchParams, self.backend.attention_batch_pipeline, &buffers, params, 5, .{ .gx = first.seq_q, .gy = @intCast(indices.len) }, WG_SIZE);
     }
 
     fn canEncodeRegionGpuOp(self: *CompiledProgram, op: backend_mod.DeviceOp) bool {
@@ -3225,6 +3251,13 @@ const CompiledProgram = struct {
                 self.encodeAttentionBatch(ops[start..], n);
                 break :blk true;
             },
+            .attention_group => blk: {
+                if (!self.canEncodeAttentionBatchIndices(ops, command.anchorIndices())) break :blk false;
+                const t_batch = nowNs();
+                self.encodeAttentionBatchIndices(ops, command.anchorIndices());
+                self.recordRegionFusedRunFromIndices(ops, command.anchorIndices(), @intCast(nowNs() - t_batch));
+                break :blk true;
+            },
             .rope_batch => blk: {
                 const n: usize = @intCast(command.op_count);
                 if (ropeBatchRunLen(ops[start..]) < n) break :blk false;
@@ -3275,7 +3308,7 @@ const CompiledProgram = struct {
         };
 
         if (!encoded) return 0;
-        if (command.kind != .projection_group and command.kind != .elementwise_batch) {
+        if (command.kind != .projection_group and command.kind != .elementwise_batch and command.kind != .attention_group) {
             self.recordRegionFusedRun(ops[start..end], @intCast(nowNs() - t0));
         }
         program_mod.markProgramCommandUsed(skipped, command);

--- a/src/backend/metal.zig
+++ b/src/backend/metal.zig
@@ -966,6 +966,170 @@ const shader_source =
     \\    }
     \\}
     \\
+    \\struct AttentionSliceAssignParams {
+    \\    uint d_head; uint seq_q; uint seq_kv;
+    \\    float scale;
+    \\    uint q_off; uint k_off; uint v_off; uint mask_off; uint dst_off;
+    \\    uint q_rs; uint q_cs; uint k_rs; uint k_cs; uint v_rs; uint v_cs;
+    \\    uint mask_rs; uint mask_cs; uint dst_rs; uint dst_cs;
+    \\    uint slice_rows; uint slice_cols;
+    \\    uint slice_src_offset; uint slice_src_row_stride; uint slice_src_col_stride;
+    \\    uint slice_dst_offset; uint slice_dst_row_stride; uint slice_dst_col_stride;
+    \\};
+    \\
+    \\kernel void attention_slice_assign_f32(
+    \\    device const float* Q         [[buffer(0)]],
+    \\    device const float* K         [[buffer(1)]],
+    \\    device const float* V         [[buffer(2)]],
+    \\    device const float* mask      [[buffer(3)]],
+    \\    device float*       dst       [[buffer(4)]],
+    \\    device const float* slice_src [[buffer(5)]],
+    \\    device float*       slice_dst [[buffer(6)]],
+    \\    constant AttentionSliceAssignParams& p [[buffer(7)]],
+    \\    uint q_col   [[threadgroup_position_in_grid]],
+    \\    uint tid     [[thread_index_in_threadgroup]]
+    \\) {
+    \\    if (q_col >= p.seq_q) return;
+    \\    const uint tg_size = 256;
+    \\
+    \\    if (q_col == 0) {
+    \\        uint copy_n = p.slice_rows * p.slice_cols;
+    \\        for (uint i = tid; i < copy_n; i += tg_size) {
+    \\            uint row = i % p.slice_rows;
+    \\            uint col = i / p.slice_rows;
+    \\            slice_dst[p.slice_dst_offset + row * p.slice_dst_row_stride + col * p.slice_dst_col_stride] =
+    \\                slice_src[p.slice_src_offset + row * p.slice_src_row_stride + col * p.slice_src_col_stride];
+    \\        }
+    \\    }
+    \\
+    \\    threadgroup float scores[MAX_SEQ];
+    \\    threadgroup float scratch[256];
+    \\
+    \\    for (uint s = tid; s < p.seq_kv; s += tg_size) {
+    \\        float mv = mask[p.mask_off + s * p.mask_rs + q_col * p.mask_cs];
+    \\        if (!isfinite(mv)) { scores[s] = -INFINITY; continue; }
+    \\        float dot = 0.0f;
+    \\        for (uint r = 0; r < p.d_head; r++)
+    \\            dot += Q[p.q_off + r * p.q_rs + q_col * p.q_cs] * K[p.k_off + r * p.k_rs + s * p.k_cs];
+    \\        scores[s] = dot * p.scale + mv;
+    \\    }
+    \\    threadgroup_barrier(mem_flags::mem_threadgroup);
+    \\
+    \\    float local_max = -INFINITY;
+    \\    for (uint s = tid; s < p.seq_kv; s += tg_size)
+    \\        local_max = max(local_max, scores[s]);
+    \\    scratch[tid] = local_max;
+    \\    threadgroup_barrier(mem_flags::mem_threadgroup);
+    \\    for (uint stride = tg_size / 2; stride > 0; stride /= 2) {
+    \\        if (tid < stride) scratch[tid] = max(scratch[tid], scratch[tid + stride]);
+    \\        threadgroup_barrier(mem_flags::mem_threadgroup);
+    \\    }
+    \\    float global_max = scratch[0];
+    \\    threadgroup_barrier(mem_flags::mem_threadgroup);
+    \\
+    \\    float local_sum = 0.0f;
+    \\    for (uint s = tid; s < p.seq_kv; s += tg_size) {
+    \\        float w = (scores[s] == -INFINITY) ? 0.0f : exp(scores[s] - global_max);
+    \\        scores[s] = w;
+    \\        local_sum += w;
+    \\    }
+    \\    scratch[tid] = local_sum;
+    \\    threadgroup_barrier(mem_flags::mem_threadgroup);
+    \\    for (uint stride = tg_size / 2; stride > 0; stride /= 2) {
+    \\        if (tid < stride) scratch[tid] += scratch[tid + stride];
+    \\        threadgroup_barrier(mem_flags::mem_threadgroup);
+    \\    }
+    \\    float inv_sum = (scratch[0] > 0.0f) ? 1.0f / scratch[0] : 0.0f;
+    \\    threadgroup_barrier(mem_flags::mem_threadgroup);
+    \\
+    \\    for (uint s = tid; s < p.seq_kv; s += tg_size)
+    \\        scores[s] *= inv_sum;
+    \\    threadgroup_barrier(mem_flags::mem_threadgroup);
+    \\
+    \\    for (uint r = tid; r < p.d_head; r += tg_size) {
+    \\        float val = 0.0f;
+    \\        for (uint s = 0; s < p.seq_kv; s++)
+    \\            val += scores[s] * V[p.v_off + r * p.v_rs + s * p.v_cs];
+    \\        dst[p.dst_off + r * p.dst_rs + q_col * p.dst_cs] = val;
+    \\    }
+    \\}
+    \\
+    \\struct AttentionStoreParams {
+    \\    uint d_head; uint seq_q; uint seq_kv;
+    \\    float scale;
+    \\    uint q_off; uint k_off; uint v_off; uint mask_off; uint dst_off;
+    \\    uint q_rs; uint q_cs; uint k_rs; uint k_cs; uint v_rs; uint v_cs;
+    \\    uint mask_rs; uint mask_cs; uint dst_rs; uint dst_cs;
+    \\    uint slice_dst_offset; uint slice_dst_row_stride; uint slice_dst_col_stride;
+    \\};
+    \\
+    \\kernel void attention_store_f32(
+    \\    device const float* Q         [[buffer(0)]],
+    \\    device const float* K         [[buffer(1)]],
+    \\    device const float* V         [[buffer(2)]],
+    \\    device const float* mask      [[buffer(3)]],
+    \\    device float*       dst       [[buffer(4)]],
+    \\    device float*       slice_dst [[buffer(5)]],
+    \\    constant AttentionStoreParams& p [[buffer(6)]],
+    \\    uint q_col   [[threadgroup_position_in_grid]],
+    \\    uint tid     [[thread_index_in_threadgroup]]
+    \\) {
+    \\    if (q_col >= p.seq_q) return;
+    \\    const uint tg_size = 256;
+    \\
+    \\    threadgroup float scores[MAX_SEQ];
+    \\    threadgroup float scratch[256];
+    \\
+    \\    for (uint s = tid; s < p.seq_kv; s += tg_size) {
+    \\        float mv = mask[p.mask_off + s * p.mask_rs + q_col * p.mask_cs];
+    \\        if (!isfinite(mv)) { scores[s] = -INFINITY; continue; }
+    \\        float dot = 0.0f;
+    \\        for (uint r = 0; r < p.d_head; r++)
+    \\            dot += Q[p.q_off + r * p.q_rs + q_col * p.q_cs] * K[p.k_off + r * p.k_rs + s * p.k_cs];
+    \\        scores[s] = dot * p.scale + mv;
+    \\    }
+    \\    threadgroup_barrier(mem_flags::mem_threadgroup);
+    \\
+    \\    float local_max = -INFINITY;
+    \\    for (uint s = tid; s < p.seq_kv; s += tg_size)
+    \\        local_max = max(local_max, scores[s]);
+    \\    scratch[tid] = local_max;
+    \\    threadgroup_barrier(mem_flags::mem_threadgroup);
+    \\    for (uint stride = tg_size / 2; stride > 0; stride /= 2) {
+    \\        if (tid < stride) scratch[tid] = max(scratch[tid], scratch[tid + stride]);
+    \\        threadgroup_barrier(mem_flags::mem_threadgroup);
+    \\    }
+    \\    float global_max = scratch[0];
+    \\    threadgroup_barrier(mem_flags::mem_threadgroup);
+    \\
+    \\    float local_sum = 0.0f;
+    \\    for (uint s = tid; s < p.seq_kv; s += tg_size) {
+    \\        float w = (scores[s] == -INFINITY) ? 0.0f : exp(scores[s] - global_max);
+    \\        scores[s] = w;
+    \\        local_sum += w;
+    \\    }
+    \\    scratch[tid] = local_sum;
+    \\    threadgroup_barrier(mem_flags::mem_threadgroup);
+    \\    for (uint stride = tg_size / 2; stride > 0; stride /= 2) {
+    \\        if (tid < stride) scratch[tid] += scratch[tid + stride];
+    \\        threadgroup_barrier(mem_flags::mem_threadgroup);
+    \\    }
+    \\    float inv_sum = (scratch[0] > 0.0f) ? 1.0f / scratch[0] : 0.0f;
+    \\    threadgroup_barrier(mem_flags::mem_threadgroup);
+    \\
+    \\    for (uint s = tid; s < p.seq_kv; s += tg_size)
+    \\        scores[s] *= inv_sum;
+    \\    threadgroup_barrier(mem_flags::mem_threadgroup);
+    \\
+    \\    for (uint r = tid; r < p.d_head; r += tg_size) {
+    \\        float val = 0.0f;
+    \\        for (uint s = 0; s < p.seq_kv; s++)
+    \\            val += scores[s] * V[p.v_off + r * p.v_rs + s * p.v_cs];
+    \\        dst[p.dst_off + r * p.dst_rs + q_col * p.dst_cs] = val;
+    \\        slice_dst[p.slice_dst_offset + r * p.slice_dst_row_stride + q_col * p.slice_dst_col_stride] = val;
+    \\    }
+    \\}
+    \\
     \\struct AttentionBatchParams {
     \\    uint n_heads; uint d_head; uint seq_q; uint seq_kv;
     \\    float scale;
@@ -1650,6 +1814,61 @@ const AttentionParams = extern struct {
     dst_cs: u32,
 };
 
+const AttentionSliceAssignParams = extern struct {
+    d_head: u32,
+    seq_q: u32,
+    seq_kv: u32,
+    scale: f32,
+    q_off: u32,
+    k_off: u32,
+    v_off: u32,
+    mask_off: u32,
+    dst_off: u32,
+    q_rs: u32,
+    q_cs: u32,
+    k_rs: u32,
+    k_cs: u32,
+    v_rs: u32,
+    v_cs: u32,
+    mask_rs: u32,
+    mask_cs: u32,
+    dst_rs: u32,
+    dst_cs: u32,
+    slice_rows: u32,
+    slice_cols: u32,
+    slice_src_offset: u32,
+    slice_src_row_stride: u32,
+    slice_src_col_stride: u32,
+    slice_dst_offset: u32,
+    slice_dst_row_stride: u32,
+    slice_dst_col_stride: u32,
+};
+
+const AttentionStoreParams = extern struct {
+    d_head: u32,
+    seq_q: u32,
+    seq_kv: u32,
+    scale: f32,
+    q_off: u32,
+    k_off: u32,
+    v_off: u32,
+    mask_off: u32,
+    dst_off: u32,
+    q_rs: u32,
+    q_cs: u32,
+    k_rs: u32,
+    k_cs: u32,
+    v_rs: u32,
+    v_cs: u32,
+    mask_rs: u32,
+    mask_cs: u32,
+    dst_rs: u32,
+    dst_cs: u32,
+    slice_dst_offset: u32,
+    slice_dst_row_stride: u32,
+    slice_dst_col_stride: u32,
+};
+
 const MAX_ATTENTION_BATCH_HEADS: usize = 16;
 
 const AttentionBatchParams = extern struct {
@@ -1942,6 +2161,65 @@ fn attentionParams(att: anytype) AttentionParams {
     };
 }
 
+fn attentionSliceAssignParams(att: anytype, sa: anytype) AttentionSliceAssignParams {
+    return .{
+        .d_head = att.d_head,
+        .seq_q = att.seq_q,
+        .seq_kv = att.seq_kv,
+        .scale = att.scale,
+        .q_off = att.q_off,
+        .k_off = att.k_off,
+        .v_off = att.v_off,
+        .mask_off = att.mask_off,
+        .dst_off = att.dst_off,
+        .q_rs = att.q_rs,
+        .q_cs = att.q_cs,
+        .k_rs = att.k_rs,
+        .k_cs = att.k_cs,
+        .v_rs = att.v_rs,
+        .v_cs = att.v_cs,
+        .mask_rs = att.mask_rs,
+        .mask_cs = att.mask_cs,
+        .dst_rs = att.dst_rs,
+        .dst_cs = att.dst_cs,
+        .slice_rows = sa.rows,
+        .slice_cols = sa.cols,
+        .slice_src_offset = sa.src_offset,
+        .slice_src_row_stride = sa.src_row_stride,
+        .slice_src_col_stride = sa.src_col_stride,
+        .slice_dst_offset = sa.dst_offset,
+        .slice_dst_row_stride = sa.dst_row_stride,
+        .slice_dst_col_stride = sa.dst_col_stride,
+    };
+}
+
+fn attentionStoreParams(att: anytype, sa: anytype) AttentionStoreParams {
+    return .{
+        .d_head = att.d_head,
+        .seq_q = att.seq_q,
+        .seq_kv = att.seq_kv,
+        .scale = att.scale,
+        .q_off = att.q_off,
+        .k_off = att.k_off,
+        .v_off = att.v_off,
+        .mask_off = att.mask_off,
+        .dst_off = att.dst_off,
+        .q_rs = att.q_rs,
+        .q_cs = att.q_cs,
+        .k_rs = att.k_rs,
+        .k_cs = att.k_cs,
+        .v_rs = att.v_rs,
+        .v_cs = att.v_cs,
+        .mask_rs = att.mask_rs,
+        .mask_cs = att.mask_cs,
+        .dst_rs = att.dst_rs,
+        .dst_cs = att.dst_cs,
+        .slice_dst_offset = sa.dst_offset,
+        .slice_dst_row_stride = sa.dst_row_stride,
+        .slice_dst_col_stride = sa.dst_col_stride,
+    };
+}
+
 fn canEncodeAttention(att: anytype) bool {
     return att.seq_q >= 1 and
         att.seq_kv <= 4096 and
@@ -1974,6 +2252,8 @@ pub const MetalBackend = struct {
     slice_assign_batch_pipeline: *anyopaque,
     rmsnorm_scale_pipeline: *anyopaque,
     attention_pipeline: *anyopaque,
+    attention_slice_assign_pipeline: *anyopaque,
+    attention_store_pipeline: *anyopaque,
     attention_batch_pipeline: *anyopaque,
     compute_pipeline: *anyopaque,
     elementwise_batch8_pipeline: *anyopaque,
@@ -2027,6 +2307,10 @@ pub const MetalBackend = struct {
         errdefer c.mtl_release(rmsnorm_scale_pipeline);
         const attention_pipeline = c.mtl_create_pipeline(device, library, "attention_f32") orelse return error.PipelineCreateFailed;
         errdefer c.mtl_release(attention_pipeline);
+        const attention_slice_assign_pipeline = c.mtl_create_pipeline(device, library, "attention_slice_assign_f32") orelse return error.PipelineCreateFailed;
+        errdefer c.mtl_release(attention_slice_assign_pipeline);
+        const attention_store_pipeline = c.mtl_create_pipeline(device, library, "attention_store_f32") orelse return error.PipelineCreateFailed;
+        errdefer c.mtl_release(attention_store_pipeline);
         const attention_batch_pipeline = c.mtl_create_pipeline(device, library, "attention_batch_f32") orelse return error.PipelineCreateFailed;
         errdefer c.mtl_release(attention_batch_pipeline);
         const compute_pipeline = c.mtl_create_pipeline(device, library, "compute_f32") orelse return error.PipelineCreateFailed;
@@ -2055,6 +2339,8 @@ pub const MetalBackend = struct {
             .slice_assign_batch_pipeline = slice_assign_batch_pipeline,
             .rmsnorm_scale_pipeline = rmsnorm_scale_pipeline,
             .attention_pipeline = attention_pipeline,
+            .attention_slice_assign_pipeline = attention_slice_assign_pipeline,
+            .attention_store_pipeline = attention_store_pipeline,
             .attention_batch_pipeline = attention_batch_pipeline,
             .compute_pipeline = compute_pipeline,
             .elementwise_batch8_pipeline = elementwise_batch8_pipeline,
@@ -2069,6 +2355,8 @@ pub const MetalBackend = struct {
         c.mtl_release(self.elementwise_batch8_pipeline);
         c.mtl_release(self.compute_pipeline);
         c.mtl_release(self.attention_batch_pipeline);
+        c.mtl_release(self.attention_store_pipeline);
+        c.mtl_release(self.attention_slice_assign_pipeline);
         c.mtl_release(self.attention_pipeline);
         c.mtl_release(self.rmsnorm_scale_pipeline);
         c.mtl_release(self.slice_assign_batch_pipeline);
@@ -2968,6 +3256,59 @@ const CompiledProgram = struct {
         self.encodeTyped(AttentionParams, self.backend.attention_pipeline, &buffers, attentionParams(att), 5, .{ .gx = att.seq_q }, WG_SIZE);
     }
 
+    fn encodeAttentionSliceAssign(self: *CompiledProgram, sa: anytype, att: anytype) bool {
+        const operand = program_mod.attentionSliceAssignOperand(sa, att) orelse return false;
+        if (!canEncodeAttention(att)) return false;
+
+        var buffers = [_]DeviceBuffer{
+            self.device_bufs[att.q],
+            self.device_bufs[att.k],
+            self.device_bufs[att.v],
+            self.device_bufs[att.mask],
+            self.device_bufs[att.dst],
+            self.device_bufs[sa.src],
+            self.device_bufs[sa.dst],
+        };
+        var params = attentionSliceAssignParams(att, sa);
+        switch (operand) {
+            .q => {
+                buffers[0] = self.device_bufs[sa.src];
+                params.q_off = sa.src_offset;
+                params.q_rs = sa.src_row_stride;
+                params.q_cs = sa.src_col_stride;
+            },
+            .k => {
+                buffers[1] = self.device_bufs[sa.src];
+                params.k_off = sa.src_offset;
+                params.k_rs = sa.src_row_stride;
+                params.k_cs = sa.src_col_stride;
+            },
+            .v => {
+                buffers[2] = self.device_bufs[sa.src];
+                params.v_off = sa.src_offset;
+                params.v_rs = sa.src_row_stride;
+                params.v_cs = sa.src_col_stride;
+            },
+        }
+        self.encodeTyped(AttentionSliceAssignParams, self.backend.attention_slice_assign_pipeline, &buffers, params, 7, .{ .gx = att.seq_q }, WG_SIZE);
+        return true;
+    }
+
+    fn encodeAttentionSliceStore(self: *CompiledProgram, att: anytype, sa: anytype) bool {
+        if (!program_mod.attentionSliceStoreCompatible(att, sa)) return false;
+        if (!canEncodeAttention(att)) return false;
+        const buffers = [_]DeviceBuffer{
+            self.device_bufs[att.q],
+            self.device_bufs[att.k],
+            self.device_bufs[att.v],
+            self.device_bufs[att.mask],
+            self.device_bufs[att.dst],
+            self.device_bufs[sa.dst],
+        };
+        self.encodeTyped(AttentionStoreParams, self.backend.attention_store_pipeline, &buffers, attentionStoreParams(att, sa), 6, .{ .gx = att.seq_q }, WG_SIZE);
+        return true;
+    }
+
     fn attentionBatchCompatible(first: anytype, next: anytype) bool {
         return program_mod.attentionBatchCompatible(first, next);
     }
@@ -3269,6 +3610,36 @@ const CompiledProgram = struct {
             .op => false,
             .projection_group => self.tryEncodeProjectionCommand(ops, command),
             .projection_chain => self.tryEncodeProjectionChainCommand(ops, command),
+            .attention_chain => blk: {
+                if (command.anchor_count != 1 or command.sidecar_count != 1) break :blk false;
+                const att_idx = command.indices[0];
+                const sa_idx = command.sidecar_indices[0] orelse break :blk false;
+                if (att_idx >= ops.len or sa_idx >= ops.len) break :blk false;
+                const sa = switch (ops[sa_idx]) {
+                    .slice_assign => |sa| sa,
+                    else => break :blk false,
+                };
+                const att = switch (ops[att_idx]) {
+                    .attention => |att| att,
+                    else => break :blk false,
+                };
+                break :blk self.encodeAttentionSliceAssign(sa, att);
+            },
+            .attention_store_chain => blk: {
+                if (command.anchor_count != 1 or command.sidecar_count != 1) break :blk false;
+                const att_idx = command.indices[0];
+                const sa_idx = command.sidecar_indices[0] orelse break :blk false;
+                if (att_idx >= ops.len or sa_idx >= ops.len) break :blk false;
+                const att = switch (ops[att_idx]) {
+                    .attention => |att| att,
+                    else => break :blk false,
+                };
+                const sa = switch (ops[sa_idx]) {
+                    .slice_assign => |sa| sa,
+                    else => break :blk false,
+                };
+                break :blk self.encodeAttentionSliceStore(att, sa);
+            },
             .attention_batch => blk: {
                 const n: usize = @intCast(command.op_count);
                 if (self.attentionBatchRunLen(ops[start..]) < n) break :blk false;
@@ -3339,7 +3710,10 @@ const CompiledProgram = struct {
         };
 
         if (!encoded) return 0;
-        if (command.kind != .projection_group and command.kind != .elementwise_batch and command.kind != .attention_group and command.kind != .movement_group) {
+        if (command.kind == .attention_store_chain) {
+            const record_indices = [_]usize{ command.indices[0], command.sidecar_indices[0] orelse command.indices[0] };
+            self.recordRegionFusedRunFromIndices(ops, record_indices[0..], @intCast(nowNs() - t0));
+        } else if (command.kind != .projection_group and command.kind != .elementwise_batch and command.kind != .attention_group and command.kind != .movement_group) {
             self.recordRegionFusedRun(ops[start..end], @intCast(nowNs() - t0));
         }
         program_mod.markProgramCommandUsed(skipped, command);
@@ -4597,6 +4971,134 @@ test "metal backend region batches attention heads" {
         lo * 60 + hi * 80,
     };
     for (expected, got) |want, actual| {
+        try std.testing.expectApproxEqAbs(want, actual, 1e-4);
+    }
+
+    const rt = be.getRuntimeProfile(handle).?;
+    try std.testing.expectEqual(@as(u64, 9), rt.backend_op_count);
+    try std.testing.expectEqual(@as(u64, 0), rt.fallback_op_count);
+    try std.testing.expectEqual(@as(u64, 8), rt.backend_dispatch_count);
+}
+
+test "metal backend fuses attention output store chains" {
+    var metal = MetalBackend.init() catch |err| switch (err) {
+        error.MetalNotAvailable => return,
+        else => return err,
+    };
+    defer metal.deinit();
+    metal.setRegionProgramDispatch(true);
+    const be = metal.backend();
+
+    var q_input = [_]f32{ 1, 0, 0, 1 };
+    var q_out = [_]f32{0} ** 4;
+    var k_cache = [_]f32{ 1, 0, 0, 1 };
+    var v_cache = [_]f32{ 10, 20, 30, 40 };
+    var mask = [_]f32{ 0, 0 };
+    var dst = [_]f32{0} ** 2;
+    var slice_dst = [_]f32{ -1, -1, -1, -1 };
+    const qdata = [_]i8{
+        1, 0, 0, 0,
+        0, 1, 0, 0,
+        0, 0, 1, 0,
+        0, 0, 0, 1,
+    };
+    const scales = [_]f32{ 1, 1, 1, 1 };
+    const qweights = [_]backend_mod.QuantizedWeightUpload{.{ .data = &qdata, .scales = &scales, .rows = 4, .cols = 4, .block_size = 4 }};
+
+    var ops: [9]backend_mod.DeviceOp = undefined;
+    for (ops[0..7]) |*op| {
+        op.* = .{ .qmatmul = .{
+            .dst = 1,
+            .input = 0,
+            .weight_idx = 0,
+            .M = 1,
+            .N = 4,
+            .K = 4,
+        } };
+    }
+    ops[7] = .{ .attention = .{
+        .dst = 5,
+        .q = 0,
+        .k = 2,
+        .v = 3,
+        .mask = 4,
+        .has_mask = true,
+        .d_head = 2,
+        .seq_q = 1,
+        .seq_kv = 2,
+        .scale = 1,
+        .q_off = 0,
+        .k_off = 0,
+        .v_off = 0,
+        .mask_off = 0,
+        .dst_off = 0,
+        .q_rs = 1,
+        .q_cs = 2,
+        .k_rs = 1,
+        .k_cs = 2,
+        .v_rs = 1,
+        .v_cs = 2,
+        .mask_rs = 1,
+        .mask_cs = 2,
+        .dst_rs = 1,
+        .dst_cs = 2,
+    } };
+    ops[8] = .{ .slice_assign = .{
+        .dst = 6,
+        .src = 5,
+        .rows = 2,
+        .cols = 1,
+        .dst_base_offset = 0,
+        .dst_offset = 2,
+        .dst_row_stride = 1,
+        .dst_col_stride = 4,
+        .src_offset = 0,
+        .src_row_stride = 1,
+        .src_col_stride = 2,
+        .patch_stride = 4,
+    } };
+
+    const buf_sizes = [_]usize{ 4, 4, 4, 4, 2, 2, 4 };
+    const uploads = [_]backend_mod.ProgramIO{
+        .{ .buf_idx = 0, .host_ptr = @ptrCast(&q_input), .size = 4 * 4 },
+        .{ .buf_idx = 1, .host_ptr = @ptrCast(&q_out), .size = 4 * 4 },
+        .{ .buf_idx = 2, .host_ptr = @ptrCast(&k_cache), .size = 4 * 4 },
+        .{ .buf_idx = 3, .host_ptr = @ptrCast(&v_cache), .size = 4 * 4 },
+        .{ .buf_idx = 4, .host_ptr = @ptrCast(&mask), .size = 2 * 4 },
+        .{ .buf_idx = 5, .host_ptr = @ptrCast(&dst), .size = 2 * 4 },
+        .{ .buf_idx = 6, .host_ptr = @ptrCast(&slice_dst), .size = 4 * 4 },
+    };
+    const program = backend_mod.DeviceProgram{
+        .ops = &ops,
+        .n_buffers = 7,
+        .buffer_sizes = &buf_sizes,
+        .initial_uploads = &uploads,
+        .qweights = &qweights,
+    };
+
+    const handle = be.compileProgram(program) orelse return error.CompileFailed;
+    defer be.freeProgram(handle);
+
+    var got_dst: [2]f32 = undefined;
+    var got_slice: [4]f32 = undefined;
+    var out = [_]backend_mod.ProgramIO{
+        .{ .buf_idx = 5, .host_ptr = @ptrCast(&got_dst), .size = 2 * 4 },
+        .{ .buf_idx = 6, .host_ptr = @ptrCast(&got_slice), .size = 4 * 4 },
+    };
+    be.executeProgram(handle, &.{}, &out);
+
+    const hi: f32 = @exp(@as(f32, 1.0)) / (@exp(@as(f32, 1.0)) + 1.0);
+    const lo: f32 = 1.0 / (@exp(@as(f32, 1.0)) + 1.0);
+    const expected = [_]f32{
+        hi * 10 + lo * 30,
+        hi * 20 + lo * 40,
+    };
+    for (expected, got_dst) |want, actual| {
+        try std.testing.expectApproxEqAbs(want, actual, 1e-4);
+    }
+    try std.testing.expectEqual(@as(f32, -1), got_slice[0]);
+    try std.testing.expectEqual(@as(f32, -1), got_slice[1]);
+    for (expected, got_slice[2..4]) |want, actual| {
         try std.testing.expectApproxEqAbs(want, actual, 1e-4);
     }
 

--- a/src/backend/metal.zig
+++ b/src/backend/metal.zig
@@ -2769,13 +2769,8 @@ const CompiledProgram = struct {
     }
 
     fn canFuseQMatmulElementwise(self: *CompiledProgram, q: anytype, e: anytype) bool {
-        if (q.M == 1 or @as(usize, q.weight_idx) >= self.qweight_views.len) return false;
-        if (e.op != .add and e.op != .mul) return false;
-        if (e.n != q.M * q.N) return false;
-        const dst_row_stride = if (q.dst_row_stride != 0) q.dst_row_stride else q.N;
-        if (dst_row_stride != q.N) return false;
-        return (e.src0 == q.dst and e.src0_offset == q.dst_offset) or
-            (e.src1 == q.dst and e.src1_offset == q.dst_offset);
+        if (@as(usize, q.weight_idx) >= self.qweight_views.len) return false;
+        return program_mod.qmatmulElementwiseSidecarCompatible(q, e);
     }
 
     fn encodeQMatmulElementwise(self: *CompiledProgram, q: anytype, e: anytype) bool {
@@ -2812,12 +2807,9 @@ const CompiledProgram = struct {
     }
 
     fn canFuseQMatmulFusedElementwise(self: *CompiledProgram, q: anytype, fe: anytype) bool {
-        if (q.M == 1 or @as(usize, q.weight_idx) >= self.qweight_views.len) return false;
+        if (@as(usize, q.weight_idx) >= self.qweight_views.len) return false;
         if (!canEncodeFusedElementwise(fe)) return false;
-        if (fe.n != q.M * q.N) return false;
-        const dst_row_stride = if (q.dst_row_stride != 0) q.dst_row_stride else q.N;
-        if (dst_row_stride != q.N) return false;
-        return fe.src == q.dst and fe.src_offset == q.dst_offset;
+        return program_mod.qmatmulFusedElementwiseSidecarCompatible(q, fe);
     }
 
     fn encodeQMatmulFusedElementwise(self: *CompiledProgram, q: anytype, fe: anytype) bool {
@@ -3089,6 +3081,23 @@ const CompiledProgram = struct {
         }
     }
 
+    fn tryEncodeProjectionChainCommand(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, command: program_mod.ProgramCommand) bool {
+        if (command.anchor_count != 1 or command.sidecar_count != 1) return false;
+        const anchor_idx = command.indices[0];
+        const sidecar_idx = command.sidecar_indices[0] orelse return false;
+        if (anchor_idx >= ops.len or sidecar_idx >= ops.len) return false;
+        const q = switch (ops[anchor_idx]) {
+            .qmatmul => |q| q,
+            else => return false,
+        };
+        return switch (ops[sidecar_idx]) {
+            .slice_assign => |sa| if (q.M == 1) self.encodeQMatvecSliceAssign(q, sa) else self.encodeQMatmulSliceAssign(q, sa),
+            .elementwise => |e| self.encodeQMatmulElementwise(q, e),
+            .fused_elementwise => |fe| self.encodeQMatmulFusedElementwise(q, fe),
+            else => false,
+        };
+    }
+
     fn tryEncodeElementwiseBatchRun(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, start: usize, skipped: []bool) bool {
         if (start >= ops.len or skipped[start]) return false;
         const first = switch (ops[start]) {
@@ -3209,6 +3218,7 @@ const CompiledProgram = struct {
         const encoded = switch (command.kind) {
             .op => false,
             .projection_group => self.tryEncodeProjectionCommand(ops, command),
+            .projection_chain => self.tryEncodeProjectionChainCommand(ops, command),
             .attention_batch => blk: {
                 const n: usize = @intCast(command.op_count);
                 if (self.attentionBatchRunLen(ops[start..]) < n) break :blk false;

--- a/src/backend/metal.zig
+++ b/src/backend/metal.zig
@@ -601,6 +601,79 @@ const shader_source =
     \\    dst[dst_col + (i + p.half_d) * p.dst_row_stride] = y_hi;
     \\}
     \\
+    \\struct RopeSliceAssignBatchParams {
+    \\    uint n_ops; uint max_n;
+    \\    uint half_d[MAX_ROPE_BATCH];
+    \\    uint seq_len[MAX_ROPE_BATCH];
+    \\    uint src_off[MAX_ROPE_BATCH];
+    \\    uint cs_off[MAX_ROPE_BATCH];
+    \\    uint src_rs[MAX_ROPE_BATCH];
+    \\    uint src_cs[MAX_ROPE_BATCH];
+    \\    uint cs_cs[MAX_ROPE_BATCH];
+    \\    uint dst_offset[MAX_ROPE_BATCH];
+    \\    uint dst_row_stride[MAX_ROPE_BATCH];
+    \\    uint dst_col_stride[MAX_ROPE_BATCH];
+    \\};
+    \\
+    \\kernel void rope_slice_assign_batch_f32(
+    \\    device const float* src0    [[buffer(0)]],
+    \\    device const float* src1    [[buffer(1)]],
+    \\    device const float* src2    [[buffer(2)]],
+    \\    device const float* src3    [[buffer(3)]],
+    \\    device const float* src4    [[buffer(4)]],
+    \\    device const float* src5    [[buffer(5)]],
+    \\    device const float* src6    [[buffer(6)]],
+    \\    device const float* src7    [[buffer(7)]],
+    \\    device const float* src8    [[buffer(8)]],
+    \\    device const float* src9    [[buffer(9)]],
+    \\    device const float* src10   [[buffer(10)]],
+    \\    device const float* src11   [[buffer(11)]],
+    \\    device const float* src12   [[buffer(12)]],
+    \\    device const float* src13   [[buffer(13)]],
+    \\    device const float* src14   [[buffer(14)]],
+    \\    device const float* src15   [[buffer(15)]],
+    \\    device const float* cos_sin [[buffer(16)]],
+    \\    device float*       dst     [[buffer(17)]],
+    \\    constant RopeSliceAssignBatchParams& p [[buffer(18)]],
+    \\    uint2 gid [[thread_position_in_grid]]
+    \\) {
+    \\    uint local = gid.x;
+    \\    uint slot = gid.y;
+    \\    if (slot >= p.n_ops || local >= p.half_d[slot] * p.seq_len[slot]) return;
+    \\    uint col = local / p.half_d[slot];
+    \\    uint i   = local % p.half_d[slot];
+    \\    device const float* src = src0;
+    \\    switch (slot) {
+    \\        case 1: src = src1; break;
+    \\        case 2: src = src2; break;
+    \\        case 3: src = src3; break;
+    \\        case 4: src = src4; break;
+    \\        case 5: src = src5; break;
+    \\        case 6: src = src6; break;
+    \\        case 7: src = src7; break;
+    \\        case 8: src = src8; break;
+    \\        case 9: src = src9; break;
+    \\        case 10: src = src10; break;
+    \\        case 11: src = src11; break;
+    \\        case 12: src = src12; break;
+    \\        case 13: src = src13; break;
+    \\        case 14: src = src14; break;
+    \\        case 15: src = src15; break;
+    \\        default: break;
+    \\    }
+    \\
+    \\    float cos_val = cos_sin[p.cs_off[slot] + col * p.cs_cs[slot] + i];
+    \\    float sin_val = cos_sin[p.cs_off[slot] + col * p.cs_cs[slot] + p.half_d[slot] + i];
+    \\    float x_lo = src[p.src_off[slot] + col * p.src_cs[slot] + i * p.src_rs[slot]];
+    \\    float x_hi = src[p.src_off[slot] + col * p.src_cs[slot] + (i + p.half_d[slot]) * p.src_rs[slot]];
+    \\    float y_lo = x_lo * cos_val - x_hi * sin_val;
+    \\    float y_hi = x_hi * cos_val + x_lo * sin_val;
+    \\
+    \\    uint dst_col = p.dst_offset[slot] + col * p.dst_col_stride[slot];
+    \\    dst[dst_col + i * p.dst_row_stride[slot]] = y_lo;
+    \\    dst[dst_col + (i + p.half_d[slot]) * p.dst_row_stride[slot]] = y_hi;
+    \\}
+    \\
     \\// ── QMatmul with an attached strided slice store ────────
     \\
     \\struct QMatmulSliceAssignParams {
@@ -2107,6 +2180,21 @@ const RopeSliceAssignParams = extern struct {
     dst_col_stride: u32,
 };
 
+const RopeSliceAssignBatchParams = extern struct {
+    n_ops: u32,
+    max_n: u32,
+    half_d: [MAX_ROPE_BATCH]u32,
+    seq_len: [MAX_ROPE_BATCH]u32,
+    src_off: [MAX_ROPE_BATCH]u32,
+    cs_off: [MAX_ROPE_BATCH]u32,
+    src_rs: [MAX_ROPE_BATCH]u32,
+    src_cs: [MAX_ROPE_BATCH]u32,
+    cs_cs: [MAX_ROPE_BATCH]u32,
+    dst_offset: [MAX_ROPE_BATCH]u32,
+    dst_row_stride: [MAX_ROPE_BATCH]u32,
+    dst_col_stride: [MAX_ROPE_BATCH]u32,
+};
+
 const QMatmulSliceAssignParams = extern struct {
     M: u32,
     N: u32,
@@ -2732,6 +2820,7 @@ pub const MetalBackend = struct {
     rope_pipeline: *anyopaque,
     rope_batch_pipeline: *anyopaque,
     rope_slice_assign_pipeline: *anyopaque,
+    rope_slice_assign_batch_pipeline: *anyopaque,
     qmatmul_slice_assign_pipeline: *anyopaque,
     qmatmul_elementwise_pipeline: *anyopaque,
     qmatmul_fused_ew_pipeline: *anyopaque,
@@ -2783,6 +2872,8 @@ pub const MetalBackend = struct {
         errdefer c.mtl_release(rope_batch_pipeline);
         const rope_slice_assign_pipeline = c.mtl_create_pipeline(device, library, "rope_slice_assign_f32") orelse return error.PipelineCreateFailed;
         errdefer c.mtl_release(rope_slice_assign_pipeline);
+        const rope_slice_assign_batch_pipeline = c.mtl_create_pipeline(device, library, "rope_slice_assign_batch_f32") orelse return error.PipelineCreateFailed;
+        errdefer c.mtl_release(rope_slice_assign_batch_pipeline);
         const qmatmul_slice_assign_pipeline = c.mtl_create_pipeline(device, library, "qmatmul_slice_assign_f32") orelse return error.PipelineCreateFailed;
         errdefer c.mtl_release(qmatmul_slice_assign_pipeline);
         const qmatmul_elementwise_pipeline = c.mtl_create_pipeline(device, library, "qmatmul_elementwise_f32") orelse return error.PipelineCreateFailed;
@@ -2828,6 +2919,7 @@ pub const MetalBackend = struct {
             .rope_pipeline = rope_pipeline,
             .rope_batch_pipeline = rope_batch_pipeline,
             .rope_slice_assign_pipeline = rope_slice_assign_pipeline,
+            .rope_slice_assign_batch_pipeline = rope_slice_assign_batch_pipeline,
             .qmatmul_slice_assign_pipeline = qmatmul_slice_assign_pipeline,
             .qmatmul_elementwise_pipeline = qmatmul_elementwise_pipeline,
             .qmatmul_fused_ew_pipeline = qmatmul_fused_ew_pipeline,
@@ -2866,6 +2958,7 @@ pub const MetalBackend = struct {
         c.mtl_release(self.qmatmul_fused_ew_pipeline);
         c.mtl_release(self.qmatmul_elementwise_pipeline);
         c.mtl_release(self.qmatmul_slice_assign_pipeline);
+        c.mtl_release(self.rope_slice_assign_batch_pipeline);
         c.mtl_release(self.rope_slice_assign_pipeline);
         c.mtl_release(self.rope_batch_pipeline);
         c.mtl_release(self.rope_pipeline);
@@ -3484,6 +3577,73 @@ const CompiledProgram = struct {
             .dst_col_stride = sa.dst_col_stride,
         };
         self.encodeTyped(RopeSliceAssignParams, self.backend.rope_slice_assign_pipeline, &buffers, params, 3, .{ .gx = linearGrid(rr.half_d * rr.seq_len) }, WG_SIZE);
+    }
+
+    fn canEncodeRopeStoreGroupCommand(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, command: program_mod.ProgramCommand) bool {
+        _ = self;
+        if (command.anchor_count < 2 or command.anchor_count > MAX_ROPE_BATCH) return false;
+        if (command.sidecar_count != command.anchor_count) return false;
+        const first_rope_idx = command.indices[0];
+        const first_sa_idx = command.sidecar_indices[0] orelse return false;
+        if (first_rope_idx >= ops.len or first_sa_idx >= ops.len) return false;
+        const first_rope = switch (ops[first_rope_idx]) {
+            .rope => |rr| rr,
+            else => return false,
+        };
+        const first_sa = switch (ops[first_sa_idx]) {
+            .slice_assign => |sa| sa,
+            else => return false,
+        };
+        if (!program_mod.ropeSliceAssignCompatible(first_rope, first_sa)) return false;
+
+        var i: usize = 1;
+        while (i < command.anchor_count) : (i += 1) {
+            const rope_idx = command.indices[i];
+            const sa_idx = command.sidecar_indices[i] orelse return false;
+            if (rope_idx >= ops.len or sa_idx >= ops.len) return false;
+            const rr = switch (ops[rope_idx]) {
+                .rope => |rr| rr,
+                else => return false,
+            };
+            const sa = switch (ops[sa_idx]) {
+                .slice_assign => |sa| sa,
+                else => return false,
+            };
+            if (!program_mod.ropeSliceAssignCompatible(rr, sa)) return false;
+            if (!program_mod.ropeStoreGroupCompatible(first_rope, first_sa, rr, sa)) return false;
+        }
+        return true;
+    }
+
+    fn encodeRopeStoreGroupCommand(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, command: program_mod.ProgramCommand) void {
+        const first_rope = ops[command.indices[0]].rope;
+        const first_sa = ops[command.sidecar_indices[0].?].slice_assign;
+        var buffers: [MAX_ROPE_BATCH + 2]DeviceBuffer = undefined;
+        for (buffers[0..MAX_ROPE_BATCH]) |*buffer| {
+            buffer.* = self.device_bufs[first_rope.src];
+        }
+        buffers[MAX_ROPE_BATCH] = self.device_bufs[first_rope.cos_sin];
+        buffers[MAX_ROPE_BATCH + 1] = self.device_bufs[first_sa.dst];
+        var params = std.mem.zeroes(RopeSliceAssignBatchParams);
+        params.n_ops = command.anchor_count;
+        var i: usize = 0;
+        while (i < command.anchor_count) : (i += 1) {
+            const rr = ops[command.indices[i]].rope;
+            const sa = ops[command.sidecar_indices[i].?].slice_assign;
+            buffers[i] = self.device_bufs[rr.src];
+            params.half_d[i] = rr.half_d;
+            params.seq_len[i] = rr.seq_len;
+            params.src_off[i] = rr.src_off;
+            params.cs_off[i] = rr.cs_off;
+            params.src_rs[i] = rr.src_rs;
+            params.src_cs[i] = rr.src_cs;
+            params.cs_cs[i] = rr.cs_cs;
+            params.dst_offset[i] = sa.dst_offset;
+            params.dst_row_stride[i] = sa.dst_row_stride;
+            params.dst_col_stride[i] = sa.dst_col_stride;
+            params.max_n = @max(params.max_n, rr.half_d * rr.seq_len);
+        }
+        self.encodeTyped(RopeSliceAssignBatchParams, self.backend.rope_slice_assign_batch_pipeline, &buffers, params, MAX_ROPE_BATCH + 2, .{ .gx = linearGrid(params.max_n), .gy = command.anchor_count }, WG_SIZE);
     }
 
     fn canFuseQMatvecSliceAssign(self: *CompiledProgram, q: anytype, sa: anytype) bool {
@@ -4356,6 +4516,11 @@ const CompiledProgram = struct {
                 self.encodeRopeBatch(ops[start..], n);
                 break :blk true;
             },
+            .rope_store_group => blk: {
+                if (!self.canEncodeRopeStoreGroupCommand(ops, command)) break :blk false;
+                self.encodeRopeStoreGroupCommand(ops, command);
+                break :blk true;
+            },
             .movement_batch => blk: {
                 const n: usize = @intCast(command.op_count);
                 if (sliceAssignBatchRunLen(ops[start..]) < n) break :blk false;
@@ -4410,7 +4575,7 @@ const CompiledProgram = struct {
             self.runtime_profile.recordProgramCommandFailed(command.kind);
             return false;
         }
-        if (command.kind == .attention_store_chain or command.kind == .attention_store_group or command.kind == .rope_attention_store_chain or command.kind == .rope_attention_store_group) {
+        if (command.kind == .rope_store_group or command.kind == .attention_store_chain or command.kind == .attention_store_group or command.kind == .rope_attention_store_chain or command.kind == .rope_attention_store_group) {
             var record_indices: [program_mod.max_projection_group_anchors * 2]usize = undefined;
             var record_count: usize = 0;
             for (command.anchorIndices()) |idx| appendCommandIndex(&record_indices, &record_count, idx);
@@ -4447,6 +4612,7 @@ const CompiledProgram = struct {
             },
             .projection_chain,
             .projection_group,
+            .rope_store_group,
             .attention_chain,
             .attention_store_chain,
             .attention_store_group,
@@ -5967,6 +6133,127 @@ test "metal backend fuses rope attention output store chains" {
     const rt = be.getRuntimeProfile(handle).?;
     try std.testing.expectEqual(@as(u64, 0), rt.fallback_op_count);
     try std.testing.expectEqual(@as(u64, 1), rt.program_command_counts[@intFromEnum(program_mod.ProgramCommandKind.rope_attention_store_chain)]);
+}
+
+test "metal backend groups rope slice stores" {
+    var metal = MetalBackend.init() catch |err| switch (err) {
+        error.MetalNotAvailable => return,
+        else => return err,
+    };
+    defer metal.deinit();
+    metal.setRegionProgramDispatch(true);
+    const be = metal.backend();
+
+    var src0 = [_]f32{ 1, 0 };
+    var src1 = [_]f32{ 0, 1 };
+    var cos_sin = [_]f32{ 1, 0 };
+    var dst = [_]f32{ -1, -1, -1, -1 };
+    var scratch = [_]f32{ -9, -9 };
+    var q_out = [_]f32{0} ** 2;
+    const qdata = [_]i8{
+        1, 0,
+        0, 1,
+    };
+    const scales = [_]f32{ 1, 1 };
+    const qweights = [_]backend_mod.QuantizedWeightUpload{.{ .data = &qdata, .scales = &scales, .rows = 2, .cols = 2, .block_size = 2 }};
+
+    var ops: [11]backend_mod.DeviceOp = undefined;
+    for (ops[0..7]) |*op| {
+        op.* = .{ .qmatmul = .{
+            .dst = 4,
+            .input = 0,
+            .weight_idx = 0,
+            .M = 1,
+            .N = 2,
+            .K = 2,
+        } };
+    }
+    ops[7] = .{ .rope = .{
+        .dst = 3,
+        .src = 0,
+        .cos_sin = 1,
+        .half_d = 1,
+        .seq_len = 1,
+        .src_off = 0,
+        .cs_off = 0,
+        .dst_off = 0,
+        .src_rs = 1,
+        .src_cs = 2,
+        .cs_cs = 1,
+    } };
+    ops[8] = .{ .slice_assign = .{
+        .dst = 2,
+        .src = 3,
+        .rows = 2,
+        .cols = 1,
+        .dst_base_offset = 0,
+        .dst_offset = 0,
+        .dst_row_stride = 1,
+        .dst_col_stride = 2,
+        .src_offset = 0,
+        .src_row_stride = 1,
+        .src_col_stride = 2,
+        .patch_stride = 2,
+    } };
+    ops[9] = .{ .rope = .{
+        .dst = 3,
+        .src = 5,
+        .cos_sin = 1,
+        .half_d = 1,
+        .seq_len = 1,
+        .src_off = 0,
+        .cs_off = 0,
+        .dst_off = 0,
+        .src_rs = 1,
+        .src_cs = 2,
+        .cs_cs = 1,
+    } };
+    ops[10] = .{ .slice_assign = .{
+        .dst = 2,
+        .src = 3,
+        .rows = 2,
+        .cols = 1,
+        .dst_base_offset = 0,
+        .dst_offset = 2,
+        .dst_row_stride = 1,
+        .dst_col_stride = 2,
+        .src_offset = 0,
+        .src_row_stride = 1,
+        .src_col_stride = 2,
+        .patch_stride = 2,
+    } };
+    const buf_sizes = [_]usize{ 2, 2, 4, 2, 2, 2 };
+    const uploads = [_]backend_mod.ProgramIO{
+        .{ .buf_idx = 0, .host_ptr = @ptrCast(&src0), .size = 2 * 4 },
+        .{ .buf_idx = 1, .host_ptr = @ptrCast(&cos_sin), .size = 2 * 4 },
+        .{ .buf_idx = 2, .host_ptr = @ptrCast(&dst), .size = 4 * 4 },
+        .{ .buf_idx = 3, .host_ptr = @ptrCast(&scratch), .size = 2 * 4 },
+        .{ .buf_idx = 4, .host_ptr = @ptrCast(&q_out), .size = 2 * 4 },
+        .{ .buf_idx = 5, .host_ptr = @ptrCast(&src1), .size = 2 * 4 },
+    };
+    const program = backend_mod.DeviceProgram{
+        .ops = &ops,
+        .n_buffers = 6,
+        .buffer_sizes = &buf_sizes,
+        .initial_uploads = &uploads,
+        .qweights = &qweights,
+    };
+
+    const handle = be.compileProgram(program) orelse return error.CompileFailed;
+    defer be.freeProgram(handle);
+
+    var got: [4]f32 = undefined;
+    var out = [_]backend_mod.ProgramIO{.{ .buf_idx = 2, .host_ptr = @ptrCast(&got), .size = 4 * 4 }};
+    be.executeProgram(handle, &.{}, &out);
+
+    const expected = [_]f32{ 1, 0, 0, 1 };
+    for (expected, got) |want, actual| {
+        try std.testing.expectApproxEqAbs(want, actual, 1e-5);
+    }
+
+    const rt = be.getRuntimeProfile(handle).?;
+    try std.testing.expectEqual(@as(u64, 0), rt.fallback_op_count);
+    try std.testing.expectEqual(@as(u64, 1), rt.program_command_counts[@intFromEnum(program_mod.ProgramCommandKind.rope_store_group)]);
 }
 
 test "metal backend groups rope attention output stores with aliased scratch" {

--- a/src/backend/metal.zig
+++ b/src/backend/metal.zig
@@ -896,6 +896,7 @@ const shader_source =
     \\
     \\constant uint MAX_SEQ = 4096;
     \\constant uint MAX_ATTENTION_BATCH_HEADS = 16;
+    \\constant uint MAX_ATTENTION_STORE_BATCH_HEADS = 4;
     \\
     \\// One threadgroup per query position. Decode is the seq_q=1 case.
     \\kernel void attention_f32(
@@ -1130,6 +1131,105 @@ const shader_source =
     \\    }
     \\}
     \\
+    \\struct AttentionRopeStoreParams {
+    \\    uint d_head; uint seq_q; uint seq_kv;
+    \\    float scale;
+    \\    uint rope_half_d; uint rope_src_off; uint rope_cs_off;
+    \\    uint rope_src_rs; uint rope_src_cs; uint rope_cs_cs;
+    \\    uint k_off; uint v_off; uint mask_off; uint dst_off;
+    \\    uint k_rs; uint k_cs; uint v_rs; uint v_cs;
+    \\    uint mask_rs; uint mask_cs; uint dst_rs; uint dst_cs;
+    \\    uint slice_dst_offset; uint slice_dst_row_stride; uint slice_dst_col_stride;
+    \\};
+    \\
+    \\inline float rope_q_value(
+    \\    device const float* q_src,
+    \\    device const float* cos_sin,
+    \\    constant AttentionRopeStoreParams& p,
+    \\    uint r,
+    \\    uint q_col
+    \\) {
+    \\    uint i = r;
+    \\    bool high = false;
+    \\    if (i >= p.rope_half_d) {
+    \\        i -= p.rope_half_d;
+    \\        high = true;
+    \\    }
+    \\    float cos_val = cos_sin[p.rope_cs_off + q_col * p.rope_cs_cs + i];
+    \\    float sin_val = cos_sin[p.rope_cs_off + q_col * p.rope_cs_cs + p.rope_half_d + i];
+    \\    float x_lo = q_src[p.rope_src_off + q_col * p.rope_src_cs + i * p.rope_src_rs];
+    \\    float x_hi = q_src[p.rope_src_off + q_col * p.rope_src_cs + (i + p.rope_half_d) * p.rope_src_rs];
+    \\    return high ? (x_hi * cos_val + x_lo * sin_val) : (x_lo * cos_val - x_hi * sin_val);
+    \\}
+    \\
+    \\kernel void attention_rope_store_f32(
+    \\    device const float* q_src     [[buffer(0)]],
+    \\    device const float* cos_sin   [[buffer(1)]],
+    \\    device const float* K         [[buffer(2)]],
+    \\    device const float* V         [[buffer(3)]],
+    \\    device const float* mask      [[buffer(4)]],
+    \\    device float*       dst       [[buffer(5)]],
+    \\    device float*       slice_dst [[buffer(6)]],
+    \\    constant AttentionRopeStoreParams& p [[buffer(7)]],
+    \\    uint q_col   [[threadgroup_position_in_grid]],
+    \\    uint tid     [[thread_index_in_threadgroup]]
+    \\) {
+    \\    if (q_col >= p.seq_q) return;
+    \\    const uint tg_size = 256;
+    \\
+    \\    threadgroup float scores[MAX_SEQ];
+    \\    threadgroup float scratch[256];
+    \\
+    \\    for (uint s = tid; s < p.seq_kv; s += tg_size) {
+    \\        float mv = mask[p.mask_off + s * p.mask_rs + q_col * p.mask_cs];
+    \\        if (!isfinite(mv)) { scores[s] = -INFINITY; continue; }
+    \\        float dot = 0.0f;
+    \\        for (uint r = 0; r < p.d_head; r++)
+    \\            dot += rope_q_value(q_src, cos_sin, p, r, q_col) * K[p.k_off + r * p.k_rs + s * p.k_cs];
+    \\        scores[s] = dot * p.scale + mv;
+    \\    }
+    \\    threadgroup_barrier(mem_flags::mem_threadgroup);
+    \\
+    \\    float local_max = -INFINITY;
+    \\    for (uint s = tid; s < p.seq_kv; s += tg_size)
+    \\        local_max = max(local_max, scores[s]);
+    \\    scratch[tid] = local_max;
+    \\    threadgroup_barrier(mem_flags::mem_threadgroup);
+    \\    for (uint stride = tg_size / 2; stride > 0; stride /= 2) {
+    \\        if (tid < stride) scratch[tid] = max(scratch[tid], scratch[tid + stride]);
+    \\        threadgroup_barrier(mem_flags::mem_threadgroup);
+    \\    }
+    \\    float global_max = scratch[0];
+    \\    threadgroup_barrier(mem_flags::mem_threadgroup);
+    \\
+    \\    float local_sum = 0.0f;
+    \\    for (uint s = tid; s < p.seq_kv; s += tg_size) {
+    \\        float w = (scores[s] == -INFINITY) ? 0.0f : exp(scores[s] - global_max);
+    \\        scores[s] = w;
+    \\        local_sum += w;
+    \\    }
+    \\    scratch[tid] = local_sum;
+    \\    threadgroup_barrier(mem_flags::mem_threadgroup);
+    \\    for (uint stride = tg_size / 2; stride > 0; stride /= 2) {
+    \\        if (tid < stride) scratch[tid] += scratch[tid + stride];
+    \\        threadgroup_barrier(mem_flags::mem_threadgroup);
+    \\    }
+    \\    float inv_sum = (scratch[0] > 0.0f) ? 1.0f / scratch[0] : 0.0f;
+    \\    threadgroup_barrier(mem_flags::mem_threadgroup);
+    \\
+    \\    for (uint s = tid; s < p.seq_kv; s += tg_size)
+    \\        scores[s] *= inv_sum;
+    \\    threadgroup_barrier(mem_flags::mem_threadgroup);
+    \\
+    \\    for (uint r = tid; r < p.d_head; r += tg_size) {
+    \\        float val = 0.0f;
+    \\        for (uint s = 0; s < p.seq_kv; s++)
+    \\            val += scores[s] * V[p.v_off + r * p.v_rs + s * p.v_cs];
+    \\        dst[p.dst_off + r * p.dst_rs + q_col * p.dst_cs] = val;
+    \\        slice_dst[p.slice_dst_offset + r * p.slice_dst_row_stride + q_col * p.slice_dst_col_stride] = val;
+    \\    }
+    \\}
+    \\
     \\struct AttentionBatchParams {
     \\    uint n_heads; uint d_head; uint seq_q; uint seq_kv;
     \\    float scale;
@@ -1140,6 +1240,20 @@ const shader_source =
     \\    uint dst_off[MAX_ATTENTION_BATCH_HEADS];
     \\    uint q_rs; uint q_cs; uint k_rs; uint k_cs; uint v_rs; uint v_cs;
     \\    uint mask_rs; uint mask_cs; uint dst_rs; uint dst_cs;
+    \\};
+    \\
+    \\struct AttentionStoreBatchParams {
+    \\    uint n_heads; uint d_head; uint seq_q; uint seq_kv;
+    \\    float scale;
+    \\    uint q_off[MAX_ATTENTION_STORE_BATCH_HEADS];
+    \\    uint k_off[MAX_ATTENTION_STORE_BATCH_HEADS];
+    \\    uint v_off[MAX_ATTENTION_STORE_BATCH_HEADS];
+    \\    uint mask_off[MAX_ATTENTION_STORE_BATCH_HEADS];
+    \\    uint dst_off[MAX_ATTENTION_STORE_BATCH_HEADS];
+    \\    uint slice_dst_offset[MAX_ATTENTION_STORE_BATCH_HEADS];
+    \\    uint q_rs; uint q_cs; uint k_rs; uint k_cs; uint v_rs; uint v_cs;
+    \\    uint mask_rs; uint mask_cs; uint dst_rs; uint dst_cs;
+    \\    uint slice_dst_row_stride; uint slice_dst_col_stride;
     \\};
     \\
     \\kernel void attention_batch_f32(
@@ -1213,6 +1327,115 @@ const shader_source =
     \\        for (uint s = 0; s < p.seq_kv; s++)
     \\            val += scores[s] * V[v_off + r * p.v_rs + s * p.v_cs];
     \\        dst[dst_off + r * p.dst_rs + q_col * p.dst_cs] = val;
+    \\    }
+    \\}
+    \\
+    \\kernel void attention_store_batch_f32(
+    \\    device const float* Q0         [[buffer(0)]],
+    \\    device const float* Q1         [[buffer(1)]],
+    \\    device const float* Q2         [[buffer(2)]],
+    \\    device const float* Q3         [[buffer(3)]],
+    \\    device const float* K0         [[buffer(4)]],
+    \\    device const float* K1         [[buffer(5)]],
+    \\    device const float* K2         [[buffer(6)]],
+    \\    device const float* K3         [[buffer(7)]],
+    \\    device const float* V0         [[buffer(8)]],
+    \\    device const float* V1         [[buffer(9)]],
+    \\    device const float* V2         [[buffer(10)]],
+    \\    device const float* V3         [[buffer(11)]],
+    \\    device const float* mask0      [[buffer(12)]],
+    \\    device const float* mask1      [[buffer(13)]],
+    \\    device const float* mask2      [[buffer(14)]],
+    \\    device const float* mask3      [[buffer(15)]],
+    \\    device float*       dst0       [[buffer(16)]],
+    \\    device float*       dst1       [[buffer(17)]],
+    \\    device float*       dst2       [[buffer(18)]],
+    \\    device float*       dst3       [[buffer(19)]],
+    \\    device float*       slice_dst0 [[buffer(20)]],
+    \\    device float*       slice_dst1 [[buffer(21)]],
+    \\    device float*       slice_dst2 [[buffer(22)]],
+    \\    device float*       slice_dst3 [[buffer(23)]],
+    \\    constant AttentionStoreBatchParams& p [[buffer(24)]],
+    \\    uint2 group [[threadgroup_position_in_grid]],
+    \\    uint tid     [[thread_index_in_threadgroup]]
+    \\) {
+    \\    uint q_col = group.x;
+    \\    uint head = group.y;
+    \\    if (q_col >= p.seq_q) return;
+    \\    if (head >= p.n_heads) return;
+    \\    const uint tg_size = 256;
+    \\
+    \\    device const float* Q = Q0;
+    \\    device const float* K = K0;
+    \\    device const float* V = V0;
+    \\    device const float* mask = mask0;
+    \\    device float* dst = dst0;
+    \\    device float* slice_dst = slice_dst0;
+    \\    if (head == 1) {
+    \\        Q = Q1; K = K1; V = V1; mask = mask1; dst = dst1; slice_dst = slice_dst1;
+    \\    } else if (head == 2) {
+    \\        Q = Q2; K = K2; V = V2; mask = mask2; dst = dst2; slice_dst = slice_dst2;
+    \\    } else if (head == 3) {
+    \\        Q = Q3; K = K3; V = V3; mask = mask3; dst = dst3; slice_dst = slice_dst3;
+    \\    }
+    \\
+    \\    threadgroup float scores[MAX_SEQ];
+    \\    threadgroup float scratch[256];
+    \\
+    \\    uint q_off = p.q_off[head];
+    \\    uint k_off = p.k_off[head];
+    \\    uint v_off = p.v_off[head];
+    \\    uint mask_off = p.mask_off[head];
+    \\    uint dst_off = p.dst_off[head];
+    \\    uint slice_dst_off = p.slice_dst_offset[head];
+    \\
+    \\    for (uint s = tid; s < p.seq_kv; s += tg_size) {
+    \\        float mv = mask[mask_off + s * p.mask_rs + q_col * p.mask_cs];
+    \\        if (!isfinite(mv)) { scores[s] = -INFINITY; continue; }
+    \\        float dot = 0.0f;
+    \\        for (uint r = 0; r < p.d_head; r++)
+    \\            dot += Q[q_off + r * p.q_rs + q_col * p.q_cs] * K[k_off + r * p.k_rs + s * p.k_cs];
+    \\        scores[s] = dot * p.scale + mv;
+    \\    }
+    \\    threadgroup_barrier(mem_flags::mem_threadgroup);
+    \\
+    \\    float local_max = -INFINITY;
+    \\    for (uint s = tid; s < p.seq_kv; s += tg_size)
+    \\        local_max = max(local_max, scores[s]);
+    \\    scratch[tid] = local_max;
+    \\    threadgroup_barrier(mem_flags::mem_threadgroup);
+    \\    for (uint stride = tg_size / 2; stride > 0; stride /= 2) {
+    \\        if (tid < stride) scratch[tid] = max(scratch[tid], scratch[tid + stride]);
+    \\        threadgroup_barrier(mem_flags::mem_threadgroup);
+    \\    }
+    \\    float global_max = scratch[0];
+    \\    threadgroup_barrier(mem_flags::mem_threadgroup);
+    \\
+    \\    float local_sum = 0.0f;
+    \\    for (uint s = tid; s < p.seq_kv; s += tg_size) {
+    \\        float w = (scores[s] == -INFINITY) ? 0.0f : exp(scores[s] - global_max);
+    \\        scores[s] = w;
+    \\        local_sum += w;
+    \\    }
+    \\    scratch[tid] = local_sum;
+    \\    threadgroup_barrier(mem_flags::mem_threadgroup);
+    \\    for (uint stride = tg_size / 2; stride > 0; stride /= 2) {
+    \\        if (tid < stride) scratch[tid] += scratch[tid + stride];
+    \\        threadgroup_barrier(mem_flags::mem_threadgroup);
+    \\    }
+    \\    float inv_sum = (scratch[0] > 0.0f) ? 1.0f / scratch[0] : 0.0f;
+    \\    threadgroup_barrier(mem_flags::mem_threadgroup);
+    \\
+    \\    for (uint s = tid; s < p.seq_kv; s += tg_size)
+    \\        scores[s] *= inv_sum;
+    \\    threadgroup_barrier(mem_flags::mem_threadgroup);
+    \\
+    \\    for (uint r = tid; r < p.d_head; r += tg_size) {
+    \\        float val = 0.0f;
+    \\        for (uint s = 0; s < p.seq_kv; s++)
+    \\            val += scores[s] * V[v_off + r * p.v_rs + s * p.v_cs];
+    \\        dst[dst_off + r * p.dst_rs + q_col * p.dst_cs] = val;
+    \\        slice_dst[slice_dst_off + r * p.slice_dst_row_stride + q_col * p.slice_dst_col_stride] = val;
     \\    }
     \\}
     \\
@@ -1869,7 +2092,36 @@ const AttentionStoreParams = extern struct {
     slice_dst_col_stride: u32,
 };
 
+const AttentionRopeStoreParams = extern struct {
+    d_head: u32,
+    seq_q: u32,
+    seq_kv: u32,
+    scale: f32,
+    rope_half_d: u32,
+    rope_src_off: u32,
+    rope_cs_off: u32,
+    rope_src_rs: u32,
+    rope_src_cs: u32,
+    rope_cs_cs: u32,
+    k_off: u32,
+    v_off: u32,
+    mask_off: u32,
+    dst_off: u32,
+    k_rs: u32,
+    k_cs: u32,
+    v_rs: u32,
+    v_cs: u32,
+    mask_rs: u32,
+    mask_cs: u32,
+    dst_rs: u32,
+    dst_cs: u32,
+    slice_dst_offset: u32,
+    slice_dst_row_stride: u32,
+    slice_dst_col_stride: u32,
+};
+
 const MAX_ATTENTION_BATCH_HEADS: usize = 16;
+const MAX_ATTENTION_STORE_BATCH_HEADS: usize = 4;
 
 const AttentionBatchParams = extern struct {
     n_heads: u32,
@@ -1892,6 +2144,32 @@ const AttentionBatchParams = extern struct {
     mask_cs: u32,
     dst_rs: u32,
     dst_cs: u32,
+};
+
+const AttentionStoreBatchParams = extern struct {
+    n_heads: u32,
+    d_head: u32,
+    seq_q: u32,
+    seq_kv: u32,
+    scale: f32,
+    q_off: [MAX_ATTENTION_STORE_BATCH_HEADS]u32,
+    k_off: [MAX_ATTENTION_STORE_BATCH_HEADS]u32,
+    v_off: [MAX_ATTENTION_STORE_BATCH_HEADS]u32,
+    mask_off: [MAX_ATTENTION_STORE_BATCH_HEADS]u32,
+    dst_off: [MAX_ATTENTION_STORE_BATCH_HEADS]u32,
+    slice_dst_offset: [MAX_ATTENTION_STORE_BATCH_HEADS]u32,
+    q_rs: u32,
+    q_cs: u32,
+    k_rs: u32,
+    k_cs: u32,
+    v_rs: u32,
+    v_cs: u32,
+    mask_rs: u32,
+    mask_cs: u32,
+    dst_rs: u32,
+    dst_cs: u32,
+    slice_dst_row_stride: u32,
+    slice_dst_col_stride: u32,
 };
 
 const ComputeParams = extern struct {
@@ -2220,6 +2498,36 @@ fn attentionStoreParams(att: anytype, sa: anytype) AttentionStoreParams {
     };
 }
 
+fn attentionRopeStoreParams(rr: anytype, att: anytype, sa: anytype) AttentionRopeStoreParams {
+    return .{
+        .d_head = att.d_head,
+        .seq_q = att.seq_q,
+        .seq_kv = att.seq_kv,
+        .scale = att.scale,
+        .rope_half_d = rr.half_d,
+        .rope_src_off = rr.src_off,
+        .rope_cs_off = rr.cs_off,
+        .rope_src_rs = rr.src_rs,
+        .rope_src_cs = rr.src_cs,
+        .rope_cs_cs = rr.cs_cs,
+        .k_off = att.k_off,
+        .v_off = att.v_off,
+        .mask_off = att.mask_off,
+        .dst_off = att.dst_off,
+        .k_rs = att.k_rs,
+        .k_cs = att.k_cs,
+        .v_rs = att.v_rs,
+        .v_cs = att.v_cs,
+        .mask_rs = att.mask_rs,
+        .mask_cs = att.mask_cs,
+        .dst_rs = att.dst_rs,
+        .dst_cs = att.dst_cs,
+        .slice_dst_offset = sa.dst_offset,
+        .slice_dst_row_stride = sa.dst_row_stride,
+        .slice_dst_col_stride = sa.dst_col_stride,
+    };
+}
+
 fn canEncodeAttention(att: anytype) bool {
     return att.seq_q >= 1 and
         att.seq_kv <= 4096 and
@@ -2254,6 +2562,8 @@ pub const MetalBackend = struct {
     attention_pipeline: *anyopaque,
     attention_slice_assign_pipeline: *anyopaque,
     attention_store_pipeline: *anyopaque,
+    attention_rope_store_pipeline: *anyopaque,
+    attention_store_batch_pipeline: *anyopaque,
     attention_batch_pipeline: *anyopaque,
     compute_pipeline: *anyopaque,
     elementwise_batch8_pipeline: *anyopaque,
@@ -2311,6 +2621,10 @@ pub const MetalBackend = struct {
         errdefer c.mtl_release(attention_slice_assign_pipeline);
         const attention_store_pipeline = c.mtl_create_pipeline(device, library, "attention_store_f32") orelse return error.PipelineCreateFailed;
         errdefer c.mtl_release(attention_store_pipeline);
+        const attention_rope_store_pipeline = c.mtl_create_pipeline(device, library, "attention_rope_store_f32") orelse return error.PipelineCreateFailed;
+        errdefer c.mtl_release(attention_rope_store_pipeline);
+        const attention_store_batch_pipeline = c.mtl_create_pipeline(device, library, "attention_store_batch_f32") orelse return error.PipelineCreateFailed;
+        errdefer c.mtl_release(attention_store_batch_pipeline);
         const attention_batch_pipeline = c.mtl_create_pipeline(device, library, "attention_batch_f32") orelse return error.PipelineCreateFailed;
         errdefer c.mtl_release(attention_batch_pipeline);
         const compute_pipeline = c.mtl_create_pipeline(device, library, "compute_f32") orelse return error.PipelineCreateFailed;
@@ -2341,6 +2655,8 @@ pub const MetalBackend = struct {
             .attention_pipeline = attention_pipeline,
             .attention_slice_assign_pipeline = attention_slice_assign_pipeline,
             .attention_store_pipeline = attention_store_pipeline,
+            .attention_rope_store_pipeline = attention_rope_store_pipeline,
+            .attention_store_batch_pipeline = attention_store_batch_pipeline,
             .attention_batch_pipeline = attention_batch_pipeline,
             .compute_pipeline = compute_pipeline,
             .elementwise_batch8_pipeline = elementwise_batch8_pipeline,
@@ -2355,6 +2671,8 @@ pub const MetalBackend = struct {
         c.mtl_release(self.elementwise_batch8_pipeline);
         c.mtl_release(self.compute_pipeline);
         c.mtl_release(self.attention_batch_pipeline);
+        c.mtl_release(self.attention_store_batch_pipeline);
+        c.mtl_release(self.attention_rope_store_pipeline);
         c.mtl_release(self.attention_store_pipeline);
         c.mtl_release(self.attention_slice_assign_pipeline);
         c.mtl_release(self.attention_pipeline);
@@ -3309,6 +3627,119 @@ const CompiledProgram = struct {
         return true;
     }
 
+    fn encodeAttentionRopeStore(self: *CompiledProgram, rr: anytype, att: anytype, sa: anytype) bool {
+        if (!program_mod.ropeAttentionCompatible(rr, att)) return false;
+        if (!program_mod.attentionSliceStoreCompatible(att, sa)) return false;
+        if (!canEncodeAttention(att)) return false;
+        if (rr.half_d * 2 != att.d_head) return false;
+        const buffers = [_]DeviceBuffer{
+            self.device_bufs[rr.src],
+            self.device_bufs[rr.cos_sin],
+            self.device_bufs[att.k],
+            self.device_bufs[att.v],
+            self.device_bufs[att.mask],
+            self.device_bufs[att.dst],
+            self.device_bufs[sa.dst],
+        };
+        self.encodeTyped(AttentionRopeStoreParams, self.backend.attention_rope_store_pipeline, &buffers, attentionRopeStoreParams(rr, att, sa), 7, .{ .gx = att.seq_q }, WG_SIZE);
+        return true;
+    }
+
+    fn canEncodeAttentionStoreBatchCommand(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, command: program_mod.ProgramCommand) bool {
+        _ = self;
+        if (command.anchor_count < 2 or command.anchor_count > MAX_ATTENTION_STORE_BATCH_HEADS) return false;
+        if (command.sidecar_count != command.anchor_count) return false;
+        const first_idx = command.indices[0];
+        const first_sa_idx = command.sidecar_indices[0] orelse return false;
+        if (first_idx >= ops.len or first_sa_idx >= ops.len) return false;
+        const first = switch (ops[first_idx]) {
+            .attention => |att| att,
+            else => return false,
+        };
+        const first_sa = switch (ops[first_sa_idx]) {
+            .slice_assign => |sa| sa,
+            else => return false,
+        };
+        if (!canEncodeAttention(first)) return false;
+        if (!program_mod.attentionSliceStoreCompatible(first, first_sa)) return false;
+        if (!program_mod.canFuseAttentionStoreSidecar(ops, first_idx, first_sa_idx, first_sa)) return false;
+
+        for (command.anchorIndices()[1..], command.sidecarIndices()[1..]) |idx, maybe_sa_idx| {
+            const sa_idx = maybe_sa_idx orelse return false;
+            if (idx >= ops.len or sa_idx >= ops.len) return false;
+            const att = switch (ops[idx]) {
+                .attention => |att| att,
+                else => return false,
+            };
+            const sa = switch (ops[sa_idx]) {
+                .slice_assign => |sa| sa,
+                else => return false,
+            };
+            if (!canEncodeAttention(att)) return false;
+            if (!program_mod.attentionGeometryCompatible(first, att)) return false;
+            if (!program_mod.attentionSliceStoreCompatible(att, sa)) return false;
+            if (!program_mod.canFuseAttentionStoreSidecar(ops, idx, sa_idx, sa)) return false;
+            if (sa.dst_row_stride != first_sa.dst_row_stride or
+                sa.dst_col_stride != first_sa.dst_col_stride) return false;
+        }
+        return true;
+    }
+
+    fn encodeAttentionStoreBatchCommand(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, command: program_mod.ProgramCommand) void {
+        const first = ops[command.indices[0]].attention;
+        const first_sa = ops[command.sidecar_indices[0].?].slice_assign;
+        const q_base = 0;
+        const k_base = q_base + MAX_ATTENTION_STORE_BATCH_HEADS;
+        const v_base = k_base + MAX_ATTENTION_STORE_BATCH_HEADS;
+        const mask_base = v_base + MAX_ATTENTION_STORE_BATCH_HEADS;
+        const dst_base = mask_base + MAX_ATTENTION_STORE_BATCH_HEADS;
+        const slice_dst_base = dst_base + MAX_ATTENTION_STORE_BATCH_HEADS;
+        var buffers: [MAX_ATTENTION_STORE_BATCH_HEADS * 6]DeviceBuffer = undefined;
+        for (0..MAX_ATTENTION_STORE_BATCH_HEADS) |i| {
+            buffers[q_base + i] = self.device_bufs[first.q];
+            buffers[k_base + i] = self.device_bufs[first.k];
+            buffers[v_base + i] = self.device_bufs[first.v];
+            buffers[mask_base + i] = self.device_bufs[first.mask];
+            buffers[dst_base + i] = self.device_bufs[first.dst];
+            buffers[slice_dst_base + i] = self.device_bufs[first_sa.dst];
+        }
+        var params = std.mem.zeroes(AttentionStoreBatchParams);
+        params.n_heads = @intCast(command.anchor_count);
+        params.d_head = first.d_head;
+        params.seq_q = first.seq_q;
+        params.seq_kv = first.seq_kv;
+        params.scale = first.scale;
+        params.q_rs = first.q_rs;
+        params.q_cs = first.q_cs;
+        params.k_rs = first.k_rs;
+        params.k_cs = first.k_cs;
+        params.v_rs = first.v_rs;
+        params.v_cs = first.v_cs;
+        params.mask_rs = first.mask_rs;
+        params.mask_cs = first.mask_cs;
+        params.dst_rs = first.dst_rs;
+        params.dst_cs = first.dst_cs;
+        params.slice_dst_row_stride = first_sa.dst_row_stride;
+        params.slice_dst_col_stride = first_sa.dst_col_stride;
+        for (command.anchorIndices(), command.sidecarIndices(), 0..) |idx, maybe_sa_idx, i| {
+            const att = ops[idx].attention;
+            const sa = ops[maybe_sa_idx.?].slice_assign;
+            buffers[q_base + i] = self.device_bufs[att.q];
+            buffers[k_base + i] = self.device_bufs[att.k];
+            buffers[v_base + i] = self.device_bufs[att.v];
+            buffers[mask_base + i] = self.device_bufs[att.mask];
+            buffers[dst_base + i] = self.device_bufs[att.dst];
+            buffers[slice_dst_base + i] = self.device_bufs[sa.dst];
+            params.q_off[i] = att.q_off;
+            params.k_off[i] = att.k_off;
+            params.v_off[i] = att.v_off;
+            params.mask_off[i] = att.mask_off;
+            params.dst_off[i] = att.dst_off;
+            params.slice_dst_offset[i] = sa.dst_offset;
+        }
+        self.encodeTyped(AttentionStoreBatchParams, self.backend.attention_store_batch_pipeline, &buffers, params, @intCast(buffers.len), .{ .gx = first.seq_q, .gy = @intCast(command.anchor_count) }, WG_SIZE);
+    }
+
     fn attentionBatchCompatible(first: anytype, next: anytype) bool {
         return program_mod.attentionBatchCompatible(first, next);
     }
@@ -3570,6 +4001,31 @@ const CompiledProgram = struct {
                 };
                 break :blk self.encodeAttentionSliceStore(att, sa);
             },
+            .attention_store_group => blk: {
+                if (!self.canEncodeAttentionStoreBatchCommand(ops, command)) break :blk false;
+                self.encodeAttentionStoreBatchCommand(ops, command);
+                break :blk true;
+            },
+            .rope_attention_store_chain => blk: {
+                if (command.anchor_count != 2 or command.sidecar_count != 1) break :blk false;
+                const rope_idx = command.indices[0];
+                const att_idx = command.indices[1];
+                const sa_idx = command.sidecar_indices[0] orelse break :blk false;
+                if (rope_idx >= ops.len or att_idx >= ops.len or sa_idx >= ops.len) break :blk false;
+                const rr = switch (ops[rope_idx]) {
+                    .rope => |rr| rr,
+                    else => break :blk false,
+                };
+                const att = switch (ops[att_idx]) {
+                    .attention => |att| att,
+                    else => break :blk false,
+                };
+                const sa = switch (ops[sa_idx]) {
+                    .slice_assign => |sa| sa,
+                    else => break :blk false,
+                };
+                break :blk self.encodeAttentionRopeStore(rr, att, sa);
+            },
             .attention_batch => blk: {
                 const n: usize = @intCast(command.op_count);
                 if (self.attentionBatchRunLen(ops[start..]) < n) break :blk false;
@@ -3643,9 +4099,14 @@ const CompiledProgram = struct {
             self.runtime_profile.recordProgramCommandFailed(command.kind);
             return false;
         }
-        if (command.kind == .attention_store_chain) {
-            const record_indices = [_]usize{ command.indices[0], command.sidecar_indices[0] orelse command.indices[0] };
-            self.recordRegionFusedRunFromIndices(ops, record_indices[0..], @intCast(nowNs() - t0));
+        if (command.kind == .attention_store_chain or command.kind == .attention_store_group or command.kind == .rope_attention_store_chain) {
+            var record_indices: [program_mod.max_projection_group_anchors * 2]usize = undefined;
+            var record_count: usize = 0;
+            for (command.anchorIndices()) |idx| appendCommandIndex(&record_indices, &record_count, idx);
+            for (command.sidecarIndices()) |maybe_idx| {
+                if (maybe_idx) |idx| appendCommandIndex(&record_indices, &record_count, idx);
+            }
+            self.recordRegionFusedRunFromIndices(ops, record_indices[0..record_count], @intCast(nowNs() - t0));
         } else if (command.kind != .projection_group and command.kind != .elementwise_batch and command.kind != .attention_group and command.kind != .movement_group) {
             self.recordRegionFusedRun(ops[start..end], @intCast(nowNs() - t0));
         }
@@ -3677,6 +4138,8 @@ const CompiledProgram = struct {
             .projection_group,
             .attention_chain,
             .attention_store_chain,
+            .attention_store_group,
+            .rope_attention_store_chain,
             .attention_group,
             .movement_group,
             .elementwise_batch,
@@ -5052,4 +5515,144 @@ test "metal backend fuses attention output store chains" {
     try std.testing.expectEqual(@as(u64, 9), rt.backend_op_count);
     try std.testing.expectEqual(@as(u64, 0), rt.fallback_op_count);
     try std.testing.expectEqual(@as(u64, 8), rt.backend_dispatch_count);
+}
+
+test "metal backend fuses rope attention output store chains" {
+    var metal = MetalBackend.init() catch |err| switch (err) {
+        error.MetalNotAvailable => return,
+        else => return err,
+    };
+    defer metal.deinit();
+    metal.setRegionProgramDispatch(true);
+    const be = metal.backend();
+
+    var q_input = [_]f32{ 1, 0 };
+    var q_rope = [_]f32{0} ** 2;
+    var cos_sin = [_]f32{ 1, 0 };
+    var k_cache = [_]f32{ 1, 0, 0, 1 };
+    var v_cache = [_]f32{ 10, 20, 30, 40 };
+    var mask = [_]f32{ 0, 0 };
+    var dst = [_]f32{0} ** 2;
+    var slice_dst = [_]f32{ -1, -1, -1, -1 };
+    const qdata = [_]i8{
+        1, 0,
+        0, 1,
+    };
+    const scales = [_]f32{ 1, 1 };
+    const qweights = [_]backend_mod.QuantizedWeightUpload{.{ .data = &qdata, .scales = &scales, .rows = 2, .cols = 2, .block_size = 2 }};
+
+    var ops: [10]backend_mod.DeviceOp = undefined;
+    for (ops[0..7]) |*op| {
+        op.* = .{ .qmatmul = .{
+            .dst = 1,
+            .input = 0,
+            .weight_idx = 0,
+            .M = 1,
+            .N = 2,
+            .K = 2,
+        } };
+    }
+    ops[7] = .{ .rope = .{
+        .dst = 1,
+        .src = 0,
+        .cos_sin = 2,
+        .half_d = 1,
+        .seq_len = 1,
+        .src_off = 0,
+        .cs_off = 0,
+        .dst_off = 0,
+        .src_rs = 1,
+        .src_cs = 2,
+        .cs_cs = 1,
+    } };
+    ops[8] = .{ .attention = .{
+        .dst = 6,
+        .q = 1,
+        .k = 3,
+        .v = 4,
+        .mask = 5,
+        .has_mask = true,
+        .d_head = 2,
+        .seq_q = 1,
+        .seq_kv = 2,
+        .scale = 1,
+        .q_off = 0,
+        .k_off = 0,
+        .v_off = 0,
+        .mask_off = 0,
+        .dst_off = 0,
+        .q_rs = 1,
+        .q_cs = 2,
+        .k_rs = 1,
+        .k_cs = 2,
+        .v_rs = 1,
+        .v_cs = 2,
+        .mask_rs = 1,
+        .mask_cs = 2,
+        .dst_rs = 1,
+        .dst_cs = 2,
+    } };
+    ops[9] = .{ .slice_assign = .{
+        .dst = 7,
+        .src = 6,
+        .rows = 2,
+        .cols = 1,
+        .dst_base_offset = 0,
+        .dst_offset = 2,
+        .dst_row_stride = 1,
+        .dst_col_stride = 4,
+        .src_offset = 0,
+        .src_row_stride = 1,
+        .src_col_stride = 2,
+        .patch_stride = 4,
+    } };
+
+    const buf_sizes = [_]usize{ 2, 2, 2, 4, 4, 2, 2, 4 };
+    const uploads = [_]backend_mod.ProgramIO{
+        .{ .buf_idx = 0, .host_ptr = @ptrCast(&q_input), .size = 2 * 4 },
+        .{ .buf_idx = 1, .host_ptr = @ptrCast(&q_rope), .size = 2 * 4 },
+        .{ .buf_idx = 2, .host_ptr = @ptrCast(&cos_sin), .size = 2 * 4 },
+        .{ .buf_idx = 3, .host_ptr = @ptrCast(&k_cache), .size = 4 * 4 },
+        .{ .buf_idx = 4, .host_ptr = @ptrCast(&v_cache), .size = 4 * 4 },
+        .{ .buf_idx = 5, .host_ptr = @ptrCast(&mask), .size = 2 * 4 },
+        .{ .buf_idx = 6, .host_ptr = @ptrCast(&dst), .size = 2 * 4 },
+        .{ .buf_idx = 7, .host_ptr = @ptrCast(&slice_dst), .size = 4 * 4 },
+    };
+    const program = backend_mod.DeviceProgram{
+        .ops = &ops,
+        .n_buffers = 8,
+        .buffer_sizes = &buf_sizes,
+        .initial_uploads = &uploads,
+        .qweights = &qweights,
+    };
+
+    const handle = be.compileProgram(program) orelse return error.CompileFailed;
+    defer be.freeProgram(handle);
+
+    var got_dst: [2]f32 = undefined;
+    var got_slice: [4]f32 = undefined;
+    var out = [_]backend_mod.ProgramIO{
+        .{ .buf_idx = 6, .host_ptr = @ptrCast(&got_dst), .size = 2 * 4 },
+        .{ .buf_idx = 7, .host_ptr = @ptrCast(&got_slice), .size = 4 * 4 },
+    };
+    be.executeProgram(handle, &.{}, &out);
+
+    const hi: f32 = @exp(@as(f32, 1.0)) / (@exp(@as(f32, 1.0)) + 1.0);
+    const lo: f32 = 1.0 / (@exp(@as(f32, 1.0)) + 1.0);
+    const expected = [_]f32{
+        hi * 10 + lo * 30,
+        hi * 20 + lo * 40,
+    };
+    for (expected, got_dst) |want, actual| {
+        try std.testing.expectApproxEqAbs(want, actual, 1e-4);
+    }
+    try std.testing.expectEqual(@as(f32, -1), got_slice[0]);
+    try std.testing.expectEqual(@as(f32, -1), got_slice[1]);
+    for (expected, got_slice[2..4]) |want, actual| {
+        try std.testing.expectApproxEqAbs(want, actual, 1e-4);
+    }
+
+    const rt = be.getRuntimeProfile(handle).?;
+    try std.testing.expectEqual(@as(u64, 0), rt.fallback_op_count);
+    try std.testing.expectEqual(@as(u64, 1), rt.program_command_counts[@intFromEnum(program_mod.ProgramCommandKind.rope_attention_store_chain)]);
 }

--- a/src/backend/metal.zig
+++ b/src/backend/metal.zig
@@ -2453,7 +2453,7 @@ const CompiledProgram = struct {
     }
 
     fn canEncodeElementwiseBatchOp(e: anytype) bool {
-        return isSupportedElementwiseOp(e.op);
+        return program_mod.canBatchElementwiseOp(e);
     }
 
     fn encodeElementwiseBatch(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, indices: []const usize) void {
@@ -3023,25 +3023,6 @@ const CompiledProgram = struct {
         };
     }
 
-    fn canHoistElementwiseTo(ops: []const backend_mod.DeviceOp, start: usize, candidate_index: usize, e: anytype) bool {
-        for (ops[start..candidate_index]) |op| {
-            if (program_mod.opWritesBuffer(op, e.src0)) return false;
-            if (e.op.isBinary() and program_mod.opWritesBuffer(op, e.src1)) return false;
-            if (program_mod.opTouchesBuffer(op, e.dst)) return false;
-        }
-        return true;
-    }
-
-    fn elementwiseConflictsSelected(ops: []const backend_mod.DeviceOp, indices: []const usize, e: anytype) bool {
-        for (indices) |idx| {
-            const selected = ops[idx].elementwise;
-            if (selected.dst == e.dst) return true;
-            if (selected.dst == e.src0 or (e.op.isBinary() and selected.dst == e.src1)) return true;
-            if (e.dst == selected.src0 or (selected.op.isBinary() and e.dst == selected.src1)) return true;
-        }
-        return false;
-    }
-
     fn recordRegionBackendOp(self: *CompiledProgram, op: backend_mod.DeviceOp, elapsed_ns: u64) void {
         const tag: usize = @intFromEnum(op);
         self.runtime_profile.backend_op_count +%= 1;
@@ -3128,8 +3109,8 @@ const CompiledProgram = struct {
                 else => continue,
             };
             if (!canEncodeElementwiseBatchOp(e)) continue;
-            if (!canHoistElementwiseTo(ops, start, scan, e)) continue;
-            if (elementwiseConflictsSelected(ops, indices[0..count], e)) continue;
+            if (!program_mod.canHoistElementwiseTo(ops, start, scan, e)) continue;
+            if (program_mod.elementwiseConflictsSelected(ops, indices[0..count], e)) continue;
             indices[count] = scan;
             count += 1;
         }
@@ -3246,6 +3227,20 @@ const CompiledProgram = struct {
                 self.encodeSliceAssignBatch(ops[start..], n);
                 break :blk true;
             },
+            .elementwise_batch => blk: {
+                for (command.anchorIndices()) |idx| {
+                    if (idx >= ops.len) break :blk false;
+                    const e = switch (ops[idx]) {
+                        .elementwise => |e| e,
+                        else => break :blk false,
+                    };
+                    if (!canEncodeElementwiseBatchOp(e)) break :blk false;
+                }
+                const t_batch = nowNs();
+                self.encodeElementwiseBatch(ops, command.anchorIndices());
+                self.recordRegionFusedRunFromIndices(ops, command.anchorIndices(), @intCast(nowNs() - t_batch));
+                break :blk true;
+            },
             .row_chain => switch (ops[start]) {
                 .rmsnorm => |rn| switch (ops[start + 1]) {
                     .repeat => |rp| switch (ops[start + 2]) {
@@ -3270,7 +3265,7 @@ const CompiledProgram = struct {
         };
 
         if (!encoded) return 0;
-        if (command.kind != .projection_group) {
+        if (command.kind != .projection_group and command.kind != .elementwise_batch) {
             self.recordRegionFusedRun(ops[start..end], @intCast(nowNs() - t0));
         }
         program_mod.markProgramCommandUsed(skipped, command);

--- a/src/backend/metal.zig
+++ b/src/backend/metal.zig
@@ -209,13 +209,18 @@ const shader_source =
     \\    uint input_row_stride[MAX_QMATMUL_BATCH];
     \\    uint dst_offset[MAX_QMATMUL_BATCH];
     \\    uint dst_row_stride[MAX_QMATMUL_BATCH];
-    \\    uint has_slice[MAX_QMATMUL_BATCH];
+    \\    uint write_primary[MAX_QMATMUL_BATCH];
+    \\    uint sidecar_kind[MAX_QMATMUL_BATCH];
     \\    uint slice_rows[MAX_QMATMUL_BATCH];
     \\    uint slice_cols[MAX_QMATMUL_BATCH];
     \\    uint slice_src_col_start[MAX_QMATMUL_BATCH];
     \\    uint slice_dst_offset[MAX_QMATMUL_BATCH];
     \\    uint slice_dst_row_stride[MAX_QMATMUL_BATCH];
     \\    uint slice_dst_col_stride[MAX_QMATMUL_BATCH];
+    \\    uint ew_op[MAX_QMATMUL_BATCH];
+    \\    uint ew_is_swapped[MAX_QMATMUL_BATCH];
+    \\    uint ew_dst_offset[MAX_QMATMUL_BATCH];
+    \\    uint ew_secondary_offset[MAX_QMATMUL_BATCH];
     \\};
     \\
     \\kernel void qmatmul_batch4_f32(
@@ -223,23 +228,27 @@ const shader_source =
     \\    device const float* s0 [[buffer(1)]],
     \\    device const float* i0 [[buffer(2)]],
     \\    device float*       o0 [[buffer(3)]],
-    \\    device float*       sd0 [[buffer(4)]],
-    \\    device const char*  w1 [[buffer(5)]],
-    \\    device const float* s1 [[buffer(6)]],
-    \\    device const float* i1 [[buffer(7)]],
-    \\    device float*       o1 [[buffer(8)]],
-    \\    device float*       sd1 [[buffer(9)]],
-    \\    device const char*  w2 [[buffer(10)]],
-    \\    device const float* s2 [[buffer(11)]],
-    \\    device const float* i2 [[buffer(12)]],
-    \\    device float*       o2 [[buffer(13)]],
-    \\    device float*       sd2 [[buffer(14)]],
-    \\    device const char*  w3 [[buffer(15)]],
-    \\    device const float* s3 [[buffer(16)]],
-    \\    device const float* i3 [[buffer(17)]],
-    \\    device float*       o3 [[buffer(18)]],
-    \\    device float*       sd3 [[buffer(19)]],
-    \\    constant QMatmulBatch4Params& p [[buffer(20)]],
+    \\    device float*       side0 [[buffer(4)]],
+    \\    device const float* sec0 [[buffer(5)]],
+    \\    device const char*  w1 [[buffer(6)]],
+    \\    device const float* s1 [[buffer(7)]],
+    \\    device const float* i1 [[buffer(8)]],
+    \\    device float*       o1 [[buffer(9)]],
+    \\    device float*       side1 [[buffer(10)]],
+    \\    device const float* sec1 [[buffer(11)]],
+    \\    device const char*  w2 [[buffer(12)]],
+    \\    device const float* s2 [[buffer(13)]],
+    \\    device const float* i2 [[buffer(14)]],
+    \\    device float*       o2 [[buffer(15)]],
+    \\    device float*       side2 [[buffer(16)]],
+    \\    device const float* sec2 [[buffer(17)]],
+    \\    device const char*  w3 [[buffer(18)]],
+    \\    device const float* s3 [[buffer(19)]],
+    \\    device const float* i3 [[buffer(20)]],
+    \\    device float*       o3 [[buffer(21)]],
+    \\    device float*       side3 [[buffer(22)]],
+    \\    device const float* sec3 [[buffer(23)]],
+    \\    constant QMatmulBatch4Params& p [[buffer(24)]],
     \\    uint2 group_id [[threadgroup_position_in_grid]],
     \\    uint  simd_idx [[simdgroup_index_in_threadgroup]],
     \\    uint  lane     [[thread_index_in_simdgroup]],
@@ -253,11 +262,12 @@ const shader_source =
     \\    device const float* s = s0;
     \\    device const float* input = i0;
     \\    device float* output = o0;
-    \\    device float* slice_dst = sd0;
+    \\    device float* sidecar_dst = side0;
+    \\    device const float* secondary = sec0;
     \\    switch (slot) {
-    \\        case 1: w = w1; s = s1; input = i1; output = o1; slice_dst = sd1; break;
-    \\        case 2: w = w2; s = s2; input = i2; output = o2; slice_dst = sd2; break;
-    \\        case 3: w = w3; s = s3; input = i3; output = o3; slice_dst = sd3; break;
+    \\        case 1: w = w1; s = s1; input = i1; output = o1; sidecar_dst = side1; secondary = sec1; break;
+    \\        case 2: w = w2; s = s2; input = i2; output = o2; sidecar_dst = side2; secondary = sec2; break;
+    \\        case 3: w = w3; s = s3; input = i3; output = o3; sidecar_dst = side3; secondary = sec3; break;
     \\        default: break;
     \\    }
     \\
@@ -319,11 +329,18 @@ const shader_source =
     \\        uint cr = gRow + r, cc = gCol + c;
     \\        if (cr < M && cc < N) {
     \\            float val = tC[i];
-    \\            output[p.dst_offset[slot] + cr * p.dst_row_stride[slot] + cc] = val;
+    \\            if (p.write_primary[slot] != 0) output[p.dst_offset[slot] + cr * p.dst_row_stride[slot] + cc] = val;
     \\            uint slice_col_start = p.slice_src_col_start[slot];
-    \\            if (p.has_slice[slot] != 0 && cc >= slice_col_start && cc < slice_col_start + p.slice_rows[slot] && cr < p.slice_cols[slot]) {
+    \\            if (p.sidecar_kind[slot] == 1 && cc >= slice_col_start && cc < slice_col_start + p.slice_rows[slot] && cr < p.slice_cols[slot]) {
     \\                uint slice_row = cc - slice_col_start;
-    \\                slice_dst[p.slice_dst_offset[slot] + slice_row * p.slice_dst_row_stride[slot] + cr * p.slice_dst_col_stride[slot]] = val;
+    \\                sidecar_dst[p.slice_dst_offset[slot] + slice_row * p.slice_dst_row_stride[slot] + cr * p.slice_dst_col_stride[slot]] = val;
+    \\            } else if (p.sidecar_kind[slot] == 2) {
+    \\                uint linear = cr * N + cc;
+    \\                float other = secondary[p.ew_secondary_offset[slot] + linear];
+    \\                float ew = val;
+    \\                if (p.ew_op[slot] == 7) ew = (p.ew_is_swapped[slot] != 0) ? other + val : val + other;
+    \\                else if (p.ew_op[slot] == 8) ew = (p.ew_is_swapped[slot] != 0) ? other * val : val * other;
+    \\                sidecar_dst[p.ew_dst_offset[slot] + linear] = ew;
     \\            }
     \\        }
     \\    }
@@ -683,6 +700,7 @@ const shader_source =
     \\    uint input_row_stride;
     \\    uint dst_offset;
     \\    uint dst_row_stride;
+    \\    uint write_primary;
     \\    uint slice_rows; uint slice_cols;
     \\    uint slice_src_col_start;
     \\    uint slice_dst_offset;
@@ -759,7 +777,7 @@ const shader_source =
     \\        uint cr = gRow + r, cc = gCol + c;
     \\        if (cr < p.M && cc < p.N) {
     \\            float val = tC[i];
-    \\            output[p.dst_offset + cr * p.dst_row_stride + cc] = val;
+    \\            if (p.write_primary != 0) output[p.dst_offset + cr * p.dst_row_stride + cc] = val;
     \\            if (cc >= p.slice_src_col_start && cc < p.slice_src_col_start + p.slice_rows && cr < p.slice_cols) {
     \\                uint slice_row = cc - p.slice_src_col_start;
     \\                slice_dst[p.slice_dst_offset + slice_row * p.slice_dst_row_stride + cr * p.slice_dst_col_stride] = val;
@@ -775,6 +793,7 @@ const shader_source =
     \\    uint input_row_stride;
     \\    uint dst_offset;
     \\    uint dst_row_stride;
+    \\    uint write_primary;
     \\    uint ew_op;
     \\    uint ew_is_swapped;
     \\    uint ew_dst_offset;
@@ -856,7 +875,7 @@ const shader_source =
     \\            float ew = val;
     \\            if (p.ew_op == 7) ew = (p.ew_is_swapped != 0) ? other + val : val + other;
     \\            else if (p.ew_op == 8) ew = (p.ew_is_swapped != 0) ? other * val : val * other;
-    \\            output[p.dst_offset + cr * p.dst_row_stride + cc] = val;
+    \\            if (p.write_primary != 0) output[p.dst_offset + cr * p.dst_row_stride + cc] = val;
     \\            ew_output[p.ew_dst_offset + linear] = ew;
     \\        }
     \\    }
@@ -878,7 +897,7 @@ const shader_source =
     \\        sum += input[p.input_offset + k] * float(weight_data[w_idx]) * weight_scales[w_idx / p.block_size];
     \\    }
     \\
-    \\    output[p.dst_offset + gid] = sum;
+    \\    if (p.write_primary != 0) output[p.dst_offset + gid] = sum;
     \\    if (gid >= p.slice_src_col_start && gid < p.slice_src_col_start + p.slice_rows) {
     \\        uint row = gid - p.slice_src_col_start;
     \\        uint col = 0;
@@ -1960,6 +1979,7 @@ const shader_source =
     \\    uint input_row_stride;
     \\    uint dst_offset;
     \\    uint dst_row_stride;
+    \\    uint write_primary;
     \\    uint n_steps;
     \\    uint ew_dst_offset;
     \\    uint op[MAX_FUSED_EW_STEPS];
@@ -2055,7 +2075,7 @@ const shader_source =
     \\                    v = fused_unary(op, v);
     \\                }
     \\            }
-    \\            output[p.dst_offset + cr * p.dst_row_stride + cc] = base;
+    \\            if (p.write_primary != 0) output[p.dst_offset + cr * p.dst_row_stride + cc] = base;
     \\            ew_output[p.ew_dst_offset + linear] = v;
     \\        }
     \\    }
@@ -2102,13 +2122,18 @@ const QMatmulBatch4Params = extern struct {
     input_row_stride: [MAX_QMATMUL_BATCH]u32,
     dst_offset: [MAX_QMATMUL_BATCH]u32,
     dst_row_stride: [MAX_QMATMUL_BATCH]u32,
-    has_slice: [MAX_QMATMUL_BATCH]u32,
+    write_primary: [MAX_QMATMUL_BATCH]u32,
+    sidecar_kind: [MAX_QMATMUL_BATCH]u32,
     slice_rows: [MAX_QMATMUL_BATCH]u32,
     slice_cols: [MAX_QMATMUL_BATCH]u32,
     slice_src_col_start: [MAX_QMATMUL_BATCH]u32,
     slice_dst_offset: [MAX_QMATMUL_BATCH]u32,
     slice_dst_row_stride: [MAX_QMATMUL_BATCH]u32,
     slice_dst_col_stride: [MAX_QMATMUL_BATCH]u32,
+    ew_op: [MAX_QMATMUL_BATCH]u32,
+    ew_is_swapped: [MAX_QMATMUL_BATCH]u32,
+    ew_dst_offset: [MAX_QMATMUL_BATCH]u32,
+    ew_secondary_offset: [MAX_QMATMUL_BATCH]u32,
 };
 
 const MAX_QMATVEC_BATCH: usize = 4;
@@ -2204,6 +2229,7 @@ const QMatmulSliceAssignParams = extern struct {
     input_row_stride: u32,
     dst_offset: u32,
     dst_row_stride: u32,
+    write_primary: u32,
     slice_rows: u32,
     slice_cols: u32,
     slice_src_col_start: u32,
@@ -2221,6 +2247,7 @@ const QMatmulElementwiseParams = extern struct {
     input_row_stride: u32,
     dst_offset: u32,
     dst_row_stride: u32,
+    write_primary: u32,
     ew_op: u32,
     ew_is_swapped: u32,
     ew_dst_offset: u32,
@@ -2488,6 +2515,7 @@ const QMatmulFusedEwParams = extern struct {
     input_row_stride: u32,
     dst_offset: u32,
     dst_row_stride: u32,
+    write_primary: u32,
     n_steps: u32,
     ew_dst_offset: u32,
     op: [MAX_FUSED_EW_STEPS]u32,
@@ -3395,17 +3423,18 @@ const CompiledProgram = struct {
         self: *CompiledProgram,
         ops: []const backend_mod.DeviceOp,
         indices: []const usize,
-        slice_indices: []const ?usize,
+        sidecar_indices: []const ?usize,
     ) void {
         const first_q = ops[indices[0]].qmatmul;
         const first_w = self.qweight_views[first_q.weight_idx];
-        var buffers: [MAX_QMATMUL_BATCH * 5]DeviceBuffer = undefined;
+        var buffers: [MAX_QMATMUL_BATCH * 6]DeviceBuffer = undefined;
         for (0..MAX_QMATMUL_BATCH) |slot| {
-            buffers[slot * 5 + 0] = first_w.data;
-            buffers[slot * 5 + 1] = first_w.scales;
-            buffers[slot * 5 + 2] = self.device_bufs[first_q.input];
-            buffers[slot * 5 + 3] = self.device_bufs[first_q.dst];
-            buffers[slot * 5 + 4] = self.device_bufs[first_q.dst];
+            buffers[slot * 6 + 0] = first_w.data;
+            buffers[slot * 6 + 1] = first_w.scales;
+            buffers[slot * 6 + 2] = self.device_bufs[first_q.input];
+            buffers[slot * 6 + 3] = self.device_bufs[first_q.dst];
+            buffers[slot * 6 + 4] = self.device_bufs[first_q.dst];
+            buffers[slot * 6 + 5] = self.device_bufs[first_q.input];
         }
 
         var params = std.mem.zeroes(QMatmulBatch4Params);
@@ -3416,11 +3445,12 @@ const CompiledProgram = struct {
             const q = ops[op_index].qmatmul;
             const w = self.qweight_views[q.weight_idx];
             const qparams = qmatmulParams(q, w.block_size);
-            buffers[slot * 5 + 0] = w.data;
-            buffers[slot * 5 + 1] = w.scales;
-            buffers[slot * 5 + 2] = self.device_bufs[q.input];
-            buffers[slot * 5 + 3] = self.device_bufs[q.dst];
-            buffers[slot * 5 + 4] = self.device_bufs[q.dst];
+            buffers[slot * 6 + 0] = w.data;
+            buffers[slot * 6 + 1] = w.scales;
+            buffers[slot * 6 + 2] = self.device_bufs[q.input];
+            buffers[slot * 6 + 3] = self.device_bufs[q.dst];
+            buffers[slot * 6 + 4] = self.device_bufs[q.dst];
+            buffers[slot * 6 + 5] = self.device_bufs[q.input];
             params.M[slot] = qparams.M;
             params.N[slot] = qparams.N;
             params.K[slot] = qparams.K;
@@ -3429,16 +3459,34 @@ const CompiledProgram = struct {
             params.input_row_stride[slot] = qparams.input_row_stride;
             params.dst_offset[slot] = qparams.dst_offset;
             params.dst_row_stride[slot] = qparams.dst_row_stride;
-            if (slice_indices[slot]) |slice_index| {
-                const sa = ops[slice_index].slice_assign;
-                params.has_slice[slot] = 1;
-                params.slice_rows[slot] = sa.rows;
-                params.slice_cols[slot] = sa.cols;
-                params.slice_src_col_start[slot] = program_mod.qmatmulSliceSrcColStart(q, sa).?;
-                params.slice_dst_offset[slot] = sa.dst_offset;
-                params.slice_dst_row_stride[slot] = sa.dst_row_stride;
-                params.slice_dst_col_stride[slot] = sa.dst_col_stride;
-                buffers[slot * 5 + 4] = self.device_bufs[sa.dst];
+            params.write_primary[slot] = 1;
+            if (sidecar_indices[slot]) |sidecar_index| {
+                params.write_primary[slot] = @intFromBool(program_mod.projectionPrimaryOutputHasExternalUsers(ops, op_index, sidecar_index));
+                switch (ops[sidecar_index]) {
+                    .slice_assign => |sa| {
+                        params.sidecar_kind[slot] = 1;
+                        params.slice_rows[slot] = sa.rows;
+                        params.slice_cols[slot] = sa.cols;
+                        params.slice_src_col_start[slot] = program_mod.qmatmulSliceSrcColStart(q, sa).?;
+                        params.slice_dst_offset[slot] = sa.dst_offset;
+                        params.slice_dst_row_stride[slot] = sa.dst_row_stride;
+                        params.slice_dst_col_stride[slot] = sa.dst_col_stride;
+                        buffers[slot * 6 + 4] = self.device_bufs[sa.dst];
+                    },
+                    .elementwise => |e| {
+                        const q_is_src0 = e.src0 == q.dst and e.src0_offset == q.dst_offset;
+                        const secondary_buf = if (q_is_src0) e.src1 else e.src0;
+                        const secondary_offset = if (q_is_src0) e.src1_offset else e.src0_offset;
+                        params.sidecar_kind[slot] = 2;
+                        params.ew_op[slot] = @intFromEnum(e.op);
+                        params.ew_is_swapped[slot] = if (q_is_src0) 0 else 1;
+                        params.ew_dst_offset[slot] = e.dst_offset;
+                        params.ew_secondary_offset[slot] = secondary_offset;
+                        buffers[slot * 6 + 4] = self.device_bufs[e.dst];
+                        buffers[slot * 6 + 5] = self.device_bufs[secondary_buf];
+                    },
+                    else => {},
+                }
             }
             max_tiles_x = @max(max_tiles_x, (qparams.N + TILE - 1) / TILE);
             max_tiles_y = @max(max_tiles_y, (qparams.M + TILE - 1) / TILE);
@@ -3450,7 +3498,7 @@ const CompiledProgram = struct {
             self.backend.qmatmul_batch4_pipeline,
             &buffers,
             params,
-            20,
+            24,
             .{ .gx = max_tiles_x, .gy = max_tiles_y * @as(u32, @intCast(indices.len)) },
             MATMUL_THREADS,
         );
@@ -3656,7 +3704,7 @@ const CompiledProgram = struct {
             program_mod.qmatmulSliceSidecarCompatible(q, sa);
     }
 
-    fn encodeQMatvecSliceAssign(self: *CompiledProgram, q: anytype, sa: anytype) bool {
+    fn encodeQMatvecSliceAssign(self: *CompiledProgram, q: anytype, sa: anytype, write_primary: bool) bool {
         if (!self.canFuseQMatvecSliceAssign(q, sa)) return false;
         const w = self.qweight_views[q.weight_idx];
         const qparams = qmatmulParams(q, w.block_size);
@@ -3676,6 +3724,7 @@ const CompiledProgram = struct {
             .input_row_stride = qparams.input_row_stride,
             .dst_offset = qparams.dst_offset,
             .dst_row_stride = qparams.dst_row_stride,
+            .write_primary = @intFromBool(write_primary),
             .slice_rows = sa.rows,
             .slice_cols = sa.cols,
             .slice_src_col_start = program_mod.qmatmulSliceSrcColStart(q, sa).?,
@@ -3687,7 +3736,7 @@ const CompiledProgram = struct {
         return true;
     }
 
-    fn encodeQMatmulSliceAssign(self: *CompiledProgram, q: anytype, sa: anytype) bool {
+    fn encodeQMatmulSliceAssign(self: *CompiledProgram, q: anytype, sa: anytype, write_primary: bool) bool {
         if (!self.canFuseQMatmulSliceAssign(q, sa)) return false;
         const w = self.qweight_views[q.weight_idx];
         const qparams = qmatmulParams(q, w.block_size);
@@ -3707,6 +3756,7 @@ const CompiledProgram = struct {
             .input_row_stride = qparams.input_row_stride,
             .dst_offset = qparams.dst_offset,
             .dst_row_stride = qparams.dst_row_stride,
+            .write_primary = @intFromBool(write_primary),
             .slice_rows = sa.rows,
             .slice_cols = sa.cols,
             .slice_src_col_start = program_mod.qmatmulSliceSrcColStart(q, sa).?,
@@ -3723,7 +3773,7 @@ const CompiledProgram = struct {
         return program_mod.qmatmulElementwiseSidecarCompatible(q, e);
     }
 
-    fn encodeQMatmulElementwise(self: *CompiledProgram, q: anytype, e: anytype) bool {
+    fn encodeQMatmulElementwise(self: *CompiledProgram, q: anytype, e: anytype, write_primary: bool) bool {
         if (!self.canFuseQMatmulElementwise(q, e)) return false;
         const q_is_src0 = e.src0 == q.dst and e.src0_offset == q.dst_offset;
         const secondary_buf = if (q_is_src0) e.src1 else e.src0;
@@ -3747,6 +3797,7 @@ const CompiledProgram = struct {
             .input_row_stride = qparams.input_row_stride,
             .dst_offset = qparams.dst_offset,
             .dst_row_stride = qparams.dst_row_stride,
+            .write_primary = @intFromBool(write_primary),
             .ew_op = @intFromEnum(e.op),
             .ew_is_swapped = if (q_is_src0) 0 else 1,
             .ew_dst_offset = e.dst_offset,
@@ -3762,7 +3813,7 @@ const CompiledProgram = struct {
         return program_mod.qmatmulFusedElementwiseSidecarCompatible(q, fe);
     }
 
-    fn encodeQMatmulFusedElementwise(self: *CompiledProgram, q: anytype, fe: anytype) bool {
+    fn encodeQMatmulFusedElementwise(self: *CompiledProgram, q: anytype, fe: anytype, write_primary: bool) bool {
         if (!self.canFuseQMatmulFusedElementwise(q, fe)) return false;
         const w = self.qweight_views[q.weight_idx];
         const qparams = qmatmulParams(q, w.block_size);
@@ -3775,6 +3826,7 @@ const CompiledProgram = struct {
         params.input_row_stride = qparams.input_row_stride;
         params.dst_offset = qparams.dst_offset;
         params.dst_row_stride = qparams.dst_row_stride;
+        params.write_primary = @intFromBool(write_primary);
         params.n_steps = @intCast(fe.steps.len);
         params.ew_dst_offset = fe.dst_offset;
 
@@ -4349,7 +4401,12 @@ const CompiledProgram = struct {
                 }
                 for (command.sidecarIndices(), 0..) |maybe_idx, slot| {
                     const idx = maybe_idx orelse continue;
-                    if (!self.canFuseQMatmulSliceAssign(ops[command.indices[slot]].qmatmul, ops[idx].slice_assign)) return false;
+                    const q = ops[command.indices[slot]].qmatmul;
+                    switch (ops[idx]) {
+                        .slice_assign => |sa| if (!self.canFuseQMatmulSliceAssign(q, sa)) return false,
+                        .elementwise => |e| if (!self.canFuseQMatmulElementwise(q, e)) return false,
+                        else => return false,
+                    }
                 }
 
                 const t0 = nowNs();
@@ -4372,10 +4429,11 @@ const CompiledProgram = struct {
             .qmatmul => |q| q,
             else => return false,
         };
+        const write_primary = program_mod.projectionPrimaryOutputHasExternalUsers(ops, anchor_idx, sidecar_idx);
         return switch (ops[sidecar_idx]) {
-            .slice_assign => |sa| if (q.M == 1) self.encodeQMatvecSliceAssign(q, sa) else self.encodeQMatmulSliceAssign(q, sa),
-            .elementwise => |e| self.encodeQMatmulElementwise(q, e),
-            .fused_elementwise => |fe| self.encodeQMatmulFusedElementwise(q, fe),
+            .slice_assign => |sa| if (q.M == 1) self.encodeQMatvecSliceAssign(q, sa, write_primary) else self.encodeQMatmulSliceAssign(q, sa, write_primary),
+            .elementwise => |e| self.encodeQMatmulElementwise(q, e, write_primary),
+            .fused_elementwise => |fe| self.encodeQMatmulFusedElementwise(q, fe, write_primary),
             else => false,
         };
     }
@@ -5204,6 +5262,74 @@ test "metal backend qmatmul batch carries cache-store sidecars" {
     try std.testing.expectEqual(@as(u64, 2), rt.backend_dispatch_count);
 }
 
+test "metal backend qmatmul batch carries elementwise sidecars" {
+    var metal = MetalBackend.init() catch |err| switch (err) {
+        error.MetalNotAvailable => return,
+        else => return err,
+    };
+    defer metal.deinit();
+    metal.setRegionProgramDispatch(true);
+    const be = metal.backend();
+
+    var input = [_]f32{ 1, 2, 3, 4, 5, 6 };
+    var bias = [_]f32{ 10, 20, 30, 40, 50, 60, 70, 80 };
+    var sidecar_out = [_]f32{0} ** 8;
+    const qdata = [_]i8{
+        1, 0, 0, 0,
+        0, 1, 0, 0,
+        0, 0, 1, 0,
+    };
+    const scales = [_]f32{ 1, 1, 1 };
+    const qweights = [_]backend_mod.QuantizedWeightUpload{.{ .data = &qdata, .scales = &scales, .rows = 3, .cols = 4, .block_size = 4 }};
+
+    var ops: [8]backend_mod.DeviceOp = undefined;
+    for (ops[0..7], 0..) |*op, i| {
+        op.* = .{ .qmatmul = .{
+            .dst = @intCast(i + 1),
+            .input = 0,
+            .weight_idx = 0,
+            .M = 2,
+            .N = 4,
+            .K = 3,
+        } };
+    }
+    ops[7] = .{ .elementwise = .{
+        .op = .add,
+        .dst = 8,
+        .src0 = 7,
+        .src1 = 9,
+        .n = 8,
+    } };
+
+    const buf_sizes = [_]usize{ 6, 8, 8, 8, 8, 8, 8, 8, 8, 8 };
+    const uploads = [_]backend_mod.ProgramIO{
+        .{ .buf_idx = 0, .host_ptr = @ptrCast(&input), .size = input.len * 4 },
+        .{ .buf_idx = 8, .host_ptr = @ptrCast(&sidecar_out), .size = sidecar_out.len * 4 },
+        .{ .buf_idx = 9, .host_ptr = @ptrCast(&bias), .size = bias.len * 4 },
+    };
+    const program = backend_mod.DeviceProgram{
+        .ops = &ops,
+        .n_buffers = 10,
+        .buffer_sizes = &buf_sizes,
+        .initial_uploads = &uploads,
+        .qweights = &qweights,
+    };
+
+    const handle = be.compileProgram(program) orelse return error.CompileFailed;
+    defer be.freeProgram(handle);
+
+    var got: [8]f32 = undefined;
+    var out = [_]backend_mod.ProgramIO{.{ .buf_idx = 8, .host_ptr = @ptrCast(&got), .size = got.len * 4 }};
+    be.executeProgram(handle, &.{}, &out);
+
+    try std.testing.expectEqualSlices(f32, &.{ 11, 22, 33, 40, 54, 65, 76, 80 }, &got);
+
+    const rt = be.getRuntimeProfile(handle).?;
+    try std.testing.expectEqual(@as(u64, 8), rt.backend_op_count);
+    try std.testing.expectEqual(@as(u64, 0), rt.fallback_op_count);
+    try std.testing.expectEqual(@as(u64, 2), rt.backend_dispatch_count);
+}
+
 test "metal backend region batches independent elementwise ops" {
     var metal = MetalBackend.init() catch |err| switch (err) {
         error.MetalNotAvailable => return,
@@ -5453,6 +5579,81 @@ test "metal backend region fuses qmatmul elementwise sidecar" {
     try std.testing.expectEqual(@as(u64, 8), rt.backend_op_count);
     try std.testing.expectEqual(@as(u64, 0), rt.fallback_op_count);
     try std.testing.expectEqual(@as(u64, 4), rt.backend_dispatch_count);
+}
+
+test "metal qmatmul sidecar elides dead primary output" {
+    var metal = MetalBackend.init() catch |err| switch (err) {
+        error.MetalNotAvailable => return,
+        else => return err,
+    };
+    defer metal.deinit();
+    metal.setRegionProgramDispatch(true);
+    const be = metal.backend();
+
+    var input = [_]f32{ 1, 2, 3, 4, 5, 6 };
+    var q_out = [_]f32{99} ** 8;
+    var residual = [_]f32{ 10, 10, 10, 10, 10, 10, 10, 10 };
+    var fused_out = [_]f32{0} ** 8;
+    const qdata = [_]i8{
+        1, 0, 0, 0,
+        0, 1, 0, 0,
+        0, 0, 1, 0,
+    };
+    const scales = [_]f32{ 1, 1, 1 };
+    const qweights = [_]backend_mod.QuantizedWeightUpload{.{ .data = &qdata, .scales = &scales, .rows = 3, .cols = 4, .block_size = 4 }};
+
+    var ops: [8]backend_mod.DeviceOp = undefined;
+    for (ops[0..7], 0..) |*op, i| {
+        op.* = .{ .qmatmul = .{
+            .dst = @intCast(i + 1),
+            .input = 0,
+            .weight_idx = 0,
+            .M = 2,
+            .N = 4,
+            .K = 3,
+        } };
+    }
+    ops[7] = .{ .elementwise = .{
+        .op = .add,
+        .dst = 9,
+        .src0 = 7,
+        .src1 = 8,
+        .n = 8,
+    } };
+
+    const buf_sizes = [_]usize{ 6, 8, 8, 8, 8, 8, 8, 8, 8, 8 };
+    const uploads = [_]backend_mod.ProgramIO{
+        .{ .buf_idx = 0, .host_ptr = @ptrCast(&input), .size = input.len * 4 },
+        .{ .buf_idx = 7, .host_ptr = @ptrCast(&q_out), .size = q_out.len * 4 },
+        .{ .buf_idx = 8, .host_ptr = @ptrCast(&residual), .size = residual.len * 4 },
+        .{ .buf_idx = 9, .host_ptr = @ptrCast(&fused_out), .size = fused_out.len * 4 },
+    };
+    const program = backend_mod.DeviceProgram{
+        .ops = &ops,
+        .n_buffers = 10,
+        .buffer_sizes = &buf_sizes,
+        .initial_uploads = &uploads,
+        .qweights = &qweights,
+    };
+
+    const handle = be.compileProgram(program) orelse return error.CompileFailed;
+    defer be.freeProgram(handle);
+
+    var got_q: [8]f32 = undefined;
+    var got_fused: [8]f32 = undefined;
+    var out = [_]backend_mod.ProgramIO{
+        .{ .buf_idx = 7, .host_ptr = @ptrCast(&got_q), .size = got_q.len * 4 },
+        .{ .buf_idx = 9, .host_ptr = @ptrCast(&got_fused), .size = got_fused.len * 4 },
+    };
+    be.executeProgram(handle, &.{}, &out);
+
+    try std.testing.expectEqualSlices(f32, &.{ 99, 99, 99, 99, 99, 99, 99, 99 }, &got_q);
+    try std.testing.expectEqualSlices(f32, &.{ 11, 12, 13, 10, 14, 15, 16, 10 }, &got_fused);
+
+    const rt = be.getRuntimeProfile(handle).?;
+    try std.testing.expectEqual(@as(u64, 8), rt.backend_op_count);
+    try std.testing.expectEqual(@as(u64, 0), rt.fallback_op_count);
+    try std.testing.expectEqual(@as(u64, 2), rt.backend_dispatch_count);
 }
 
 test "metal backend region fuses qmatmul fused-elementwise sidecar" {

--- a/src/backend/metal.zig
+++ b/src/backend/metal.zig
@@ -2880,15 +2880,39 @@ const CompiledProgram = struct {
     }
 
     fn encodeSliceAssignBatch(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, n: usize) void {
-        const first = ops[0].slice_assign;
+        var indices: [MAX_SLICE_ASSIGN_BATCH]usize = undefined;
+        for (0..n) |i| indices[i] = i;
+        self.encodeSliceAssignBatchIndices(ops, indices[0..n]);
+    }
+
+    fn canEncodeSliceAssignBatchIndices(_: *CompiledProgram, ops: []const backend_mod.DeviceOp, indices: []const usize) bool {
+        if (indices.len < 2 or indices.len > MAX_SLICE_ASSIGN_BATCH) return false;
+        if (indices[0] >= ops.len) return false;
+        const first = switch (ops[indices[0]]) {
+            .slice_assign => |sa| sa,
+            else => return false,
+        };
+        for (indices[1..]) |idx| {
+            if (idx >= ops.len) return false;
+            const next = switch (ops[idx]) {
+                .slice_assign => |sa| sa,
+                else => return false,
+            };
+            if (!sliceAssignBatchCompatible(first, next)) return false;
+        }
+        return true;
+    }
+
+    fn encodeSliceAssignBatchIndices(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, indices: []const usize) void {
+        const first = ops[indices[0]].slice_assign;
         const buffers = [_]DeviceBuffer{
             self.device_bufs[first.src],
             self.device_bufs[first.dst],
         };
         var params = std.mem.zeroes(SliceAssignBatchParams);
-        params.n_ops = @intCast(n);
-        for (ops[0..n], 0..) |op, i| {
-            const sa = op.slice_assign;
+        params.n_ops = @intCast(indices.len);
+        for (indices, 0..) |idx, i| {
+            const sa = ops[idx].slice_assign;
             params.rows[i] = sa.rows;
             params.cols[i] = sa.cols;
             params.dst_offset[i] = sa.dst_offset;
@@ -2899,7 +2923,7 @@ const CompiledProgram = struct {
             params.src_col_stride[i] = sa.src_col_stride;
             params.max_n = @max(params.max_n, sa.rows * sa.cols);
         }
-        self.encodeTyped(SliceAssignBatchParams, self.backend.slice_assign_batch_pipeline, &buffers, params, 2, .{ .gx = linearGrid(params.max_n), .gy = @intCast(n) }, WG_SIZE);
+        self.encodeTyped(SliceAssignBatchParams, self.backend.slice_assign_batch_pipeline, &buffers, params, 2, .{ .gx = linearGrid(params.max_n), .gy = @intCast(indices.len) }, WG_SIZE);
     }
 
     fn canFuseRmsnormRepeatMul(rn: anytype, rp: anytype, e: anytype) bool {
@@ -3270,6 +3294,13 @@ const CompiledProgram = struct {
                 self.encodeSliceAssignBatch(ops[start..], n);
                 break :blk true;
             },
+            .movement_group => blk: {
+                if (!self.canEncodeSliceAssignBatchIndices(ops, command.anchorIndices())) break :blk false;
+                const t_batch = nowNs();
+                self.encodeSliceAssignBatchIndices(ops, command.anchorIndices());
+                self.recordRegionFusedRunFromIndices(ops, command.anchorIndices(), @intCast(nowNs() - t_batch));
+                break :blk true;
+            },
             .elementwise_batch => blk: {
                 for (command.anchorIndices()) |idx| {
                     if (idx >= ops.len) break :blk false;
@@ -3308,7 +3339,7 @@ const CompiledProgram = struct {
         };
 
         if (!encoded) return 0;
-        if (command.kind != .projection_group and command.kind != .elementwise_batch and command.kind != .attention_group) {
+        if (command.kind != .projection_group and command.kind != .elementwise_batch and command.kind != .attention_group and command.kind != .movement_group) {
             self.recordRegionFusedRun(ops[start..end], @intCast(nowNs() - t0));
         }
         program_mod.markProgramCommandUsed(skipped, command);

--- a/src/backend/metal.zig
+++ b/src/backend/metal.zig
@@ -10,9 +10,29 @@ const profile_mod = @import("../profile.zig");
 const reference = @import("reference.zig");
 const program_mod = @import("program.zig");
 const c = @cImport(@cInclude("metal_shim.h"));
+const DeviceOpTag = std.meta.Tag(backend_mod.DeviceOp);
 
 fn nowNs() i96 {
     return std.Io.Clock.awake.now(std.Io.Threaded.global_single_threaded.io()).nanoseconds;
+}
+
+fn DeviceOpPayload(comptime tag: DeviceOpTag) type {
+    inline for (@typeInfo(backend_mod.DeviceOp).@"union".fields) |field| {
+        if (comptime std.mem.eql(u8, field.name, @tagName(tag))) return field.type;
+    }
+    @compileError("unknown DeviceOp tag: " ++ @tagName(tag));
+}
+
+fn deviceOpAs(comptime tag: DeviceOpTag, op: backend_mod.DeviceOp) ?DeviceOpPayload(tag) {
+    return switch (op) {
+        tag => |payload| payload,
+        else => null,
+    };
+}
+
+fn deviceOpAt(comptime tag: DeviceOpTag, ops: []const backend_mod.DeviceOp, idx: usize) ?DeviceOpPayload(tag) {
+    if (idx >= ops.len) return null;
+    return deviceOpAs(tag, ops[idx]);
 }
 
 // ── Tile size for simdgroup kernel ────────────────────────────────
@@ -198,6 +218,7 @@ const shader_source =
     \\}
     \\
     \\constant uint MAX_QMATMUL_BATCH = 4;
+    \\constant uint MAX_QMATMUL_BATCH_SIDECARS = 8;
     \\
     \\struct QMatmulBatch4Params {
     \\    uint n_ops; uint max_tiles_y;
@@ -210,17 +231,18 @@ const shader_source =
     \\    uint dst_offset[MAX_QMATMUL_BATCH];
     \\    uint dst_row_stride[MAX_QMATMUL_BATCH];
     \\    uint write_primary[MAX_QMATMUL_BATCH];
-    \\    uint sidecar_kind[MAX_QMATMUL_BATCH];
-    \\    uint slice_rows[MAX_QMATMUL_BATCH];
-    \\    uint slice_cols[MAX_QMATMUL_BATCH];
-    \\    uint slice_src_col_start[MAX_QMATMUL_BATCH];
-    \\    uint slice_dst_offset[MAX_QMATMUL_BATCH];
-    \\    uint slice_dst_row_stride[MAX_QMATMUL_BATCH];
-    \\    uint slice_dst_col_stride[MAX_QMATMUL_BATCH];
-    \\    uint ew_op[MAX_QMATMUL_BATCH];
-    \\    uint ew_is_swapped[MAX_QMATMUL_BATCH];
-    \\    uint ew_dst_offset[MAX_QMATMUL_BATCH];
-    \\    uint ew_secondary_offset[MAX_QMATMUL_BATCH];
+    \\    uint sidecar_count[MAX_QMATMUL_BATCH];
+    \\    uint sidecar_kind[MAX_QMATMUL_BATCH * MAX_QMATMUL_BATCH_SIDECARS];
+    \\    uint slice_rows[MAX_QMATMUL_BATCH * MAX_QMATMUL_BATCH_SIDECARS];
+    \\    uint slice_cols[MAX_QMATMUL_BATCH * MAX_QMATMUL_BATCH_SIDECARS];
+    \\    uint slice_src_col_start[MAX_QMATMUL_BATCH * MAX_QMATMUL_BATCH_SIDECARS];
+    \\    uint slice_dst_offset[MAX_QMATMUL_BATCH * MAX_QMATMUL_BATCH_SIDECARS];
+    \\    uint slice_dst_row_stride[MAX_QMATMUL_BATCH * MAX_QMATMUL_BATCH_SIDECARS];
+    \\    uint slice_dst_col_stride[MAX_QMATMUL_BATCH * MAX_QMATMUL_BATCH_SIDECARS];
+    \\    uint ew_op[MAX_QMATMUL_BATCH * MAX_QMATMUL_BATCH_SIDECARS];
+    \\    uint ew_is_swapped[MAX_QMATMUL_BATCH * MAX_QMATMUL_BATCH_SIDECARS];
+    \\    uint ew_dst_offset[MAX_QMATMUL_BATCH * MAX_QMATMUL_BATCH_SIDECARS];
+    \\    uint ew_secondary_offset[MAX_QMATMUL_BATCH * MAX_QMATMUL_BATCH_SIDECARS];
     \\};
     \\
     \\kernel void qmatmul_batch4_f32(
@@ -330,18 +352,200 @@ const shader_source =
     \\        if (cr < M && cc < N) {
     \\            float val = tC[i];
     \\            if (p.write_primary[slot] != 0) output[p.dst_offset[slot] + cr * p.dst_row_stride[slot] + cc] = val;
-    \\            uint slice_col_start = p.slice_src_col_start[slot];
-    \\            if (p.sidecar_kind[slot] == 1 && cc >= slice_col_start && cc < slice_col_start + p.slice_rows[slot] && cr < p.slice_cols[slot]) {
-    \\                uint slice_row = cc - slice_col_start;
-    \\                sidecar_dst[p.slice_dst_offset[slot] + slice_row * p.slice_dst_row_stride[slot] + cr * p.slice_dst_col_stride[slot]] = val;
-    \\            } else if (p.sidecar_kind[slot] == 2) {
-    \\                uint linear = cr * N + cc;
-    \\                float other = secondary[p.ew_secondary_offset[slot] + linear];
-    \\                float ew = val;
-    \\                if (p.ew_op[slot] == 7) ew = (p.ew_is_swapped[slot] != 0) ? other + val : val + other;
-    \\                else if (p.ew_op[slot] == 8) ew = (p.ew_is_swapped[slot] != 0) ? other * val : val * other;
-    \\                sidecar_dst[p.ew_dst_offset[slot] + linear] = ew;
+    \\            for (uint sid = 0; sid < p.sidecar_count[slot]; sid++) {
+    \\                uint si = slot * MAX_QMATMUL_BATCH_SIDECARS + sid;
+    \\                uint slice_col_start = p.slice_src_col_start[si];
+    \\                if (p.sidecar_kind[si] == 1 && cc >= slice_col_start && cc < slice_col_start + p.slice_rows[si] && cr < p.slice_cols[si]) {
+    \\                    uint slice_row = cc - slice_col_start;
+    \\                    sidecar_dst[p.slice_dst_offset[si] + slice_row * p.slice_dst_row_stride[si] + cr * p.slice_dst_col_stride[si]] = val;
+    \\                } else if (p.sidecar_kind[si] == 2) {
+    \\                    uint linear = cr * N + cc;
+    \\                    float other = secondary[p.ew_secondary_offset[si] + linear];
+    \\                    float ew = val;
+    \\                    if (p.ew_op[si] == 7) ew = (p.ew_is_swapped[si] != 0) ? other + val : val + other;
+    \\                    else if (p.ew_op[si] == 8) ew = (p.ew_is_swapped[si] != 0) ? other * val : val * other;
+    \\                    sidecar_dst[p.ew_dst_offset[si] + linear] = ew;
+    \\                }
     \\            }
+    \\        }
+    \\    }
+    \\}
+    \\
+    \\constant uint MAX_QMATMUL_ROPE_STORE_BATCH = 4;
+    \\
+    \\struct QMatmulRopeStoreBatch4Params {
+    \\    uint n_ops; uint max_tiles_y;
+    \\    uint M[MAX_QMATMUL_ROPE_STORE_BATCH];
+    \\    uint N[MAX_QMATMUL_ROPE_STORE_BATCH];
+    \\    uint K[MAX_QMATMUL_ROPE_STORE_BATCH];
+    \\    uint block_size[MAX_QMATMUL_ROPE_STORE_BATCH];
+    \\    uint input_offset[MAX_QMATMUL_ROPE_STORE_BATCH];
+    \\    uint input_row_stride[MAX_QMATMUL_ROPE_STORE_BATCH];
+    \\    uint dst_offset[MAX_QMATMUL_ROPE_STORE_BATCH];
+    \\    uint dst_row_stride[MAX_QMATMUL_ROPE_STORE_BATCH];
+    \\    uint write_primary[MAX_QMATMUL_ROPE_STORE_BATCH];
+    \\    uint rope_half_d[MAX_QMATMUL_ROPE_STORE_BATCH];
+    \\    uint rope_src_col_start[MAX_QMATMUL_ROPE_STORE_BATCH];
+    \\    uint rope_cs_off[MAX_QMATMUL_ROPE_STORE_BATCH];
+    \\    uint rope_cs_cs[MAX_QMATMUL_ROPE_STORE_BATCH];
+    \\    uint slice_dst_offset[MAX_QMATMUL_ROPE_STORE_BATCH];
+    \\    uint slice_dst_row_stride[MAX_QMATMUL_ROPE_STORE_BATCH];
+    \\    uint slice_dst_col_stride[MAX_QMATMUL_ROPE_STORE_BATCH];
+    \\};
+    \\
+    \\kernel void qmatmul_rope_store_batch4_f32(
+    \\    device const char*  w0 [[buffer(0)]],
+    \\    device const float* s0 [[buffer(1)]],
+    \\    device const float* i0 [[buffer(2)]],
+    \\    device float*       o0 [[buffer(3)]],
+    \\    device const float* cs0 [[buffer(4)]],
+    \\    device float*       dst0 [[buffer(5)]],
+    \\    device const char*  w1 [[buffer(6)]],
+    \\    device const float* s1 [[buffer(7)]],
+    \\    device const float* i1 [[buffer(8)]],
+    \\    device float*       o1 [[buffer(9)]],
+    \\    device const float* cs1 [[buffer(10)]],
+    \\    device float*       dst1 [[buffer(11)]],
+    \\    device const char*  w2 [[buffer(12)]],
+    \\    device const float* s2 [[buffer(13)]],
+    \\    device const float* i2 [[buffer(14)]],
+    \\    device float*       o2 [[buffer(15)]],
+    \\    device const float* cs2 [[buffer(16)]],
+    \\    device float*       dst2 [[buffer(17)]],
+    \\    device const char*  w3 [[buffer(18)]],
+    \\    device const float* s3 [[buffer(19)]],
+    \\    device const float* i3 [[buffer(20)]],
+    \\    device float*       o3 [[buffer(21)]],
+    \\    device const float* cs3 [[buffer(22)]],
+    \\    device float*       dst3 [[buffer(23)]],
+    \\    constant QMatmulRopeStoreBatch4Params& p [[buffer(24)]],
+    \\    uint2 group_id [[threadgroup_position_in_grid]],
+    \\    uint  simd_idx [[simdgroup_index_in_threadgroup]],
+    \\    uint  lane     [[thread_index_in_simdgroup]],
+    \\    uint  tid      [[thread_index_in_threadgroup]]
+    \\) {
+    \\    uint slot = group_id.y / p.max_tiles_y;
+    \\    uint row_tile = group_id.y - slot * p.max_tiles_y;
+    \\    if (slot >= p.n_ops) return;
+    \\
+    \\    uint M = p.M[slot], N = p.N[slot], K = p.K[slot];
+    \\    uint rope_half = p.rope_half_d[slot];
+    \\    uint rope_d = rope_half * 2;
+    \\    const uint local_col_base = group_id.x * TILE;
+    \\    if (local_col_base >= rope_d) return;
+    \\    bool lower_half_tile = local_col_base < rope_half;
+    \\    if (!lower_half_tile && p.write_primary[slot] == 0) return;
+    \\
+    \\    device const char* w = w0;
+    \\    device const float* s = s0;
+    \\    device const float* input = i0;
+    \\    device float* output = o0;
+    \\    device const float* cos_sin = cs0;
+    \\    device float* slice_dst = dst0;
+    \\    switch (slot) {
+    \\        case 1: w = w1; s = s1; input = i1; output = o1; cos_sin = cs1; slice_dst = dst1; break;
+    \\        case 2: w = w2; s = s2; input = i2; output = o2; cos_sin = cs2; slice_dst = dst2; break;
+    \\        case 3: w = w3; s = s3; input = i3; output = o3; cos_sin = cs3; slice_dst = dst3; break;
+    \\        default: break;
+    \\    }
+    \\
+    \\    const uint gRow = row_tile * TILE;
+    \\    const uint sRow = (simd_idx / 2) * 16;
+    \\    const uint sCol = (simd_idx % 2) * 16;
+    \\    const uint gCol = p.rope_src_col_start[slot] + local_col_base;
+    \\    const uint pairCol = gCol + rope_half;
+    \\
+    \\    simdgroup_float8x8 acc[4] = {
+    \\        simdgroup_float8x8(0), simdgroup_float8x8(0),
+    \\        simdgroup_float8x8(0), simdgroup_float8x8(0)
+    \\    };
+    \\    simdgroup_float8x8 pair_acc[4] = {
+    \\        simdgroup_float8x8(0), simdgroup_float8x8(0),
+    \\        simdgroup_float8x8(0), simdgroup_float8x8(0)
+    \\    };
+    \\
+    \\    threadgroup float tI[TILE * 8];
+    \\    threadgroup float tW[8 * TILE];
+    \\    threadgroup float tWPair[8 * TILE];
+    \\
+    \\    for (uint kt = 0; kt < K; kt += 8) {
+    \\        for (uint i = tid; i < TILE * 8; i += 128) {
+    \\            uint r = i / 8, c = i % 8;
+    \\            uint ir = gRow + r, ic = kt + c;
+    \\            tI[i] = (ir < M && ic < K) ? input[p.input_offset[slot] + ir * p.input_row_stride[slot] + ic] : 0.0f;
+    \\        }
+    \\        for (uint i = tid; i < 8 * TILE; i += 128) {
+    \\            uint r = i / TILE, c = i % TILE;
+    \\            uint kr = kt + r, nc = gCol + c;
+    \\            if (kr < K && nc < N) {
+    \\                uint w_idx = kr * N + nc;
+    \\                tW[i] = float(w[w_idx]) * s[w_idx / p.block_size[slot]];
+    \\            } else {
+    \\                tW[i] = 0.0f;
+    \\            }
+    \\            uint pc = pairCol + c;
+    \\            if (lower_half_tile && kr < K && pc < N) {
+    \\                uint pair_w_idx = kr * N + pc;
+    \\                tWPair[i] = float(w[pair_w_idx]) * s[pair_w_idx / p.block_size[slot]];
+    \\            } else {
+    \\                tWPair[i] = 0.0f;
+    \\            }
+    \\        }
+    \\        threadgroup_barrier(mem_flags::mem_threadgroup);
+    \\
+    \\        simdgroup_float8x8 a0, a1, b0, b1;
+    \\        simdgroup_load(a0, tI + (sRow + 0) * 8, 8);
+    \\        simdgroup_load(a1, tI + (sRow + 8) * 8, 8);
+    \\        simdgroup_load(b0, tW + (sCol + 0), TILE);
+    \\        simdgroup_load(b1, tW + (sCol + 8), TILE);
+    \\        simdgroup_multiply_accumulate(acc[0], a0, b0, acc[0]);
+    \\        simdgroup_multiply_accumulate(acc[1], a0, b1, acc[1]);
+    \\        simdgroup_multiply_accumulate(acc[2], a1, b0, acc[2]);
+    \\        simdgroup_multiply_accumulate(acc[3], a1, b1, acc[3]);
+    \\        if (lower_half_tile) {
+    \\            simdgroup_float8x8 pb0, pb1;
+    \\            simdgroup_load(pb0, tWPair + (sCol + 0), TILE);
+    \\            simdgroup_load(pb1, tWPair + (sCol + 8), TILE);
+    \\            simdgroup_multiply_accumulate(pair_acc[0], a0, pb0, pair_acc[0]);
+    \\            simdgroup_multiply_accumulate(pair_acc[1], a0, pb1, pair_acc[1]);
+    \\            simdgroup_multiply_accumulate(pair_acc[2], a1, pb0, pair_acc[2]);
+    \\            simdgroup_multiply_accumulate(pair_acc[3], a1, pb1, pair_acc[3]);
+    \\        }
+    \\        threadgroup_barrier(mem_flags::mem_threadgroup);
+    \\    }
+    \\
+    \\    threadgroup float tC[TILE * TILE];
+    \\    threadgroup float tCPair[TILE * TILE];
+    \\    simdgroup_store(acc[0], tC + (sRow + 0) * TILE + sCol + 0, TILE);
+    \\    simdgroup_store(acc[1], tC + (sRow + 0) * TILE + sCol + 8, TILE);
+    \\    simdgroup_store(acc[2], tC + (sRow + 8) * TILE + sCol + 0, TILE);
+    \\    simdgroup_store(acc[3], tC + (sRow + 8) * TILE + sCol + 8, TILE);
+    \\    if (lower_half_tile) {
+    \\        simdgroup_store(pair_acc[0], tCPair + (sRow + 0) * TILE + sCol + 0, TILE);
+    \\        simdgroup_store(pair_acc[1], tCPair + (sRow + 0) * TILE + sCol + 8, TILE);
+    \\        simdgroup_store(pair_acc[2], tCPair + (sRow + 8) * TILE + sCol + 0, TILE);
+    \\        simdgroup_store(pair_acc[3], tCPair + (sRow + 8) * TILE + sCol + 8, TILE);
+    \\    }
+    \\    threadgroup_barrier(mem_flags::mem_threadgroup);
+    \\
+    \\    for (uint i = tid; i < TILE * TILE; i += 128) {
+    \\        uint r = i / TILE, c = i % TILE;
+    \\        uint cr = gRow + r, local_cc = local_col_base + c;
+    \\        if (cr >= M || local_cc >= rope_d) continue;
+    \\        uint cc = p.rope_src_col_start[slot] + local_cc;
+    \\        float val = tC[i];
+    \\        if (p.write_primary[slot] != 0 && cc < N) {
+    \\            output[p.dst_offset[slot] + cr * p.dst_row_stride[slot] + cc] = val;
+    \\        }
+    \\        if (lower_half_tile && local_cc < rope_half) {
+    \\            float pair = tCPair[i];
+    \\            float cos_val = cos_sin[p.rope_cs_off[slot] + cr * p.rope_cs_cs[slot] + local_cc];
+    \\            float sin_val = cos_sin[p.rope_cs_off[slot] + cr * p.rope_cs_cs[slot] + rope_half + local_cc];
+    \\            float y_lo = val * cos_val - pair * sin_val;
+    \\            float y_hi = pair * cos_val + val * sin_val;
+    \\            uint dst_col = p.slice_dst_offset[slot] + cr * p.slice_dst_col_stride[slot];
+    \\            slice_dst[dst_col + local_cc * p.slice_dst_row_stride[slot]] = y_lo;
+    \\            slice_dst[dst_col + (local_cc + rope_half) * p.slice_dst_row_stride[slot]] = y_hi;
     \\        }
     \\    }
     \\}
@@ -373,6 +577,18 @@ const shader_source =
     \\    uint block_size[MAX_QMATVEC_BATCH];
     \\    uint input_offset[MAX_QMATVEC_BATCH];
     \\    uint dst_offset[MAX_QMATVEC_BATCH];
+    \\    uint write_primary[MAX_QMATVEC_BATCH];
+    \\    uint sidecar_kind[MAX_QMATVEC_BATCH];
+    \\    uint slice_rows[MAX_QMATVEC_BATCH];
+    \\    uint slice_src_col_start[MAX_QMATVEC_BATCH];
+    \\    uint slice_dst_offset[MAX_QMATVEC_BATCH];
+    \\    uint slice_dst_row_stride[MAX_QMATVEC_BATCH];
+    \\    uint rope_half_d[MAX_QMATVEC_BATCH];
+    \\    uint rope_cs_off[MAX_QMATVEC_BATCH];
+    \\    uint ew_op[MAX_QMATVEC_BATCH];
+    \\    uint ew_is_swapped[MAX_QMATVEC_BATCH];
+    \\    uint ew_dst_offset[MAX_QMATVEC_BATCH];
+    \\    uint ew_secondary_offset[MAX_QMATVEC_BATCH];
     \\};
     \\
     \\kernel void qmatvec_batch4_f32(
@@ -380,19 +596,27 @@ const shader_source =
     \\    device const float* s0 [[buffer(1)]],
     \\    device const float* i0 [[buffer(2)]],
     \\    device float*       o0 [[buffer(3)]],
-    \\    device const char*  w1 [[buffer(4)]],
-    \\    device const float* s1 [[buffer(5)]],
-    \\    device const float* i1 [[buffer(6)]],
-    \\    device float*       o1 [[buffer(7)]],
-    \\    device const char*  w2 [[buffer(8)]],
-    \\    device const float* s2 [[buffer(9)]],
-    \\    device const float* i2 [[buffer(10)]],
-    \\    device float*       o2 [[buffer(11)]],
-    \\    device const char*  w3 [[buffer(12)]],
-    \\    device const float* s3 [[buffer(13)]],
-    \\    device const float* i3 [[buffer(14)]],
-    \\    device float*       o3 [[buffer(15)]],
-    \\    constant QMatvecBatch4Params& p [[buffer(16)]],
+    \\    device const float* aux0 [[buffer(4)]],
+    \\    device float*       d0 [[buffer(5)]],
+    \\    device const char*  w1 [[buffer(6)]],
+    \\    device const float* s1 [[buffer(7)]],
+    \\    device const float* i1 [[buffer(8)]],
+    \\    device float*       o1 [[buffer(9)]],
+    \\    device const float* aux1 [[buffer(10)]],
+    \\    device float*       d1 [[buffer(11)]],
+    \\    device const char*  w2 [[buffer(12)]],
+    \\    device const float* s2 [[buffer(13)]],
+    \\    device const float* i2 [[buffer(14)]],
+    \\    device float*       o2 [[buffer(15)]],
+    \\    device const float* aux2 [[buffer(16)]],
+    \\    device float*       d2 [[buffer(17)]],
+    \\    device const char*  w3 [[buffer(18)]],
+    \\    device const float* s3 [[buffer(19)]],
+    \\    device const float* i3 [[buffer(20)]],
+    \\    device float*       o3 [[buffer(21)]],
+    \\    device const float* aux3 [[buffer(22)]],
+    \\    device float*       d3 [[buffer(23)]],
+    \\    constant QMatvecBatch4Params& p [[buffer(24)]],
     \\    uint2 gid [[thread_position_in_grid]]
     \\) {
     \\    uint col = gid.x;
@@ -403,10 +627,12 @@ const shader_source =
     \\    device const float* s = s0;
     \\    device const float* input = i0;
     \\    device float* output = o0;
+    \\    device const float* sidecar_src = aux0;
+    \\    device float* sidecar_dst = d0;
     \\    switch (slot) {
-    \\        case 1: w = w1; s = s1; input = i1; output = o1; break;
-    \\        case 2: w = w2; s = s2; input = i2; output = o2; break;
-    \\        case 3: w = w3; s = s3; input = i3; output = o3; break;
+    \\        case 1: w = w1; s = s1; input = i1; output = o1; sidecar_src = aux1; sidecar_dst = d1; break;
+    \\        case 2: w = w2; s = s2; input = i2; output = o2; sidecar_src = aux2; sidecar_dst = d2; break;
+    \\        case 3: w = w3; s = s3; input = i3; output = o3; sidecar_src = aux3; sidecar_dst = d3; break;
     \\        default: break;
     \\    }
     \\
@@ -415,7 +641,33 @@ const shader_source =
     \\        uint w_idx = k * p.N[slot] + col;
     \\        sum += input[p.input_offset[slot] + k] * float(w[w_idx]) * s[w_idx / p.block_size[slot]];
     \\    }
-    \\    output[p.dst_offset[slot] + col] = sum;
+    \\    if (p.write_primary[slot] != 0) output[p.dst_offset[slot] + col] = sum;
+    \\    uint slice_col_start = p.slice_src_col_start[slot];
+    \\    if (p.sidecar_kind[slot] == 1 && col >= slice_col_start && col < slice_col_start + p.slice_rows[slot]) {
+    \\        uint slice_row = col - slice_col_start;
+    \\        sidecar_dst[p.slice_dst_offset[slot] + slice_row * p.slice_dst_row_stride[slot]] = sum;
+    \\    } else if (p.sidecar_kind[slot] == 2) {
+    \\        uint rope_half = p.rope_half_d[slot];
+    \\        if (col >= slice_col_start && col < slice_col_start + rope_half) {
+    \\            uint local = col - slice_col_start;
+    \\            uint pair_col = col + rope_half;
+    \\            float pair_sum = 0.0f;
+    \\            for (uint k = 0; k < p.K[slot]; k++) {
+    \\                uint w_idx = k * p.N[slot] + pair_col;
+    \\                pair_sum += input[p.input_offset[slot] + k] * float(w[w_idx]) * s[w_idx / p.block_size[slot]];
+    \\            }
+    \\            float cos_val = sidecar_src[p.rope_cs_off[slot] + local];
+    \\            float sin_val = sidecar_src[p.rope_cs_off[slot] + rope_half + local];
+    \\            sidecar_dst[p.slice_dst_offset[slot] + local * p.slice_dst_row_stride[slot]] = sum * cos_val - pair_sum * sin_val;
+    \\            sidecar_dst[p.slice_dst_offset[slot] + (local + rope_half) * p.slice_dst_row_stride[slot]] = pair_sum * cos_val + sum * sin_val;
+    \\        }
+    \\    } else if (p.sidecar_kind[slot] == 3) {
+    \\        float other = sidecar_src[p.ew_secondary_offset[slot] + col];
+    \\        float ew = sum;
+    \\        if (p.ew_op[slot] == 7) ew = (p.ew_is_swapped[slot] != 0) ? other + sum : sum + other;
+    \\        else if (p.ew_op[slot] == 8) ew = (p.ew_is_swapped[slot] != 0) ? other * sum : sum * other;
+    \\        sidecar_dst[p.ew_dst_offset[slot] + col] = ew;
+    \\    }
     \\}
     \\
     \\// ── F16 matvec: M==1, one thread per output element ────
@@ -989,6 +1241,7 @@ const shader_source =
     \\constant uint MAX_SEQ = 4096;
     \\constant uint MAX_ATTENTION_BATCH_HEADS = 16;
     \\constant uint MAX_ATTENTION_STORE_BATCH_HEADS = 4;
+    \\constant uint MAX_ATTENTION_ROPE_STORE_SHARED_BATCH_HEADS = 16;
     \\
     \\// One threadgroup per query position. Decode is the seq_q=1 case.
     \\kernel void attention_f32(
@@ -1472,6 +1725,117 @@ const shader_source =
     \\    }
     \\}
     \\
+    \\struct AttentionRopeStoreSharedBatchParams {
+    \\    uint n_heads; uint d_head; uint seq_q; uint seq_kv;
+    \\    float scale;
+    \\    uint rope_half_d;
+    \\    uint rope_src_off[MAX_ATTENTION_ROPE_STORE_SHARED_BATCH_HEADS];
+    \\    uint rope_cs_off[MAX_ATTENTION_ROPE_STORE_SHARED_BATCH_HEADS];
+    \\    uint k_off[MAX_ATTENTION_ROPE_STORE_SHARED_BATCH_HEADS];
+    \\    uint v_off[MAX_ATTENTION_ROPE_STORE_SHARED_BATCH_HEADS];
+    \\    uint mask_off[MAX_ATTENTION_ROPE_STORE_SHARED_BATCH_HEADS];
+    \\    uint slice_dst_offset[MAX_ATTENTION_ROPE_STORE_SHARED_BATCH_HEADS];
+    \\    uint rope_src_rs; uint rope_src_cs; uint rope_cs_cs;
+    \\    uint k_rs; uint k_cs; uint v_rs; uint v_cs;
+    \\    uint mask_rs; uint mask_cs;
+    \\    uint slice_dst_row_stride; uint slice_dst_col_stride;
+    \\};
+    \\
+    \\inline float rope_shared_batch_q_value(
+    \\    device const float* q_src,
+    \\    device const float* cos_sin,
+    \\    constant AttentionRopeStoreSharedBatchParams& p,
+    \\    uint head,
+    \\    uint r,
+    \\    uint q_col
+    \\) {
+    \\    uint i = r;
+    \\    bool high = false;
+    \\    if (i >= p.rope_half_d) {
+    \\        i -= p.rope_half_d;
+    \\        high = true;
+    \\    }
+    \\    float cos_val = cos_sin[p.rope_cs_off[head] + q_col * p.rope_cs_cs + i];
+    \\    float sin_val = cos_sin[p.rope_cs_off[head] + q_col * p.rope_cs_cs + p.rope_half_d + i];
+    \\    float x_lo = q_src[p.rope_src_off[head] + q_col * p.rope_src_cs + i * p.rope_src_rs];
+    \\    float x_hi = q_src[p.rope_src_off[head] + q_col * p.rope_src_cs + (i + p.rope_half_d) * p.rope_src_rs];
+    \\    return high ? (x_hi * cos_val + x_lo * sin_val) : (x_lo * cos_val - x_hi * sin_val);
+    \\}
+    \\
+    \\kernel void attention_rope_store_shared_batch_f32(
+    \\    device const float* q_src     [[buffer(0)]],
+    \\    device const float* cos_sin   [[buffer(1)]],
+    \\    device const float* K         [[buffer(2)]],
+    \\    device const float* V         [[buffer(3)]],
+    \\    device const float* mask      [[buffer(4)]],
+    \\    device float*       slice_dst [[buffer(5)]],
+    \\    constant AttentionRopeStoreSharedBatchParams& p [[buffer(6)]],
+    \\    uint2 group [[threadgroup_position_in_grid]],
+    \\    uint tid     [[thread_index_in_threadgroup]]
+    \\) {
+    \\    uint q_col = group.x;
+    \\    uint head = group.y;
+    \\    if (q_col >= p.seq_q) return;
+    \\    if (head >= p.n_heads) return;
+    \\    const uint tg_size = 256;
+    \\
+    \\    threadgroup float scores[MAX_SEQ];
+    \\    threadgroup float scratch[256];
+    \\
+    \\    uint k_off = p.k_off[head];
+    \\    uint v_off = p.v_off[head];
+    \\    uint mask_off = p.mask_off[head];
+    \\    uint slice_dst_off = p.slice_dst_offset[head];
+    \\
+    \\    for (uint s = tid; s < p.seq_kv; s += tg_size) {
+    \\        float mv = mask[mask_off + s * p.mask_rs + q_col * p.mask_cs];
+    \\        if (!isfinite(mv)) { scores[s] = -INFINITY; continue; }
+    \\        float dot = 0.0f;
+    \\        for (uint r = 0; r < p.d_head; r++)
+    \\            dot += rope_shared_batch_q_value(q_src, cos_sin, p, head, r, q_col) * K[k_off + r * p.k_rs + s * p.k_cs];
+    \\        scores[s] = dot * p.scale + mv;
+    \\    }
+    \\    threadgroup_barrier(mem_flags::mem_threadgroup);
+    \\
+    \\    float local_max = -INFINITY;
+    \\    for (uint s = tid; s < p.seq_kv; s += tg_size)
+    \\        local_max = max(local_max, scores[s]);
+    \\    scratch[tid] = local_max;
+    \\    threadgroup_barrier(mem_flags::mem_threadgroup);
+    \\    for (uint stride = tg_size / 2; stride > 0; stride /= 2) {
+    \\        if (tid < stride) scratch[tid] = max(scratch[tid], scratch[tid + stride]);
+    \\        threadgroup_barrier(mem_flags::mem_threadgroup);
+    \\    }
+    \\    float global_max = scratch[0];
+    \\    threadgroup_barrier(mem_flags::mem_threadgroup);
+    \\
+    \\    float local_sum = 0.0f;
+    \\    for (uint s = tid; s < p.seq_kv; s += tg_size) {
+    \\        float w = (scores[s] == -INFINITY) ? 0.0f : exp(scores[s] - global_max);
+    \\        scores[s] = w;
+    \\        local_sum += w;
+    \\    }
+    \\    scratch[tid] = local_sum;
+    \\    threadgroup_barrier(mem_flags::mem_threadgroup);
+    \\    for (uint stride = tg_size / 2; stride > 0; stride /= 2) {
+    \\        if (tid < stride) scratch[tid] += scratch[tid + stride];
+    \\        threadgroup_barrier(mem_flags::mem_threadgroup);
+    \\    }
+    \\    float inv_sum = (scratch[0] > 0.0f) ? 1.0f / scratch[0] : 0.0f;
+    \\    threadgroup_barrier(mem_flags::mem_threadgroup);
+    \\
+    \\    for (uint s = tid; s < p.seq_kv; s += tg_size)
+    \\        scores[s] *= inv_sum;
+    \\    threadgroup_barrier(mem_flags::mem_threadgroup);
+    \\
+    \\    for (uint r = tid; r < p.d_head; r += tg_size) {
+    \\        float val = 0.0f;
+    \\        for (uint s = 0; s < p.seq_kv; s++)
+    \\            val += scores[s] * V[v_off + r * p.v_rs + s * p.v_cs];
+    \\        slice_dst[slice_dst_off + r * p.slice_dst_row_stride + q_col * p.slice_dst_col_stride] = val;
+    \\    }
+    \\}
+    \\
     \\struct AttentionBatchParams {
     \\    uint n_heads; uint d_head; uint seq_q; uint seq_kv;
     \\    float scale;
@@ -1826,6 +2190,12 @@ const shader_source =
     \\    uint is_swapped[MAX_FUSED_EW_STEPS];
     \\    uint secondary_slot[MAX_FUSED_EW_STEPS];
     \\    uint secondary_offset[MAX_FUSED_EW_STEPS];
+    \\    uint secondary_is_repeat[MAX_FUSED_EW_STEPS];
+    \\    uint secondary_repeat_dst_offset[MAX_FUSED_EW_STEPS];
+    \\    uint secondary_repeat_src_offset[MAX_FUSED_EW_STEPS];
+    \\    uint secondary_repeat_src_ne[MAX_FUSED_EW_STEPS][4];
+    \\    uint secondary_repeat_src_strides[MAX_FUSED_EW_STEPS][4];
+    \\    uint secondary_repeat_dst_strides[MAX_FUSED_EW_STEPS][4];
     \\};
     \\
     \\float fused_secondary(
@@ -1877,6 +2247,20 @@ const shader_source =
     \\        case 8: return a * b;
     \\        default: return fused_unary(op, a);
     \\    }
+    \\}
+    \\
+    \\uint fused_repeat_secondary_index(uint step, uint gid, constant FusedEwParams& p) {
+    \\    uint idx = p.secondary_repeat_dst_offset[step] + gid;
+    \\    uint src_idx = p.secondary_repeat_src_offset[step];
+    \\    for (int d = 3; d >= 0; d--) {
+    \\        uint ud = uint(d);
+    \\        uint stride = p.secondary_repeat_dst_strides[step][ud];
+    \\        uint coord = (stride == 0) ? 0 : idx / stride;
+    \\        if (stride != 0) idx %= stride;
+    \\        uint extent = p.secondary_repeat_src_ne[step][ud];
+    \\        src_idx += ((extent == 0) ? 0 : coord % extent) * p.secondary_repeat_src_strides[step][ud];
+    \\    }
+    \\    return src_idx;
     \\}
     \\
     \\constant uint MAX_ELEMENTWISE_BATCH = 8;
@@ -1961,7 +2345,9 @@ const shader_source =
     \\    for (uint step = 0; step < p.n_steps; step++) {
     \\        uint op = p.op[step];
     \\        if (op == 7 || op == 8) {
-    \\            uint sec_idx = p.secondary_offset[step] + gid;
+    \\            uint sec_idx = (p.secondary_is_repeat[step] != 0)
+    \\                ? fused_repeat_secondary_index(step, gid, p)
+    \\                : p.secondary_offset[step] + gid;
     \\            float other = fused_secondary(p.secondary_slot[step], sec_idx, s0, s1, s2, s3, s4, s5, s6, s7);
     \\            if (op == 7) v = (p.is_swapped[step] != 0) ? other + v : v + other;
     \\            else v = (p.is_swapped[step] != 0) ? other * v : v * other;
@@ -1986,7 +2372,28 @@ const shader_source =
     \\    uint is_swapped[MAX_FUSED_EW_STEPS];
     \\    uint secondary_slot[MAX_FUSED_EW_STEPS];
     \\    uint secondary_offset[MAX_FUSED_EW_STEPS];
+    \\    uint secondary_is_repeat[MAX_FUSED_EW_STEPS];
+    \\    uint secondary_is_primary[MAX_FUSED_EW_STEPS];
+    \\    uint secondary_repeat_dst_offset[MAX_FUSED_EW_STEPS];
+    \\    uint secondary_repeat_src_offset[MAX_FUSED_EW_STEPS];
+    \\    uint secondary_repeat_src_ne[MAX_FUSED_EW_STEPS][4];
+    \\    uint secondary_repeat_src_strides[MAX_FUSED_EW_STEPS][4];
+    \\    uint secondary_repeat_dst_strides[MAX_FUSED_EW_STEPS][4];
     \\};
+    \\
+    \\uint qmatmul_fused_repeat_secondary_index(uint step, uint linear, constant QMatmulFusedEwParams& p) {
+    \\    uint idx = p.secondary_repeat_dst_offset[step] + linear;
+    \\    uint src_idx = p.secondary_repeat_src_offset[step];
+    \\    for (int d = 3; d >= 0; d--) {
+    \\        uint ud = uint(d);
+    \\        uint stride = p.secondary_repeat_dst_strides[step][ud];
+    \\        uint coord = (stride == 0) ? 0 : idx / stride;
+    \\        if (stride != 0) idx %= stride;
+    \\        uint extent = p.secondary_repeat_src_ne[step][ud];
+    \\        src_idx += ((extent == 0) ? 0 : coord % extent) * p.secondary_repeat_src_strides[step][ud];
+    \\    }
+    \\    return src_idx;
+    \\}
     \\
     \\kernel void qmatmul_fused_elementwise_f32(
     \\    device const char*  weight_data   [[buffer(0)]],
@@ -2067,8 +2474,15 @@ const shader_source =
     \\            for (uint step = 0; step < p.n_steps; step++) {
     \\                uint op = p.op[step];
     \\                if (op == 7 || op == 8) {
-    \\                    uint sec_idx = p.secondary_offset[step] + linear;
-    \\                    float other = fused_secondary(p.secondary_slot[step], sec_idx, s0, s1, s2, s3, s4, s5, s6, s7);
+    \\                    float other;
+    \\                    if (p.secondary_is_primary[step] != 0) {
+    \\                        other = base;
+    \\                    } else {
+    \\                        uint sec_idx = (p.secondary_is_repeat[step] != 0)
+    \\                            ? qmatmul_fused_repeat_secondary_index(step, linear, p)
+    \\                            : p.secondary_offset[step] + linear;
+    \\                        other = fused_secondary(p.secondary_slot[step], sec_idx, s0, s1, s2, s3, s4, s5, s6, s7);
+    \\                    }
     \\                    if (op == 7) v = (p.is_swapped[step] != 0) ? other + v : v + other;
     \\                    else v = (p.is_swapped[step] != 0) ? other * v : v * other;
     \\                } else {
@@ -2077,6 +2491,160 @@ const shader_source =
     \\            }
     \\            if (p.write_primary != 0) output[p.dst_offset + cr * p.dst_row_stride + cc] = base;
     \\            ew_output[p.ew_dst_offset + linear] = v;
+    \\        }
+    \\    }
+    \\}
+    \\
+    \\struct QMatmulPairFusedEwParams {
+    \\    uint M; uint N; uint K;
+    \\    uint left_block_size;
+    \\    uint right_block_size;
+    \\    uint input_offset;
+    \\    uint input_row_stride;
+    \\    uint dst_offset;
+    \\    uint n_steps;
+    \\    uint op[MAX_FUSED_EW_STEPS];
+    \\    uint is_swapped[MAX_FUSED_EW_STEPS];
+    \\    uint secondary_slot[MAX_FUSED_EW_STEPS];
+    \\    uint secondary_offset[MAX_FUSED_EW_STEPS];
+    \\    uint secondary_is_repeat[MAX_FUSED_EW_STEPS];
+    \\    uint secondary_is_primary[MAX_FUSED_EW_STEPS];
+    \\    uint secondary_repeat_dst_offset[MAX_FUSED_EW_STEPS];
+    \\    uint secondary_repeat_src_offset[MAX_FUSED_EW_STEPS];
+    \\    uint secondary_repeat_src_ne[MAX_FUSED_EW_STEPS][4];
+    \\    uint secondary_repeat_src_strides[MAX_FUSED_EW_STEPS][4];
+    \\    uint secondary_repeat_dst_strides[MAX_FUSED_EW_STEPS][4];
+    \\};
+    \\
+    \\uint qmatmul_pair_repeat_secondary_index(uint step, uint linear, constant QMatmulPairFusedEwParams& p) {
+    \\    uint idx = p.secondary_repeat_dst_offset[step] + linear;
+    \\    uint src_idx = p.secondary_repeat_src_offset[step];
+    \\    for (int d = 3; d >= 0; d--) {
+    \\        uint ud = uint(d);
+    \\        uint stride = p.secondary_repeat_dst_strides[step][ud];
+    \\        uint coord = (stride == 0) ? 0 : idx / stride;
+    \\        if (stride != 0) idx %= stride;
+    \\        uint extent = p.secondary_repeat_src_ne[step][ud];
+    \\        src_idx += ((extent == 0) ? 0 : coord % extent) * p.secondary_repeat_src_strides[step][ud];
+    \\    }
+    \\    return src_idx;
+    \\}
+    \\
+    \\kernel void qmatmul_pair_fused_elementwise_f32(
+    \\    device const char*  left_weight_data    [[buffer(0)]],
+    \\    device const float* left_weight_scales  [[buffer(1)]],
+    \\    device const char*  right_weight_data   [[buffer(2)]],
+    \\    device const float* right_weight_scales [[buffer(3)]],
+    \\    device const float* input               [[buffer(4)]],
+    \\    device float*       output              [[buffer(5)]],
+    \\    device const float* s0 [[buffer(6)]],
+    \\    device const float* s1 [[buffer(7)]],
+    \\    device const float* s2 [[buffer(8)]],
+    \\    device const float* s3 [[buffer(9)]],
+    \\    device const float* s4 [[buffer(10)]],
+    \\    device const float* s5 [[buffer(11)]],
+    \\    device const float* s6 [[buffer(12)]],
+    \\    device const float* s7 [[buffer(13)]],
+    \\    constant QMatmulPairFusedEwParams& p [[buffer(14)]],
+    \\    uint2 group_id  [[threadgroup_position_in_grid]],
+    \\    uint  simd_idx  [[simdgroup_index_in_threadgroup]],
+    \\    uint  lane      [[thread_index_in_simdgroup]],
+    \\    uint  tid       [[thread_index_in_threadgroup]]
+    \\) {
+    \\    const uint gRow = group_id.y * TILE;
+    \\    const uint gCol = group_id.x * TILE;
+    \\    const uint sRow = (simd_idx / 2) * 16;
+    \\    const uint sCol = (simd_idx % 2) * 16;
+    \\
+    \\    simdgroup_float8x8 left_acc[4] = {
+    \\        simdgroup_float8x8(0), simdgroup_float8x8(0),
+    \\        simdgroup_float8x8(0), simdgroup_float8x8(0)
+    \\    };
+    \\    simdgroup_float8x8 right_acc[4] = {
+    \\        simdgroup_float8x8(0), simdgroup_float8x8(0),
+    \\        simdgroup_float8x8(0), simdgroup_float8x8(0)
+    \\    };
+    \\    threadgroup float tI[TILE * 8];
+    \\    threadgroup float tWL[8 * TILE];
+    \\    threadgroup float tWR[8 * TILE];
+    \\
+    \\    for (uint kt = 0; kt < p.K; kt += 8) {
+    \\        for (uint i = tid; i < TILE * 8; i += 128) {
+    \\            uint r = i / 8, c = i % 8;
+    \\            uint ir = gRow + r, ic = kt + c;
+    \\            tI[i] = (ir < p.M && ic < p.K) ? input[p.input_offset + ir * p.input_row_stride + ic] : 0.0f;
+    \\        }
+    \\        for (uint i = tid; i < 8 * TILE; i += 128) {
+    \\            uint r = i / TILE, c = i % TILE;
+    \\            uint kr = kt + r, nc = gCol + c;
+    \\            if (kr < p.K && nc < p.N) {
+    \\                uint w_idx = kr * p.N + nc;
+    \\                tWL[i] = float(left_weight_data[w_idx]) * left_weight_scales[w_idx / p.left_block_size];
+    \\                tWR[i] = float(right_weight_data[w_idx]) * right_weight_scales[w_idx / p.right_block_size];
+    \\            } else {
+    \\                tWL[i] = 0.0f;
+    \\                tWR[i] = 0.0f;
+    \\            }
+    \\        }
+    \\        threadgroup_barrier(mem_flags::mem_threadgroup);
+    \\
+    \\        simdgroup_float8x8 a0, a1, lb0, lb1, rb0, rb1;
+    \\        simdgroup_load(a0, tI + (sRow + 0) * 8, 8);
+    \\        simdgroup_load(a1, tI + (sRow + 8) * 8, 8);
+    \\        simdgroup_load(lb0, tWL + (sCol + 0), TILE);
+    \\        simdgroup_load(lb1, tWL + (sCol + 8), TILE);
+    \\        simdgroup_load(rb0, tWR + (sCol + 0), TILE);
+    \\        simdgroup_load(rb1, tWR + (sCol + 8), TILE);
+    \\        simdgroup_multiply_accumulate(left_acc[0], a0, lb0, left_acc[0]);
+    \\        simdgroup_multiply_accumulate(left_acc[1], a0, lb1, left_acc[1]);
+    \\        simdgroup_multiply_accumulate(left_acc[2], a1, lb0, left_acc[2]);
+    \\        simdgroup_multiply_accumulate(left_acc[3], a1, lb1, left_acc[3]);
+    \\        simdgroup_multiply_accumulate(right_acc[0], a0, rb0, right_acc[0]);
+    \\        simdgroup_multiply_accumulate(right_acc[1], a0, rb1, right_acc[1]);
+    \\        simdgroup_multiply_accumulate(right_acc[2], a1, rb0, right_acc[2]);
+    \\        simdgroup_multiply_accumulate(right_acc[3], a1, rb1, right_acc[3]);
+    \\        threadgroup_barrier(mem_flags::mem_threadgroup);
+    \\    }
+    \\
+    \\    threadgroup float tL[TILE * TILE];
+    \\    threadgroup float tR[TILE * TILE];
+    \\    simdgroup_store(left_acc[0], tL + (sRow + 0) * TILE + sCol + 0, TILE);
+    \\    simdgroup_store(left_acc[1], tL + (sRow + 0) * TILE + sCol + 8, TILE);
+    \\    simdgroup_store(left_acc[2], tL + (sRow + 8) * TILE + sCol + 0, TILE);
+    \\    simdgroup_store(left_acc[3], tL + (sRow + 8) * TILE + sCol + 8, TILE);
+    \\    simdgroup_store(right_acc[0], tR + (sRow + 0) * TILE + sCol + 0, TILE);
+    \\    simdgroup_store(right_acc[1], tR + (sRow + 0) * TILE + sCol + 8, TILE);
+    \\    simdgroup_store(right_acc[2], tR + (sRow + 8) * TILE + sCol + 0, TILE);
+    \\    simdgroup_store(right_acc[3], tR + (sRow + 8) * TILE + sCol + 8, TILE);
+    \\    threadgroup_barrier(mem_flags::mem_threadgroup);
+    \\
+    \\    for (uint i = tid; i < TILE * TILE; i += 128) {
+    \\        uint r = i / TILE, c = i % TILE;
+    \\        uint cr = gRow + r, cc = gCol + c;
+    \\        if (cr < p.M && cc < p.N) {
+    \\            float left_base = tL[i];
+    \\            float right_base = tR[i];
+    \\            uint linear = cr * p.N + cc;
+    \\            float v = left_base;
+    \\            for (uint step = 0; step < p.n_steps; step++) {
+    \\                uint op = p.op[step];
+    \\                if (op == 7 || op == 8) {
+    \\                    float other;
+    \\                    if (p.secondary_is_primary[step] != 0) {
+    \\                        other = left_base;
+    \\                    } else {
+    \\                        uint sec_idx = (p.secondary_is_repeat[step] != 0)
+    \\                            ? qmatmul_pair_repeat_secondary_index(step, linear, p)
+    \\                            : p.secondary_offset[step] + linear;
+    \\                        other = fused_secondary(p.secondary_slot[step], sec_idx, s0, s1, s2, s3, s4, s5, s6, s7);
+    \\                    }
+    \\                    if (op == 7) v = (p.is_swapped[step] != 0) ? other + v : v + other;
+    \\                    else v = (p.is_swapped[step] != 0) ? other * v : v * other;
+    \\                } else {
+    \\                    v = fused_unary(op, v);
+    \\                }
+    \\            }
+    \\            output[p.dst_offset + linear] = v * right_base;
     \\        }
     \\    }
     \\}
@@ -2110,6 +2678,71 @@ const QMatMulParams = extern struct {
 };
 
 const MAX_QMATMUL_BATCH: usize = 4;
+const MAX_QMATMUL_BATCH_SIDECARS: usize = 8;
+
+fn BatchKernelLayout(comptime Buffer: type, comptime max_ops: usize) type {
+    const buffers_per_op = switch (@typeInfo(Buffer)) {
+        .@"enum" => |info| info.fields.len,
+        else => @compileError("kernel buffer layout expects an enum"),
+    };
+    if (max_ops == 0) @compileError("kernel batch size must be non-zero");
+
+    return struct {
+        const buffer_count = max_ops * buffers_per_op;
+        const params_index: u32 = @intCast(buffer_count);
+
+        fn bufferIndex(slot: usize, buffer: Buffer) usize {
+            std.debug.assert(slot < max_ops);
+            return slot * buffers_per_op + @as(usize, @intFromEnum(buffer));
+        }
+    };
+}
+
+fn SlottedLayout(comptime max_slots: usize, comptime per_slot: usize) type {
+    if (max_slots == 0 or per_slot == 0) @compileError("slotted layout dimensions must be non-zero");
+
+    return struct {
+        const slots = max_slots * per_slot;
+
+        fn index(slot: usize, item_slot: usize) usize {
+            std.debug.assert(slot < max_slots);
+            std.debug.assert(item_slot < per_slot);
+            return slot * per_slot + item_slot;
+        }
+
+        fn start(slot: usize) usize {
+            std.debug.assert(slot < max_slots);
+            return slot * per_slot;
+        }
+    };
+}
+
+fn requireShaderUintConst(comptime name: []const u8, comptime value: comptime_int) void {
+    const needle = std.fmt.comptimePrint("constant uint {s} = {d};", .{ name, value });
+    if (std.mem.indexOf(u8, shader_source, needle) == null) {
+        @compileError("Metal shader constant drifted from Zig: " ++ name);
+    }
+}
+
+const QMatmulBatchBuffer = enum(u8) {
+    weight_data,
+    weight_scales,
+    input,
+    output,
+    sidecar_dst,
+    secondary,
+};
+
+const QMatmulBatchKernel = BatchKernelLayout(QMatmulBatchBuffer, MAX_QMATMUL_BATCH);
+
+const QMatmulBatchSidecarCode = enum(u32) {
+    none = 0,
+    slice = 1,
+    elementwise = 2,
+};
+
+const QMatmulBatchSidecarLayout = SlottedLayout(MAX_QMATMUL_BATCH, MAX_QMATMUL_BATCH_SIDECARS);
+const QMATMUL_BATCH_SIDECAR_SLOTS: usize = QMatmulBatchSidecarLayout.slots;
 
 const QMatmulBatch4Params = extern struct {
     n_ops: u32,
@@ -2123,20 +2756,86 @@ const QMatmulBatch4Params = extern struct {
     dst_offset: [MAX_QMATMUL_BATCH]u32,
     dst_row_stride: [MAX_QMATMUL_BATCH]u32,
     write_primary: [MAX_QMATMUL_BATCH]u32,
-    sidecar_kind: [MAX_QMATMUL_BATCH]u32,
-    slice_rows: [MAX_QMATMUL_BATCH]u32,
-    slice_cols: [MAX_QMATMUL_BATCH]u32,
-    slice_src_col_start: [MAX_QMATMUL_BATCH]u32,
-    slice_dst_offset: [MAX_QMATMUL_BATCH]u32,
-    slice_dst_row_stride: [MAX_QMATMUL_BATCH]u32,
-    slice_dst_col_stride: [MAX_QMATMUL_BATCH]u32,
-    ew_op: [MAX_QMATMUL_BATCH]u32,
-    ew_is_swapped: [MAX_QMATMUL_BATCH]u32,
-    ew_dst_offset: [MAX_QMATMUL_BATCH]u32,
-    ew_secondary_offset: [MAX_QMATMUL_BATCH]u32,
+    sidecar_count: [MAX_QMATMUL_BATCH]u32,
+    sidecar_kind: [QMATMUL_BATCH_SIDECAR_SLOTS]u32,
+    slice_rows: [QMATMUL_BATCH_SIDECAR_SLOTS]u32,
+    slice_cols: [QMATMUL_BATCH_SIDECAR_SLOTS]u32,
+    slice_src_col_start: [QMATMUL_BATCH_SIDECAR_SLOTS]u32,
+    slice_dst_offset: [QMATMUL_BATCH_SIDECAR_SLOTS]u32,
+    slice_dst_row_stride: [QMATMUL_BATCH_SIDECAR_SLOTS]u32,
+    slice_dst_col_stride: [QMATMUL_BATCH_SIDECAR_SLOTS]u32,
+    ew_op: [QMATMUL_BATCH_SIDECAR_SLOTS]u32,
+    ew_is_swapped: [QMATMUL_BATCH_SIDECAR_SLOTS]u32,
+    ew_dst_offset: [QMATMUL_BATCH_SIDECAR_SLOTS]u32,
+    ew_secondary_offset: [QMATMUL_BATCH_SIDECAR_SLOTS]u32,
 };
 
+const MAX_QMATMUL_ROPE_STORE_BATCH: usize = 4;
+
+const QMatmulRopeStoreBuffer = enum(u8) {
+    weight_data,
+    weight_scales,
+    input,
+    output,
+    cos_sin,
+    slice_dst,
+};
+
+const QMatmulRopeStoreKernel = BatchKernelLayout(QMatmulRopeStoreBuffer, MAX_QMATMUL_ROPE_STORE_BATCH);
+
+const QMatmulRopeStoreBatch4Params = extern struct {
+    n_ops: u32,
+    max_tiles_y: u32,
+    M: [MAX_QMATMUL_ROPE_STORE_BATCH]u32,
+    N: [MAX_QMATMUL_ROPE_STORE_BATCH]u32,
+    K: [MAX_QMATMUL_ROPE_STORE_BATCH]u32,
+    block_size: [MAX_QMATMUL_ROPE_STORE_BATCH]u32,
+    input_offset: [MAX_QMATMUL_ROPE_STORE_BATCH]u32,
+    input_row_stride: [MAX_QMATMUL_ROPE_STORE_BATCH]u32,
+    dst_offset: [MAX_QMATMUL_ROPE_STORE_BATCH]u32,
+    dst_row_stride: [MAX_QMATMUL_ROPE_STORE_BATCH]u32,
+    write_primary: [MAX_QMATMUL_ROPE_STORE_BATCH]u32,
+    rope_half_d: [MAX_QMATMUL_ROPE_STORE_BATCH]u32,
+    rope_src_col_start: [MAX_QMATMUL_ROPE_STORE_BATCH]u32,
+    rope_cs_off: [MAX_QMATMUL_ROPE_STORE_BATCH]u32,
+    rope_cs_cs: [MAX_QMATMUL_ROPE_STORE_BATCH]u32,
+    slice_dst_offset: [MAX_QMATMUL_ROPE_STORE_BATCH]u32,
+    slice_dst_row_stride: [MAX_QMATMUL_ROPE_STORE_BATCH]u32,
+    slice_dst_col_stride: [MAX_QMATMUL_ROPE_STORE_BATCH]u32,
+};
+
+fn requireKernelBuffers(comptime Kernel: type, comptime expected: usize, comptime name: []const u8) void {
+    if (Kernel.buffer_count != expected) @compileError(name ++ " MSL buffer layout changed; update Zig encoder and shader together");
+    if (Kernel.buffer_count > max_encode_buffers) @compileError(name ++ " uses more buffers than the Metal encoder wrapper can pass");
+}
+
+const max_encode_buffers = 32;
+
+comptime {
+    requireShaderUintConst("MAX_QMATMUL_BATCH", MAX_QMATMUL_BATCH);
+    requireShaderUintConst("MAX_QMATMUL_BATCH_SIDECARS", MAX_QMATMUL_BATCH_SIDECARS);
+    requireShaderUintConst("MAX_QMATMUL_ROPE_STORE_BATCH", MAX_QMATMUL_ROPE_STORE_BATCH);
+    requireKernelBuffers(QMatmulBatchKernel, 24, "qmatmul_batch4_f32");
+    requireKernelBuffers(QMatmulRopeStoreKernel, 24, "qmatmul_rope_store_batch4_f32");
+}
+
 const MAX_QMATVEC_BATCH: usize = 4;
+
+const QMatvecBatchBuffer = enum(u8) {
+    weight_data,
+    weight_scales,
+    input,
+    output,
+    sidecar_src,
+    sidecar_dst,
+};
+
+const QMatvecBatchKernel = BatchKernelLayout(QMatvecBatchBuffer, MAX_QMATVEC_BATCH);
+
+comptime {
+    requireShaderUintConst("MAX_QMATVEC_BATCH", MAX_QMATVEC_BATCH);
+    requireKernelBuffers(QMatvecBatchKernel, 24, "qmatvec_batch4_f32");
+}
 
 const QMatvecBatch4Params = extern struct {
     n_ops: u32,
@@ -2146,6 +2845,18 @@ const QMatvecBatch4Params = extern struct {
     block_size: [MAX_QMATVEC_BATCH]u32,
     input_offset: [MAX_QMATVEC_BATCH]u32,
     dst_offset: [MAX_QMATVEC_BATCH]u32,
+    write_primary: [MAX_QMATVEC_BATCH]u32,
+    sidecar_kind: [MAX_QMATVEC_BATCH]u32,
+    slice_rows: [MAX_QMATVEC_BATCH]u32,
+    slice_src_col_start: [MAX_QMATVEC_BATCH]u32,
+    slice_dst_offset: [MAX_QMATVEC_BATCH]u32,
+    slice_dst_row_stride: [MAX_QMATVEC_BATCH]u32,
+    rope_half_d: [MAX_QMATVEC_BATCH]u32,
+    rope_cs_off: [MAX_QMATVEC_BATCH]u32,
+    ew_op: [MAX_QMATVEC_BATCH]u32,
+    ew_is_swapped: [MAX_QMATVEC_BATCH]u32,
+    ew_dst_offset: [MAX_QMATVEC_BATCH]u32,
+    ew_secondary_offset: [MAX_QMATVEC_BATCH]u32,
 };
 
 const MatVecParams = extern struct {
@@ -2387,6 +3098,13 @@ const AttentionRopeStoreParams = extern struct {
 
 const MAX_ATTENTION_BATCH_HEADS: usize = 16;
 const MAX_ATTENTION_STORE_BATCH_HEADS: usize = 4;
+const MAX_ATTENTION_ROPE_STORE_SHARED_BATCH_HEADS: usize = 16;
+
+comptime {
+    requireShaderUintConst("MAX_ATTENTION_BATCH_HEADS", MAX_ATTENTION_BATCH_HEADS);
+    requireShaderUintConst("MAX_ATTENTION_STORE_BATCH_HEADS", MAX_ATTENTION_STORE_BATCH_HEADS);
+    requireShaderUintConst("MAX_ATTENTION_ROPE_STORE_SHARED_BATCH_HEADS", MAX_ATTENTION_ROPE_STORE_SHARED_BATCH_HEADS);
+}
 
 const AttentionRopeStoreBatchParams = extern struct {
     n_heads: u32,
@@ -2413,6 +3131,32 @@ const AttentionRopeStoreBatchParams = extern struct {
     mask_cs: u32,
     dst_rs: u32,
     dst_cs: u32,
+    slice_dst_row_stride: u32,
+    slice_dst_col_stride: u32,
+};
+
+const AttentionRopeStoreSharedBatchParams = extern struct {
+    n_heads: u32,
+    d_head: u32,
+    seq_q: u32,
+    seq_kv: u32,
+    scale: f32,
+    rope_half_d: u32,
+    rope_src_off: [MAX_ATTENTION_ROPE_STORE_SHARED_BATCH_HEADS]u32,
+    rope_cs_off: [MAX_ATTENTION_ROPE_STORE_SHARED_BATCH_HEADS]u32,
+    k_off: [MAX_ATTENTION_ROPE_STORE_SHARED_BATCH_HEADS]u32,
+    v_off: [MAX_ATTENTION_ROPE_STORE_SHARED_BATCH_HEADS]u32,
+    mask_off: [MAX_ATTENTION_ROPE_STORE_SHARED_BATCH_HEADS]u32,
+    slice_dst_offset: [MAX_ATTENTION_ROPE_STORE_SHARED_BATCH_HEADS]u32,
+    rope_src_rs: u32,
+    rope_src_cs: u32,
+    rope_cs_cs: u32,
+    k_rs: u32,
+    k_cs: u32,
+    v_rs: u32,
+    v_cs: u32,
+    mask_rs: u32,
+    mask_cs: u32,
     slice_dst_row_stride: u32,
     slice_dst_col_stride: u32,
 };
@@ -2492,6 +3236,12 @@ const FusedEwParams = extern struct {
     is_swapped: [MAX_FUSED_EW_STEPS]u32,
     secondary_slot: [MAX_FUSED_EW_STEPS]u32,
     secondary_offset: [MAX_FUSED_EW_STEPS]u32,
+    secondary_is_repeat: [MAX_FUSED_EW_STEPS]u32,
+    secondary_repeat_dst_offset: [MAX_FUSED_EW_STEPS]u32,
+    secondary_repeat_src_offset: [MAX_FUSED_EW_STEPS]u32,
+    secondary_repeat_src_ne: [MAX_FUSED_EW_STEPS][4]u32,
+    secondary_repeat_src_strides: [MAX_FUSED_EW_STEPS][4]u32,
+    secondary_repeat_dst_strides: [MAX_FUSED_EW_STEPS][4]u32,
 };
 
 const MAX_ELEMENTWISE_BATCH: usize = 8;
@@ -2522,6 +3272,36 @@ const QMatmulFusedEwParams = extern struct {
     is_swapped: [MAX_FUSED_EW_STEPS]u32,
     secondary_slot: [MAX_FUSED_EW_STEPS]u32,
     secondary_offset: [MAX_FUSED_EW_STEPS]u32,
+    secondary_is_repeat: [MAX_FUSED_EW_STEPS]u32,
+    secondary_is_primary: [MAX_FUSED_EW_STEPS]u32,
+    secondary_repeat_dst_offset: [MAX_FUSED_EW_STEPS]u32,
+    secondary_repeat_src_offset: [MAX_FUSED_EW_STEPS]u32,
+    secondary_repeat_src_ne: [MAX_FUSED_EW_STEPS][4]u32,
+    secondary_repeat_src_strides: [MAX_FUSED_EW_STEPS][4]u32,
+    secondary_repeat_dst_strides: [MAX_FUSED_EW_STEPS][4]u32,
+};
+
+const QMatmulPairFusedEwParams = extern struct {
+    M: u32,
+    N: u32,
+    K: u32,
+    left_block_size: u32,
+    right_block_size: u32,
+    input_offset: u32,
+    input_row_stride: u32,
+    dst_offset: u32,
+    n_steps: u32,
+    op: [MAX_FUSED_EW_STEPS]u32,
+    is_swapped: [MAX_FUSED_EW_STEPS]u32,
+    secondary_slot: [MAX_FUSED_EW_STEPS]u32,
+    secondary_offset: [MAX_FUSED_EW_STEPS]u32,
+    secondary_is_repeat: [MAX_FUSED_EW_STEPS]u32,
+    secondary_is_primary: [MAX_FUSED_EW_STEPS]u32,
+    secondary_repeat_dst_offset: [MAX_FUSED_EW_STEPS]u32,
+    secondary_repeat_src_offset: [MAX_FUSED_EW_STEPS]u32,
+    secondary_repeat_src_ne: [MAX_FUSED_EW_STEPS][4]u32,
+    secondary_repeat_src_strides: [MAX_FUSED_EW_STEPS][4]u32,
+    secondary_repeat_dst_strides: [MAX_FUSED_EW_STEPS][4]u32,
 };
 
 const WG_SIZE: u32 = 256;
@@ -2835,40 +3615,78 @@ fn canEncodeAttention(att: anytype) bool {
 
 // ── MetalBackend ──────────────────────────────────────────────────
 
+const MetalKernel = enum(u8) {
+    matmul_f32,
+    qmatmul_f32,
+    qmatmul_batch4_f32,
+    qmatmul_rope_store_batch4_f32,
+    qmatvec_f32,
+    qmatvec_batch4_f32,
+    matvec_f16,
+    matmul_f16,
+    rope_f32,
+    rope_batch_f32,
+    rope_slice_assign_f32,
+    rope_slice_assign_batch_f32,
+    qmatmul_slice_assign_f32,
+    qmatmul_elementwise_f32,
+    qmatmul_fused_elementwise_f32,
+    qmatmul_pair_fused_elementwise_f32,
+    qmatvec_slice_assign_f32,
+    slice_assign_batch_f32,
+    rmsnorm_scale_f32,
+    attention_f32,
+    attention_slice_assign_f32,
+    attention_store_f32,
+    attention_rope_store_f32,
+    attention_rope_store_batch_f32,
+    attention_rope_store_shared_batch_f32,
+    attention_store_batch_f32,
+    attention_batch_f32,
+    compute_f32,
+    elementwise_batch8_f32,
+    fused_elementwise_f32,
+};
+
+const metal_kernel_count = @typeInfo(MetalKernel).@"enum".fields.len;
+
+fn metalKernelName(kernel: MetalKernel) [:0]const u8 {
+    return @tagName(kernel);
+}
+
+fn requireShaderKernel(comptime name: []const u8) void {
+    const needle = std.fmt.comptimePrint("kernel void {s}(", .{name});
+    if (std.mem.indexOf(u8, shader_source, needle) == null) {
+        @compileError("Metal kernel is listed in Zig but missing from shader source: " ++ name);
+    }
+}
+
+comptime {
+    @setEvalBranchQuota(500_000);
+    for (@typeInfo(MetalKernel).@"enum".fields) |field| {
+        const kernel: MetalKernel = @enumFromInt(field.value);
+        requireShaderKernel(metalKernelName(kernel));
+    }
+}
+
+fn releaseMetalPipelines(pipelines: *[metal_kernel_count]?*anyopaque) void {
+    for (pipelines[0..]) |*maybe_pipeline| {
+        if (maybe_pipeline.*) |pipeline| {
+            c.mtl_release(pipeline);
+            maybe_pipeline.* = null;
+        }
+    }
+}
+
 pub const MetalBackend = struct {
     device: *anyopaque,
     queue: *anyopaque,
-    matmul_pipeline: *anyopaque,
-    qmatmul_pipeline: *anyopaque,
-    qmatmul_batch4_pipeline: *anyopaque,
-    qmatvec_pipeline: *anyopaque,
-    qmatvec_batch4_pipeline: *anyopaque,
-    matvec_f16_pipeline: *anyopaque,
-    matmul_f16_pipeline: *anyopaque,
-    rope_pipeline: *anyopaque,
-    rope_batch_pipeline: *anyopaque,
-    rope_slice_assign_pipeline: *anyopaque,
-    rope_slice_assign_batch_pipeline: *anyopaque,
-    qmatmul_slice_assign_pipeline: *anyopaque,
-    qmatmul_elementwise_pipeline: *anyopaque,
-    qmatmul_fused_ew_pipeline: *anyopaque,
-    qmatvec_slice_assign_pipeline: *anyopaque,
-    slice_assign_batch_pipeline: *anyopaque,
-    rmsnorm_scale_pipeline: *anyopaque,
-    attention_pipeline: *anyopaque,
-    attention_slice_assign_pipeline: *anyopaque,
-    attention_store_pipeline: *anyopaque,
-    attention_rope_store_pipeline: *anyopaque,
-    attention_rope_store_batch_pipeline: *anyopaque,
-    attention_store_batch_pipeline: *anyopaque,
-    attention_batch_pipeline: *anyopaque,
-    compute_pipeline: *anyopaque,
-    elementwise_batch8_pipeline: *anyopaque,
-    fused_ew_pipeline: *anyopaque,
+    pipelines: [metal_kernel_count]?*anyopaque,
     library: *anyopaque,
     active_commands: ?*anyopaque = null,
     fine_grained_program_dispatch: bool = false,
     region_program_dispatch: bool = false,
+    projection_rope_cache_sidecars: bool = false,
 
     pub fn init() !MetalBackend {
         const device = c.mtl_create_device() orelse return error.MetalNotAvailable;
@@ -2880,126 +3698,31 @@ pub const MetalBackend = struct {
         const library = c.mtl_compile_source(device, shader_source.ptr, shader_source.len) orelse return error.ShaderCompileFailed;
         errdefer c.mtl_release(library);
 
-        const matmul_pipeline = c.mtl_create_pipeline(device, library, "matmul_f32") orelse return error.PipelineCreateFailed;
-        errdefer c.mtl_release(matmul_pipeline);
-        const qmatmul_pipeline = c.mtl_create_pipeline(device, library, "qmatmul_f32") orelse return error.PipelineCreateFailed;
-        errdefer c.mtl_release(qmatmul_pipeline);
-        const qmatmul_batch4_pipeline = c.mtl_create_pipeline(device, library, "qmatmul_batch4_f32") orelse return error.PipelineCreateFailed;
-        errdefer c.mtl_release(qmatmul_batch4_pipeline);
-        const qmatvec_pipeline = c.mtl_create_pipeline(device, library, "qmatvec_f32") orelse return error.PipelineCreateFailed;
-        errdefer c.mtl_release(qmatvec_pipeline);
-        const qmatvec_batch4_pipeline = c.mtl_create_pipeline(device, library, "qmatvec_batch4_f32") orelse return error.PipelineCreateFailed;
-        errdefer c.mtl_release(qmatvec_batch4_pipeline);
-        const matvec_f16_pipeline = c.mtl_create_pipeline(device, library, "matvec_f16") orelse return error.PipelineCreateFailed;
-        errdefer c.mtl_release(matvec_f16_pipeline);
-        const matmul_f16_pipeline = c.mtl_create_pipeline(device, library, "matmul_f16") orelse return error.PipelineCreateFailed;
-        errdefer c.mtl_release(matmul_f16_pipeline);
-        const rope_pipeline = c.mtl_create_pipeline(device, library, "rope_f32") orelse return error.PipelineCreateFailed;
-        errdefer c.mtl_release(rope_pipeline);
-        const rope_batch_pipeline = c.mtl_create_pipeline(device, library, "rope_batch_f32") orelse return error.PipelineCreateFailed;
-        errdefer c.mtl_release(rope_batch_pipeline);
-        const rope_slice_assign_pipeline = c.mtl_create_pipeline(device, library, "rope_slice_assign_f32") orelse return error.PipelineCreateFailed;
-        errdefer c.mtl_release(rope_slice_assign_pipeline);
-        const rope_slice_assign_batch_pipeline = c.mtl_create_pipeline(device, library, "rope_slice_assign_batch_f32") orelse return error.PipelineCreateFailed;
-        errdefer c.mtl_release(rope_slice_assign_batch_pipeline);
-        const qmatmul_slice_assign_pipeline = c.mtl_create_pipeline(device, library, "qmatmul_slice_assign_f32") orelse return error.PipelineCreateFailed;
-        errdefer c.mtl_release(qmatmul_slice_assign_pipeline);
-        const qmatmul_elementwise_pipeline = c.mtl_create_pipeline(device, library, "qmatmul_elementwise_f32") orelse return error.PipelineCreateFailed;
-        errdefer c.mtl_release(qmatmul_elementwise_pipeline);
-        const qmatmul_fused_ew_pipeline = c.mtl_create_pipeline(device, library, "qmatmul_fused_elementwise_f32") orelse return error.PipelineCreateFailed;
-        errdefer c.mtl_release(qmatmul_fused_ew_pipeline);
-        const qmatvec_slice_assign_pipeline = c.mtl_create_pipeline(device, library, "qmatvec_slice_assign_f32") orelse return error.PipelineCreateFailed;
-        errdefer c.mtl_release(qmatvec_slice_assign_pipeline);
-        const slice_assign_batch_pipeline = c.mtl_create_pipeline(device, library, "slice_assign_batch_f32") orelse return error.PipelineCreateFailed;
-        errdefer c.mtl_release(slice_assign_batch_pipeline);
-        const rmsnorm_scale_pipeline = c.mtl_create_pipeline(device, library, "rmsnorm_scale_f32") orelse return error.PipelineCreateFailed;
-        errdefer c.mtl_release(rmsnorm_scale_pipeline);
-        const attention_pipeline = c.mtl_create_pipeline(device, library, "attention_f32") orelse return error.PipelineCreateFailed;
-        errdefer c.mtl_release(attention_pipeline);
-        const attention_slice_assign_pipeline = c.mtl_create_pipeline(device, library, "attention_slice_assign_f32") orelse return error.PipelineCreateFailed;
-        errdefer c.mtl_release(attention_slice_assign_pipeline);
-        const attention_store_pipeline = c.mtl_create_pipeline(device, library, "attention_store_f32") orelse return error.PipelineCreateFailed;
-        errdefer c.mtl_release(attention_store_pipeline);
-        const attention_rope_store_pipeline = c.mtl_create_pipeline(device, library, "attention_rope_store_f32") orelse return error.PipelineCreateFailed;
-        errdefer c.mtl_release(attention_rope_store_pipeline);
-        const attention_rope_store_batch_pipeline = c.mtl_create_pipeline(device, library, "attention_rope_store_batch_f32") orelse return error.PipelineCreateFailed;
-        errdefer c.mtl_release(attention_rope_store_batch_pipeline);
-        const attention_store_batch_pipeline = c.mtl_create_pipeline(device, library, "attention_store_batch_f32") orelse return error.PipelineCreateFailed;
-        errdefer c.mtl_release(attention_store_batch_pipeline);
-        const attention_batch_pipeline = c.mtl_create_pipeline(device, library, "attention_batch_f32") orelse return error.PipelineCreateFailed;
-        errdefer c.mtl_release(attention_batch_pipeline);
-        const compute_pipeline = c.mtl_create_pipeline(device, library, "compute_f32") orelse return error.PipelineCreateFailed;
-        errdefer c.mtl_release(compute_pipeline);
-        const elementwise_batch8_pipeline = c.mtl_create_pipeline(device, library, "elementwise_batch8_f32") orelse return error.PipelineCreateFailed;
-        errdefer c.mtl_release(elementwise_batch8_pipeline);
-        const fused_ew_pipeline = c.mtl_create_pipeline(device, library, "fused_elementwise_f32") orelse return error.PipelineCreateFailed;
+        var pipelines = [_]?*anyopaque{null} ** metal_kernel_count;
+        errdefer releaseMetalPipelines(&pipelines);
+        inline for (@typeInfo(MetalKernel).@"enum".fields) |field| {
+            const kernel: MetalKernel = @enumFromInt(field.value);
+            pipelines[@intFromEnum(kernel)] = c.mtl_create_pipeline(device, library, metalKernelName(kernel).ptr) orelse return error.PipelineCreateFailed;
+        }
 
         return .{
             .device = device,
             .queue = queue,
-            .matmul_pipeline = matmul_pipeline,
-            .qmatmul_pipeline = qmatmul_pipeline,
-            .qmatmul_batch4_pipeline = qmatmul_batch4_pipeline,
-            .qmatvec_pipeline = qmatvec_pipeline,
-            .qmatvec_batch4_pipeline = qmatvec_batch4_pipeline,
-            .matvec_f16_pipeline = matvec_f16_pipeline,
-            .matmul_f16_pipeline = matmul_f16_pipeline,
-            .rope_pipeline = rope_pipeline,
-            .rope_batch_pipeline = rope_batch_pipeline,
-            .rope_slice_assign_pipeline = rope_slice_assign_pipeline,
-            .rope_slice_assign_batch_pipeline = rope_slice_assign_batch_pipeline,
-            .qmatmul_slice_assign_pipeline = qmatmul_slice_assign_pipeline,
-            .qmatmul_elementwise_pipeline = qmatmul_elementwise_pipeline,
-            .qmatmul_fused_ew_pipeline = qmatmul_fused_ew_pipeline,
-            .qmatvec_slice_assign_pipeline = qmatvec_slice_assign_pipeline,
-            .slice_assign_batch_pipeline = slice_assign_batch_pipeline,
-            .rmsnorm_scale_pipeline = rmsnorm_scale_pipeline,
-            .attention_pipeline = attention_pipeline,
-            .attention_slice_assign_pipeline = attention_slice_assign_pipeline,
-            .attention_store_pipeline = attention_store_pipeline,
-            .attention_rope_store_pipeline = attention_rope_store_pipeline,
-            .attention_rope_store_batch_pipeline = attention_rope_store_batch_pipeline,
-            .attention_store_batch_pipeline = attention_store_batch_pipeline,
-            .attention_batch_pipeline = attention_batch_pipeline,
-            .compute_pipeline = compute_pipeline,
-            .elementwise_batch8_pipeline = elementwise_batch8_pipeline,
-            .fused_ew_pipeline = fused_ew_pipeline,
+            .pipelines = pipelines,
             .library = library,
         };
     }
 
     pub fn deinit(self: *MetalBackend) void {
         self.flushCommands();
-        c.mtl_release(self.fused_ew_pipeline);
-        c.mtl_release(self.elementwise_batch8_pipeline);
-        c.mtl_release(self.compute_pipeline);
-        c.mtl_release(self.attention_batch_pipeline);
-        c.mtl_release(self.attention_store_batch_pipeline);
-        c.mtl_release(self.attention_rope_store_batch_pipeline);
-        c.mtl_release(self.attention_rope_store_pipeline);
-        c.mtl_release(self.attention_store_pipeline);
-        c.mtl_release(self.attention_slice_assign_pipeline);
-        c.mtl_release(self.attention_pipeline);
-        c.mtl_release(self.rmsnorm_scale_pipeline);
-        c.mtl_release(self.slice_assign_batch_pipeline);
-        c.mtl_release(self.qmatvec_slice_assign_pipeline);
-        c.mtl_release(self.qmatmul_fused_ew_pipeline);
-        c.mtl_release(self.qmatmul_elementwise_pipeline);
-        c.mtl_release(self.qmatmul_slice_assign_pipeline);
-        c.mtl_release(self.rope_slice_assign_batch_pipeline);
-        c.mtl_release(self.rope_slice_assign_pipeline);
-        c.mtl_release(self.rope_batch_pipeline);
-        c.mtl_release(self.rope_pipeline);
-        c.mtl_release(self.matmul_f16_pipeline);
-        c.mtl_release(self.matvec_f16_pipeline);
-        c.mtl_release(self.qmatvec_batch4_pipeline);
-        c.mtl_release(self.qmatvec_pipeline);
-        c.mtl_release(self.qmatmul_batch4_pipeline);
-        c.mtl_release(self.qmatmul_pipeline);
-        c.mtl_release(self.matmul_pipeline);
+        releaseMetalPipelines(&self.pipelines);
         c.mtl_release(self.library);
         c.mtl_release(self.queue);
         c.mtl_release(self.device);
+    }
+
+    fn pipeline(self: *MetalBackend, kernel: MetalKernel) *anyopaque {
+        return self.pipelines[@intFromEnum(kernel)].?;
     }
 
     /// Enable one-dispatch-per-DeviceOp execution for experiments and
@@ -3014,6 +3737,28 @@ pub const MetalBackend = struct {
     /// transformer-shaped regions when it has a native implementation.
     pub fn setRegionProgramDispatch(self: *MetalBackend, enabled: bool) void {
         self.region_program_dispatch = enabled;
+    }
+
+    /// Enable the experimental projection -> RoPE -> KV-store lowering. This
+    /// remains opt-in until benchmarks prove it wins on the target Apple GPU.
+    pub fn setProjectionRopeCacheSidecars(self: *MetalBackend, enabled: bool) void {
+        self.projection_rope_cache_sidecars = enabled;
+    }
+
+    pub fn setQMatmulRopeCacheSidecars(self: *MetalBackend, enabled: bool) void {
+        self.setProjectionRopeCacheSidecars(enabled);
+    }
+
+    pub fn commandStreamPolicy(self: *const MetalBackend) program_mod.CommandStreamPolicy {
+        var policy = program_mod.CommandStreamPolicy.fromCapabilities(backend_mod.Capabilities.metal);
+        policy.projection_rope_cache_sidecars = self.projection_rope_cache_sidecars;
+        return policy;
+    }
+
+    pub fn capabilities(self: *const MetalBackend) backend_mod.Capabilities {
+        var caps = backend_mod.Capabilities.metal;
+        caps.command_stream.projection_rope_cache_sidecars = self.projection_rope_cache_sidecars;
+        return caps;
     }
 
     /// Ensure a command session is active, creating one if needed.
@@ -3038,7 +3783,7 @@ pub const MetalBackend = struct {
             .vtable = &vtable,
             .name_str = "metal",
             .device_type = .metal,
-            .capabilities = backend_mod.Capabilities.metal,
+            .capabilities = self.capabilities(),
         };
     }
 };
@@ -3102,26 +3847,47 @@ fn metalSchedulePolicy(fine_grained: bool) program_mod.SchedulePolicy {
     };
 }
 
-const metal_pattern_decode_layer_stage: u32 = 0;
-const metal_pattern_prefill_layer_stage: u32 = 1;
-const metal_projection_anchors_per_stage: u32 = 7;
+pub const MetalRegionPattern = enum(u32) {
+    decode_layer_stage,
+    prefill_layer_stage,
 
-fn buildMetalRegionSchedule(alloc: std.mem.Allocator, schedule: []const program_mod.KernelItem) ![]program_mod.ScheduleUnit {
-    const stages = [_]program_mod.StagePolicy{
-        program_mod.StagePolicy.anchored(
-            "decode-layer",
-            metal_pattern_decode_layer_stage,
-            program_mod.RegionPolicy.qmatvecCluster(),
+    pub fn index(self: MetalRegionPattern) u32 {
+        return @intFromEnum(self);
+    }
+
+    pub fn stageName(self: MetalRegionPattern) []const u8 {
+        return switch (self) {
+            .decode_layer_stage => "decode-layer",
+            .prefill_layer_stage => "prefill-layer",
+        };
+    }
+
+    pub fn stagePolicy(self: MetalRegionPattern) program_mod.StagePolicy {
+        return program_mod.StagePolicy.anchored(
+            self.stageName(),
+            self.index(),
+            switch (self) {
+                .decode_layer_stage => program_mod.RegionPolicy.qmatvecCluster(),
+                .prefill_layer_stage => program_mod.RegionPolicy.qmatmulCluster(),
+            },
             metal_projection_anchors_per_stage,
-        ),
-        program_mod.StagePolicy.anchored(
-            "prefill-layer",
-            metal_pattern_prefill_layer_stage,
-            program_mod.RegionPolicy.qmatmulCluster(),
-            metal_projection_anchors_per_stage,
-        ),
-    };
-    return program_mod.buildStageRegionSchedule(alloc, schedule, &stages);
+        );
+    }
+};
+
+const metal_projection_anchors_per_stage: u32 = 7;
+const metal_region_stages = [_]program_mod.StagePolicy{
+    MetalRegionPattern.decode_layer_stage.stagePolicy(),
+    MetalRegionPattern.prefill_layer_stage.stagePolicy(),
+};
+
+fn buildMetalExecutionPlan(
+    alloc: std.mem.Allocator,
+    ops: []const backend_mod.DeviceOp,
+    schedule_policy: program_mod.SchedulePolicy,
+    command_policy: program_mod.CommandStreamPolicy,
+) !program_mod.ExecutionPlan {
+    return program_mod.buildExecutionPlan(alloc, ops, schedule_policy, &metal_region_stages, command_policy);
 }
 
 const CompiledProgram = struct {
@@ -3131,8 +3897,7 @@ const CompiledProgram = struct {
     qweight_views: []DeviceQWeight,
     ref_qweights: []reference.QWeight,
     ops: []const backend_mod.DeviceOp,
-    schedule: []const program_mod.KernelItem,
-    region_schedule: []const program_mod.ScheduleUnit,
+    plan: program_mod.ExecutionPlan,
     alloc: std.mem.Allocator,
     runtime_profile: profile_mod.RuntimeProfile = .{},
 
@@ -3144,8 +3909,7 @@ const CompiledProgram = struct {
         self.alloc.free(self.device_bufs);
         if (self.qweight_views.len > 0) self.alloc.free(self.qweight_views);
         if (self.ref_qweights.len > 0) self.alloc.free(self.ref_qweights);
-        if (self.schedule.len > 0) self.alloc.free(self.schedule);
-        if (self.region_schedule.len > 0) self.alloc.free(self.region_schedule);
+        self.plan.deinit(self.alloc);
         self.alloc.destroy(self);
     }
 
@@ -3153,7 +3917,7 @@ const CompiledProgram = struct {
         // Upload per-step inputs (token embed, pos, mask) via shared memory.
         reference.uploadToBuffers(self.ref_buffers, inputs);
 
-        if (self.schedule.len == 0 and self.ops.len > 0) {
+        if (self.plan.schedule.len == 0 and self.ops.len > 0) {
             self.executeUnscheduled();
         } else {
             self.executeScheduled();
@@ -3172,22 +3936,22 @@ const CompiledProgram = struct {
     }
 
     fn executeScheduled(self: *CompiledProgram) void {
-        if (self.backend.region_program_dispatch and self.region_schedule.len > 0) {
+        if (self.backend.region_program_dispatch and self.plan.regions.len > 0) {
             self.executeRegionScheduled();
             return;
         }
 
-        for (self.schedule) |item| {
+        for (self.plan.schedule) |item| {
             self.executeScheduleItem(item);
         }
     }
 
     fn executeRegionScheduled(self: *CompiledProgram) void {
-        for (self.region_schedule) |unit| {
+        for (self.plan.regions, 0..) |unit, unit_index| {
             switch (unit.kind) {
-                .item => self.executeScheduleItem(self.schedule[@intCast(unit.start_item)]),
+                .item => self.executeScheduleItem(self.plan.schedule[@intCast(unit.start_item)]),
                 .pattern_region => {
-                    if (!self.tryEncodePatternRegion(unit)) {
+                    if (!self.tryEncodePatternRegion(unit, unit_index)) {
                         self.executeScheduleItems(unit.start_item, unit.item_count);
                     }
                 },
@@ -3198,7 +3962,7 @@ const CompiledProgram = struct {
     fn executeScheduleItems(self: *CompiledProgram, start_item: u32, item_count: u32) void {
         const start: usize = @intCast(start_item);
         const end = start + @as(usize, item_count);
-        for (self.schedule[start..end]) |item| {
+        for (self.plan.schedule[start..end]) |item| {
             self.executeScheduleItem(item);
         }
     }
@@ -3260,7 +4024,7 @@ const CompiledProgram = struct {
         grid: DispatchGrid,
         threads_x: u32,
     ) void {
-        var raw_buffers: [32]?*anyopaque = undefined;
+        var raw_buffers: [max_encode_buffers]?*anyopaque = undefined;
         std.debug.assert(buffers.len <= raw_buffers.len);
         for (buffers, 0..) |buf, i| raw_buffers[i] = buf.ptr;
         c.mtl_encode_dispatch(
@@ -3279,17 +4043,17 @@ const CompiledProgram = struct {
         self.runtime_profile.backend_dispatch_count +%= 1;
     }
 
-    fn encodeTyped(
+    fn encodeKernel(
         self: *CompiledProgram,
-        comptime Params: type,
-        pipeline: *anyopaque,
+        kernel: MetalKernel,
         buffers: []const DeviceBuffer,
-        params: Params,
+        params: anytype,
         params_index: u32,
         grid: DispatchGrid,
         threads_x: u32,
     ) void {
-        self.encode(pipeline, buffers, &params, @sizeOf(Params), params_index, grid, threads_x);
+        const Params = @TypeOf(params);
+        self.encode(self.backend.pipeline(kernel), buffers, &params, @sizeOf(Params), params_index, grid, threads_x);
     }
 
     fn canEncodeFusedElementwise(fe: anytype) bool {
@@ -3300,7 +4064,35 @@ const CompiledProgram = struct {
         return true;
     }
 
+    const RepeatSecondaryView = struct {
+        dst: u16,
+        src: u16,
+        n: u32,
+        dst_offset: u32,
+        src_offset: u32,
+        src_ne: [4]u32,
+        src_strides: [4]u32,
+        dst_strides: [4]u32,
+    };
+
+    fn repeatSecondaryView(rp: anytype) RepeatSecondaryView {
+        return .{
+            .dst = rp.dst,
+            .src = rp.src,
+            .n = rp.n,
+            .dst_offset = rp.dst_offset,
+            .src_offset = rp.src_offset,
+            .src_ne = rp.src_ne,
+            .src_strides = rp.src_strides,
+            .dst_strides = rp.dst_strides,
+        };
+    }
+
     fn encodeFusedElementwise(self: *CompiledProgram, fe: anytype) bool {
+        return self.encodeFusedElementwiseWithRepeatView(fe, null);
+    }
+
+    fn encodeFusedElementwiseWithRepeatView(self: *CompiledProgram, fe: anytype, repeat_view: ?RepeatSecondaryView) bool {
         if (!canEncodeFusedElementwise(fe)) return false;
 
         var params = std.mem.zeroes(FusedEwParams);
@@ -3323,13 +4115,29 @@ const CompiledProgram = struct {
             params.secondary_offset[i] = step.secondary_offset;
 
             if (step.op.isBinary()) {
+                var secondary_buf = step.secondary_buf;
+                if (repeat_view) |rp| {
+                    if (step.secondary_buf == rp.dst) {
+                        if (step.secondary_offset < rp.dst_offset) return false;
+                        const rel = step.secondary_offset - rp.dst_offset;
+                        if (@as(u64, rel) + @as(u64, fe.n) > @as(u64, rp.n)) return false;
+                        secondary_buf = rp.src;
+                        params.secondary_is_repeat[i] = 1;
+                        params.secondary_repeat_dst_offset[i] = rel;
+                        params.secondary_repeat_src_offset[i] = rp.src_offset;
+                        params.secondary_repeat_src_ne[i] = rp.src_ne;
+                        params.secondary_repeat_src_strides[i] = rp.src_strides;
+                        params.secondary_repeat_dst_strides[i] = rp.dst_strides;
+                    }
+                }
+
                 const slot = for (secondary_bufs[0..secondary_count], 0..) |buf_idx, slot_idx| {
-                    if (buf_idx == step.secondary_buf) break slot_idx;
+                    if (buf_idx == secondary_buf) break slot_idx;
                 } else blk: {
                     if (secondary_count >= MAX_FUSED_EW_SECONDARIES) return false;
                     const next = secondary_count;
-                    secondary_bufs[next] = step.secondary_buf;
-                    buffers[2 + next] = self.device_bufs[step.secondary_buf];
+                    secondary_bufs[next] = secondary_buf;
+                    buffers[2 + next] = self.device_bufs[secondary_buf];
                     secondary_count += 1;
                     break :blk next;
                 };
@@ -3337,9 +4145,8 @@ const CompiledProgram = struct {
             }
         }
 
-        self.encodeTyped(
-            FusedEwParams,
-            self.backend.fused_ew_pipeline,
+        self.encodeKernel(
+            .fused_elementwise_f32,
             buffers[0..],
             params,
             10,
@@ -3347,6 +4154,11 @@ const CompiledProgram = struct {
             WG_SIZE,
         );
         return true;
+    }
+
+    fn encodeRepeatFusedElementwise(self: *CompiledProgram, rp: anytype, fe: anytype) bool {
+        if (!program_mod.repeatFusedElementwiseCompatible(rp, fe)) return false;
+        return self.encodeFusedElementwiseWithRepeatView(fe, repeatSecondaryView(rp));
     }
 
     fn tryEncodeFusedElementwise(self: *CompiledProgram, fe: anytype) bool {
@@ -3360,7 +4172,7 @@ const CompiledProgram = struct {
             self.device_bufs[spec.src1],
             self.device_bufs[spec.dst],
         };
-        self.encodeTyped(ComputeParams, self.backend.compute_pipeline, &buffers, spec.params, 3, spec.grid, WG_SIZE);
+        self.encodeKernel(.compute_f32, &buffers, spec.params, 3, spec.grid, WG_SIZE);
     }
 
     fn canEncodeElementwiseBatchOp(e: anytype) bool {
@@ -3391,9 +4203,8 @@ const CompiledProgram = struct {
             params.max_n = @max(params.max_n, e.n);
         }
 
-        self.encodeTyped(
-            ElementwiseBatchParams,
-            self.backend.elementwise_batch8_pipeline,
+        self.encodeKernel(
+            .elementwise_batch8_f32,
             &buffers,
             params,
             24,
@@ -3411,7 +4222,7 @@ const CompiledProgram = struct {
             self.device_bufs[q.input],
             self.device_bufs[q.dst],
         };
-        self.encodeTyped(QMatMulParams, self.backend.qmatvec_pipeline, &buffers, qmatmulParams(q, w.block_size), 4, .{ .gx = linearGrid(q.N) }, WG_SIZE);
+        self.encodeKernel(.qmatvec_f32, &buffers, qmatmulParams(q, w.block_size), 4, .{ .gx = linearGrid(q.N) }, WG_SIZE);
         return true;
     }
 
@@ -3419,22 +4230,75 @@ const CompiledProgram = struct {
         return q.M != 1 and @as(usize, q.weight_idx) < self.qweight_views.len;
     }
 
+    const QMatmulBatchSidecarKind = enum {
+        slice,
+        elementwise,
+    };
+
+    const QMatmulBatchSidecarPlan = struct {
+        counts: [MAX_QMATMUL_BATCH]u32 = [_]u32{0} ** MAX_QMATMUL_BATCH,
+        indices: [QMATMUL_BATCH_SIDECAR_SLOTS]?usize = [_]?usize{null} ** QMATMUL_BATCH_SIDECAR_SLOTS,
+        kinds: [QMATMUL_BATCH_SIDECAR_SLOTS]QMatmulBatchSidecarKind = [_]QMatmulBatchSidecarKind{.slice} ** QMATMUL_BATCH_SIDECAR_SLOTS,
+
+        fn append(self: *QMatmulBatchSidecarPlan, slot: usize, kind: QMatmulBatchSidecarKind, idx: usize) bool {
+            if (slot >= MAX_QMATMUL_BATCH) return false;
+            const count: usize = @intCast(self.counts[slot]);
+            if (count >= MAX_QMATMUL_BATCH_SIDECARS) return false;
+            const sidecar_slot = QMatmulBatchSidecarLayout.index(slot, count);
+            self.indices[sidecar_slot] = idx;
+            self.kinds[sidecar_slot] = kind;
+            self.counts[slot] += 1;
+            return true;
+        }
+
+        fn appendSlice(self: *QMatmulBatchSidecarPlan, slot: usize, idx: usize) bool {
+            return self.append(slot, .slice, idx);
+        }
+
+        fn appendElementwise(self: *QMatmulBatchSidecarPlan, slot: usize, idx: usize) bool {
+            return self.append(slot, .elementwise, idx);
+        }
+
+        fn slotIndices(self: *const QMatmulBatchSidecarPlan, slot: usize) []const ?usize {
+            const start = QMatmulBatchSidecarLayout.start(slot);
+            const count: usize = @intCast(self.counts[slot]);
+            return self.indices[start .. start + count];
+        }
+    };
+
     fn encodeQMatmulBatch(
         self: *CompiledProgram,
         ops: []const backend_mod.DeviceOp,
         indices: []const usize,
         sidecar_indices: []const ?usize,
     ) void {
+        var sidecars = QMatmulBatchSidecarPlan{};
+        for (sidecar_indices, 0..) |maybe_idx, slot| {
+            if (maybe_idx) |idx| switch (ops[idx]) {
+                .slice_assign => _ = sidecars.appendSlice(slot, idx),
+                .elementwise => _ = sidecars.appendElementwise(slot, idx),
+                else => {},
+            };
+        }
+        self.encodeQMatmulBatchWithSidecars(ops, indices, &sidecars);
+    }
+
+    fn encodeQMatmulBatchWithSidecars(
+        self: *CompiledProgram,
+        ops: []const backend_mod.DeviceOp,
+        indices: []const usize,
+        sidecars: *const QMatmulBatchSidecarPlan,
+    ) void {
         const first_q = ops[indices[0]].qmatmul;
         const first_w = self.qweight_views[first_q.weight_idx];
-        var buffers: [MAX_QMATMUL_BATCH * 6]DeviceBuffer = undefined;
+        var buffers: [QMatmulBatchKernel.buffer_count]DeviceBuffer = undefined;
         for (0..MAX_QMATMUL_BATCH) |slot| {
-            buffers[slot * 6 + 0] = first_w.data;
-            buffers[slot * 6 + 1] = first_w.scales;
-            buffers[slot * 6 + 2] = self.device_bufs[first_q.input];
-            buffers[slot * 6 + 3] = self.device_bufs[first_q.dst];
-            buffers[slot * 6 + 4] = self.device_bufs[first_q.dst];
-            buffers[slot * 6 + 5] = self.device_bufs[first_q.input];
+            buffers[QMatmulBatchKernel.bufferIndex(slot, .weight_data)] = first_w.data;
+            buffers[QMatmulBatchKernel.bufferIndex(slot, .weight_scales)] = first_w.scales;
+            buffers[QMatmulBatchKernel.bufferIndex(slot, .input)] = self.device_bufs[first_q.input];
+            buffers[QMatmulBatchKernel.bufferIndex(slot, .output)] = self.device_bufs[first_q.dst];
+            buffers[QMatmulBatchKernel.bufferIndex(slot, .sidecar_dst)] = self.device_bufs[first_q.dst];
+            buffers[QMatmulBatchKernel.bufferIndex(slot, .secondary)] = self.device_bufs[first_q.input];
         }
 
         var params = std.mem.zeroes(QMatmulBatch4Params);
@@ -3445,12 +4309,12 @@ const CompiledProgram = struct {
             const q = ops[op_index].qmatmul;
             const w = self.qweight_views[q.weight_idx];
             const qparams = qmatmulParams(q, w.block_size);
-            buffers[slot * 6 + 0] = w.data;
-            buffers[slot * 6 + 1] = w.scales;
-            buffers[slot * 6 + 2] = self.device_bufs[q.input];
-            buffers[slot * 6 + 3] = self.device_bufs[q.dst];
-            buffers[slot * 6 + 4] = self.device_bufs[q.dst];
-            buffers[slot * 6 + 5] = self.device_bufs[q.input];
+            buffers[QMatmulBatchKernel.bufferIndex(slot, .weight_data)] = w.data;
+            buffers[QMatmulBatchKernel.bufferIndex(slot, .weight_scales)] = w.scales;
+            buffers[QMatmulBatchKernel.bufferIndex(slot, .input)] = self.device_bufs[q.input];
+            buffers[QMatmulBatchKernel.bufferIndex(slot, .output)] = self.device_bufs[q.dst];
+            buffers[QMatmulBatchKernel.bufferIndex(slot, .sidecar_dst)] = self.device_bufs[q.dst];
+            buffers[QMatmulBatchKernel.bufferIndex(slot, .secondary)] = self.device_bufs[q.input];
             params.M[slot] = qparams.M;
             params.N[slot] = qparams.N;
             params.K[slot] = qparams.K;
@@ -3460,32 +4324,38 @@ const CompiledProgram = struct {
             params.dst_offset[slot] = qparams.dst_offset;
             params.dst_row_stride[slot] = qparams.dst_row_stride;
             params.write_primary[slot] = 1;
-            if (sidecar_indices[slot]) |sidecar_index| {
-                params.write_primary[slot] = @intFromBool(program_mod.projectionPrimaryOutputHasExternalUsers(ops, op_index, sidecar_index));
-                switch (ops[sidecar_index]) {
-                    .slice_assign => |sa| {
-                        params.sidecar_kind[slot] = 1;
-                        params.slice_rows[slot] = sa.rows;
-                        params.slice_cols[slot] = sa.cols;
-                        params.slice_src_col_start[slot] = program_mod.qmatmulSliceSrcColStart(q, sa).?;
-                        params.slice_dst_offset[slot] = sa.dst_offset;
-                        params.slice_dst_row_stride[slot] = sa.dst_row_stride;
-                        params.slice_dst_col_stride[slot] = sa.dst_col_stride;
-                        buffers[slot * 6 + 4] = self.device_bufs[sa.dst];
+            params.sidecar_count[slot] = sidecars.counts[slot];
+            if (params.sidecar_count[slot] > 0) {
+                params.write_primary[slot] = @intFromBool(program_mod.projectionPrimaryOutputHasExternalUsersExcept(ops, op_index, sidecars.slotIndices(slot)));
+            }
+            for (sidecars.slotIndices(slot), 0..) |maybe_sidecar_index, sidecar_slot| {
+                const sidecar_index = maybe_sidecar_index orelse continue;
+                const param_slot = QMatmulBatchSidecarLayout.index(slot, sidecar_slot);
+                switch (sidecars.kinds[param_slot]) {
+                    .slice => {
+                        const sa = ops[sidecar_index].slice_assign;
+                        params.sidecar_kind[param_slot] = @intFromEnum(QMatmulBatchSidecarCode.slice);
+                        params.slice_rows[param_slot] = sa.rows;
+                        params.slice_cols[param_slot] = sa.cols;
+                        params.slice_src_col_start[param_slot] = program_mod.qmatmulSliceSrcColStart(q, sa).?;
+                        params.slice_dst_offset[param_slot] = sa.dst_offset;
+                        params.slice_dst_row_stride[param_slot] = sa.dst_row_stride;
+                        params.slice_dst_col_stride[param_slot] = sa.dst_col_stride;
+                        buffers[QMatmulBatchKernel.bufferIndex(slot, .sidecar_dst)] = self.device_bufs[sa.dst];
                     },
-                    .elementwise => |e| {
+                    .elementwise => {
+                        const e = ops[sidecar_index].elementwise;
                         const q_is_src0 = e.src0 == q.dst and e.src0_offset == q.dst_offset;
                         const secondary_buf = if (q_is_src0) e.src1 else e.src0;
                         const secondary_offset = if (q_is_src0) e.src1_offset else e.src0_offset;
-                        params.sidecar_kind[slot] = 2;
-                        params.ew_op[slot] = @intFromEnum(e.op);
-                        params.ew_is_swapped[slot] = if (q_is_src0) 0 else 1;
-                        params.ew_dst_offset[slot] = e.dst_offset;
-                        params.ew_secondary_offset[slot] = secondary_offset;
-                        buffers[slot * 6 + 4] = self.device_bufs[e.dst];
-                        buffers[slot * 6 + 5] = self.device_bufs[secondary_buf];
+                        params.sidecar_kind[param_slot] = @intFromEnum(QMatmulBatchSidecarCode.elementwise);
+                        params.ew_op[param_slot] = @intFromEnum(e.op);
+                        params.ew_is_swapped[param_slot] = if (q_is_src0) 0 else 1;
+                        params.ew_dst_offset[param_slot] = e.dst_offset;
+                        params.ew_secondary_offset[param_slot] = secondary_offset;
+                        buffers[QMatmulBatchKernel.bufferIndex(slot, .sidecar_dst)] = self.device_bufs[e.dst];
+                        buffers[QMatmulBatchKernel.bufferIndex(slot, .secondary)] = self.device_bufs[secondary_buf];
                     },
-                    else => {},
                 }
             }
             max_tiles_x = @max(max_tiles_x, (qparams.N + TILE - 1) / TILE);
@@ -3493,16 +4363,136 @@ const CompiledProgram = struct {
         }
         params.max_tiles_y = max_tiles_y;
 
-        self.encodeTyped(
-            QMatmulBatch4Params,
-            self.backend.qmatmul_batch4_pipeline,
+        self.encodeKernel(
+            .qmatmul_batch4_f32,
             &buffers,
             params,
-            24,
+            QMatmulBatchKernel.params_index,
             .{ .gx = max_tiles_x, .gy = max_tiles_y * @as(u32, @intCast(indices.len)) },
             MATMUL_THREADS,
         );
     }
+
+    const QMatmulRopeStorePair = struct {
+        anchor_slot: usize,
+        q_index: usize,
+        rope_index: usize,
+        store_index: usize,
+    };
+
+    fn canEncodeQMatmulRopeStorePair(self: *CompiledProgram, q: anytype, rr: anytype, sa: anytype) bool {
+        return self.canEncodeQMatmulBatchOp(q) and
+            program_mod.qmatmulRopeStoreTilePairCompatible(q, rr, sa, TILE);
+    }
+
+    fn encodeQMatmulRopeStoreBatch(
+        self: *CompiledProgram,
+        ops: []const backend_mod.DeviceOp,
+        pairs: []const QMatmulRopeStorePair,
+    ) void {
+        if (pairs.len == 0) return;
+
+        const first_q = ops[pairs[0].q_index].qmatmul;
+        const first_rr = ops[pairs[0].rope_index].rope;
+        const first_sa = ops[pairs[0].store_index].slice_assign;
+        const first_w = self.qweight_views[first_q.weight_idx];
+        var buffers: [QMatmulRopeStoreKernel.buffer_count]DeviceBuffer = undefined;
+        for (0..MAX_QMATMUL_ROPE_STORE_BATCH) |slot| {
+            buffers[QMatmulRopeStoreKernel.bufferIndex(slot, .weight_data)] = first_w.data;
+            buffers[QMatmulRopeStoreKernel.bufferIndex(slot, .weight_scales)] = first_w.scales;
+            buffers[QMatmulRopeStoreKernel.bufferIndex(slot, .input)] = self.device_bufs[first_q.input];
+            buffers[QMatmulRopeStoreKernel.bufferIndex(slot, .output)] = self.device_bufs[first_q.dst];
+            buffers[QMatmulRopeStoreKernel.bufferIndex(slot, .cos_sin)] = self.device_bufs[first_rr.cos_sin];
+            buffers[QMatmulRopeStoreKernel.bufferIndex(slot, .slice_dst)] = self.device_bufs[first_sa.dst];
+        }
+
+        var params = std.mem.zeroes(QMatmulRopeStoreBatch4Params);
+        params.n_ops = @intCast(pairs.len);
+        var max_tiles_x: u32 = 1;
+        var max_tiles_y: u32 = 1;
+        for (pairs, 0..) |pair, slot| {
+            const q = ops[pair.q_index].qmatmul;
+            const rr = ops[pair.rope_index].rope;
+            const sa = ops[pair.store_index].slice_assign;
+            const w = self.qweight_views[q.weight_idx];
+            const qparams = qmatmulParams(q, w.block_size);
+
+            buffers[QMatmulRopeStoreKernel.bufferIndex(slot, .weight_data)] = w.data;
+            buffers[QMatmulRopeStoreKernel.bufferIndex(slot, .weight_scales)] = w.scales;
+            buffers[QMatmulRopeStoreKernel.bufferIndex(slot, .input)] = self.device_bufs[q.input];
+            buffers[QMatmulRopeStoreKernel.bufferIndex(slot, .output)] = self.device_bufs[q.dst];
+            buffers[QMatmulRopeStoreKernel.bufferIndex(slot, .cos_sin)] = self.device_bufs[rr.cos_sin];
+            buffers[QMatmulRopeStoreKernel.bufferIndex(slot, .slice_dst)] = self.device_bufs[sa.dst];
+
+            params.M[slot] = qparams.M;
+            params.N[slot] = qparams.N;
+            params.K[slot] = qparams.K;
+            params.block_size[slot] = qparams.block_size;
+            params.input_offset[slot] = qparams.input_offset;
+            params.input_row_stride[slot] = qparams.input_row_stride;
+            params.dst_offset[slot] = qparams.dst_offset;
+            params.dst_row_stride[slot] = qparams.dst_row_stride;
+            params.write_primary[slot] = 0;
+            params.rope_half_d[slot] = rr.half_d;
+            params.rope_src_col_start[slot] = program_mod.qmatmulRopeSrcColStart(q, rr).?;
+            params.rope_cs_off[slot] = rr.cs_off;
+            params.rope_cs_cs[slot] = rr.cs_cs;
+            params.slice_dst_offset[slot] = sa.dst_offset;
+            params.slice_dst_row_stride[slot] = sa.dst_row_stride;
+            params.slice_dst_col_stride[slot] = sa.dst_col_stride;
+            max_tiles_x = @max(max_tiles_x, (rr.half_d + TILE - 1) / TILE);
+            max_tiles_y = @max(max_tiles_y, (qparams.M + TILE - 1) / TILE);
+        }
+        params.max_tiles_y = max_tiles_y;
+
+        self.encodeKernel(
+            .qmatmul_rope_store_batch4_f32,
+            &buffers,
+            params,
+            QMatmulRopeStoreKernel.params_index,
+            .{ .gx = max_tiles_x, .gy = max_tiles_y * @as(u32, @intCast(pairs.len)) },
+            MATMUL_THREADS,
+        );
+    }
+
+    const QMatvecBatchSidecarKind = enum(u32) {
+        none = 0,
+        slice = 1,
+        rope = 2,
+        elementwise = 3,
+    };
+
+    const QMatvecBatchSidecarPlan = struct {
+        kinds: [MAX_QMATVEC_BATCH]QMatvecBatchSidecarKind = [_]QMatvecBatchSidecarKind{.none} ** MAX_QMATVEC_BATCH,
+        rope_indices: [MAX_QMATVEC_BATCH]?usize = [_]?usize{null} ** MAX_QMATVEC_BATCH,
+        store_indices: [MAX_QMATVEC_BATCH]?usize = [_]?usize{null} ** MAX_QMATVEC_BATCH,
+
+        fn appendSlice(self: *QMatvecBatchSidecarPlan, slot: usize, idx: usize) bool {
+            if (slot >= MAX_QMATVEC_BATCH or self.kinds[slot] != .none) return false;
+            self.kinds[slot] = .slice;
+            self.store_indices[slot] = idx;
+            return true;
+        }
+
+        fn appendElementwise(self: *QMatvecBatchSidecarPlan, slot: usize, idx: usize) bool {
+            if (slot >= MAX_QMATVEC_BATCH or self.kinds[slot] != .none) return false;
+            self.kinds[slot] = .elementwise;
+            self.store_indices[slot] = idx;
+            return true;
+        }
+
+        fn appendRope(self: *QMatvecBatchSidecarPlan, slot: usize, rope_idx: usize, store_idx: ?usize) bool {
+            if (slot >= MAX_QMATVEC_BATCH or self.kinds[slot] != .none) return false;
+            self.kinds[slot] = .rope;
+            self.rope_indices[slot] = rope_idx;
+            self.store_indices[slot] = store_idx;
+            return true;
+        }
+
+        fn appendRopeStore(self: *QMatvecBatchSidecarPlan, slot: usize, rope_idx: usize, store_idx: usize) bool {
+            return self.appendRope(slot, rope_idx, store_idx);
+        }
+    };
 
     fn canEncodeQMatvecBatchOp(self: *CompiledProgram, q: anytype) bool {
         return q.M == 1 and
@@ -3511,15 +4501,47 @@ const CompiledProgram = struct {
             (q.dst_row_stride == 0 or q.dst_row_stride == q.N);
     }
 
-    fn encodeQMatvecBatch(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, indices: []const usize) void {
+    fn canEncodeQMatvecElementwiseSidecar(_: *CompiledProgram, q: anytype, e: anytype) bool {
+        if (!program_mod.qmatvecElementwiseSidecarCompatible(q, e)) return false;
+        const primary_is_src0 = e.src0 == q.dst and e.src0_offset == q.dst_offset;
+        const secondary_buf = if (primary_is_src0) e.src1 else e.src0;
+        return secondary_buf != q.dst;
+    }
+
+    fn encodeQMatvecBatch(
+        self: *CompiledProgram,
+        ops: []const backend_mod.DeviceOp,
+        indices: []const usize,
+        sidecar_indices: []const ?usize,
+    ) void {
+        var sidecars = QMatvecBatchSidecarPlan{};
+        for (sidecar_indices, 0..) |maybe_idx, slot| {
+            const idx = maybe_idx orelse continue;
+            switch (ops[idx]) {
+                .slice_assign => _ = sidecars.appendSlice(slot, idx),
+                .elementwise => _ = sidecars.appendElementwise(slot, idx),
+                else => {},
+            }
+        }
+        self.encodeQMatvecBatchWithSidecars(ops, indices, &sidecars);
+    }
+
+    fn encodeQMatvecBatchWithSidecars(
+        self: *CompiledProgram,
+        ops: []const backend_mod.DeviceOp,
+        indices: []const usize,
+        sidecars: *const QMatvecBatchSidecarPlan,
+    ) void {
         const first_q = ops[indices[0]].qmatmul;
         const first_w = self.qweight_views[first_q.weight_idx];
-        var buffers: [MAX_QMATVEC_BATCH * 4]DeviceBuffer = undefined;
+        var buffers: [QMatvecBatchKernel.buffer_count]DeviceBuffer = undefined;
         for (0..MAX_QMATVEC_BATCH) |slot| {
-            buffers[slot * 4 + 0] = first_w.data;
-            buffers[slot * 4 + 1] = first_w.scales;
-            buffers[slot * 4 + 2] = self.device_bufs[first_q.input];
-            buffers[slot * 4 + 3] = self.device_bufs[first_q.dst];
+            buffers[QMatvecBatchKernel.bufferIndex(slot, .weight_data)] = first_w.data;
+            buffers[QMatvecBatchKernel.bufferIndex(slot, .weight_scales)] = first_w.scales;
+            buffers[QMatvecBatchKernel.bufferIndex(slot, .input)] = self.device_bufs[first_q.input];
+            buffers[QMatvecBatchKernel.bufferIndex(slot, .output)] = self.device_bufs[first_q.dst];
+            buffers[QMatvecBatchKernel.bufferIndex(slot, .sidecar_src)] = self.device_bufs[first_q.input];
+            buffers[QMatvecBatchKernel.bufferIndex(slot, .sidecar_dst)] = self.device_bufs[first_q.dst];
         }
 
         var params = std.mem.zeroes(QMatvecBatch4Params);
@@ -3528,24 +4550,81 @@ const CompiledProgram = struct {
             const q = ops[op_index].qmatmul;
             const w = self.qweight_views[q.weight_idx];
             const qparams = qmatmulParams(q, w.block_size);
-            buffers[slot * 4 + 0] = w.data;
-            buffers[slot * 4 + 1] = w.scales;
-            buffers[slot * 4 + 2] = self.device_bufs[q.input];
-            buffers[slot * 4 + 3] = self.device_bufs[q.dst];
+            buffers[QMatvecBatchKernel.bufferIndex(slot, .weight_data)] = w.data;
+            buffers[QMatvecBatchKernel.bufferIndex(slot, .weight_scales)] = w.scales;
+            buffers[QMatvecBatchKernel.bufferIndex(slot, .input)] = self.device_bufs[q.input];
+            buffers[QMatvecBatchKernel.bufferIndex(slot, .output)] = self.device_bufs[q.dst];
+            buffers[QMatvecBatchKernel.bufferIndex(slot, .sidecar_src)] = self.device_bufs[q.input];
+            buffers[QMatvecBatchKernel.bufferIndex(slot, .sidecar_dst)] = self.device_bufs[q.dst];
             params.N[slot] = qparams.N;
             params.K[slot] = qparams.K;
             params.block_size[slot] = qparams.block_size;
             params.input_offset[slot] = qparams.input_offset;
             params.dst_offset[slot] = qparams.dst_offset;
+            params.write_primary[slot] = 1;
+            switch (sidecars.kinds[slot]) {
+                .none => {},
+                .slice => {
+                    const sidecar_index = sidecars.store_indices[slot].?;
+                    const sa = ops[sidecar_index].slice_assign;
+                    const carried = [_]?usize{sidecar_index};
+                    params.write_primary[slot] = @intFromBool(program_mod.projectionPrimaryOutputHasExternalUsersExcept(ops, op_index, &carried));
+                    params.sidecar_kind[slot] = @intFromEnum(QMatvecBatchSidecarKind.slice);
+                    params.slice_rows[slot] = sa.rows;
+                    params.slice_src_col_start[slot] = program_mod.qmatmulSliceSrcColStart(q, sa).?;
+                    params.slice_dst_offset[slot] = sa.dst_offset;
+                    params.slice_dst_row_stride[slot] = sa.dst_row_stride;
+                    buffers[QMatvecBatchKernel.bufferIndex(slot, .sidecar_dst)] = self.device_bufs[sa.dst];
+                },
+                .elementwise => {
+                    const sidecar_index = sidecars.store_indices[slot].?;
+                    const e = ops[sidecar_index].elementwise;
+                    if (!program_mod.qmatvecElementwiseSidecarCompatible(q, e)) return;
+                    const primary_is_src0 = e.src0 == q.dst and e.src0_offset == q.dst_offset;
+                    const secondary_buf = if (primary_is_src0) e.src1 else e.src0;
+                    const secondary_offset = if (primary_is_src0) e.src1_offset else e.src0_offset;
+                    if (secondary_buf == q.dst) return;
+                    const carried = [_]?usize{sidecar_index};
+                    params.write_primary[slot] = @intFromBool(program_mod.projectionPrimaryOutputHasExternalUsersExcept(ops, op_index, &carried));
+                    params.sidecar_kind[slot] = @intFromEnum(QMatvecBatchSidecarKind.elementwise);
+                    params.ew_op[slot] = @intFromEnum(e.op);
+                    params.ew_is_swapped[slot] = @intFromBool(!primary_is_src0);
+                    params.ew_dst_offset[slot] = e.dst_offset;
+                    params.ew_secondary_offset[slot] = secondary_offset;
+                    buffers[QMatvecBatchKernel.bufferIndex(slot, .sidecar_src)] = self.device_bufs[secondary_buf];
+                    buffers[QMatvecBatchKernel.bufferIndex(slot, .sidecar_dst)] = self.device_bufs[e.dst];
+                },
+                .rope => {
+                    const rope_index = sidecars.rope_indices[slot].?;
+                    const rr = ops[rope_index].rope;
+                    const maybe_store_index = sidecars.store_indices[slot];
+                    const carried = [_]?usize{ rope_index, maybe_store_index };
+                    params.write_primary[slot] = @intFromBool(program_mod.projectionPrimaryOutputHasExternalUsersExcept(ops, op_index, &carried));
+                    params.sidecar_kind[slot] = @intFromEnum(QMatvecBatchSidecarKind.rope);
+                    params.slice_rows[slot] = rr.half_d * 2;
+                    params.slice_src_col_start[slot] = program_mod.qmatmulRopeSrcColStart(q, rr).?;
+                    params.slice_dst_offset[slot] = rr.dst_off;
+                    params.slice_dst_row_stride[slot] = 1;
+                    params.rope_half_d[slot] = rr.half_d;
+                    params.rope_cs_off[slot] = rr.cs_off;
+                    buffers[QMatvecBatchKernel.bufferIndex(slot, .sidecar_src)] = self.device_bufs[rr.cos_sin];
+                    buffers[QMatvecBatchKernel.bufferIndex(slot, .sidecar_dst)] = self.device_bufs[rr.dst];
+                    if (maybe_store_index) |store_index| {
+                        const sa = ops[store_index].slice_assign;
+                        params.slice_dst_offset[slot] = sa.dst_offset;
+                        params.slice_dst_row_stride[slot] = sa.dst_row_stride;
+                        buffers[QMatvecBatchKernel.bufferIndex(slot, .sidecar_dst)] = self.device_bufs[sa.dst];
+                    }
+                },
+            }
             params.max_n = @max(params.max_n, qparams.N);
         }
 
-        self.encodeTyped(
-            QMatvecBatch4Params,
-            self.backend.qmatvec_batch4_pipeline,
+        self.encodeKernel(
+            .qmatvec_batch4_f32,
             &buffers,
             params,
-            16,
+            QMatvecBatchKernel.params_index,
             .{ .gx = linearGrid(params.max_n), .gy = @intCast(indices.len) },
             WG_SIZE,
         );
@@ -3567,7 +4646,7 @@ const CompiledProgram = struct {
             .src_cs = rr.src_cs,
             .cs_cs = rr.cs_cs,
         };
-        self.encodeTyped(RopeParams, self.backend.rope_pipeline, &buffers, params, 3, .{ .gx = linearGrid(rr.half_d * rr.seq_len) }, WG_SIZE);
+        self.encodeKernel(.rope_f32, &buffers, params, 3, .{ .gx = linearGrid(rr.half_d * rr.seq_len) }, WG_SIZE);
     }
 
     fn ropeBatchCompatible(first: anytype, next: anytype) bool {
@@ -3599,7 +4678,7 @@ const CompiledProgram = struct {
             params.cs_cs[i] = rr.cs_cs;
             params.max_n = @max(params.max_n, rr.half_d * rr.seq_len);
         }
-        self.encodeTyped(RopeBatchParams, self.backend.rope_batch_pipeline, &buffers, params, 3, .{ .gx = linearGrid(params.max_n), .gy = @intCast(n) }, WG_SIZE);
+        self.encodeKernel(.rope_batch_f32, &buffers, params, 3, .{ .gx = linearGrid(params.max_n), .gy = @intCast(n) }, WG_SIZE);
     }
 
     fn canFuseRopeSliceAssign(rr: anytype, sa: anytype) bool {
@@ -3624,7 +4703,7 @@ const CompiledProgram = struct {
             .dst_row_stride = sa.dst_row_stride,
             .dst_col_stride = sa.dst_col_stride,
         };
-        self.encodeTyped(RopeSliceAssignParams, self.backend.rope_slice_assign_pipeline, &buffers, params, 3, .{ .gx = linearGrid(rr.half_d * rr.seq_len) }, WG_SIZE);
+        self.encodeKernel(.rope_slice_assign_f32, &buffers, params, 3, .{ .gx = linearGrid(rr.half_d * rr.seq_len) }, WG_SIZE);
     }
 
     fn canEncodeRopeStoreGroupCommand(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, command: program_mod.ProgramCommand) bool {
@@ -3691,7 +4770,7 @@ const CompiledProgram = struct {
             params.dst_col_stride[i] = sa.dst_col_stride;
             params.max_n = @max(params.max_n, rr.half_d * rr.seq_len);
         }
-        self.encodeTyped(RopeSliceAssignBatchParams, self.backend.rope_slice_assign_batch_pipeline, &buffers, params, MAX_ROPE_BATCH + 2, .{ .gx = linearGrid(params.max_n), .gy = command.anchor_count }, WG_SIZE);
+        self.encodeKernel(.rope_slice_assign_batch_f32, &buffers, params, MAX_ROPE_BATCH + 2, .{ .gx = linearGrid(params.max_n), .gy = command.anchor_count }, WG_SIZE);
     }
 
     fn canFuseQMatvecSliceAssign(self: *CompiledProgram, q: anytype, sa: anytype) bool {
@@ -3732,7 +4811,7 @@ const CompiledProgram = struct {
             .slice_dst_row_stride = sa.dst_row_stride,
             .slice_dst_col_stride = sa.dst_col_stride,
         };
-        self.encodeTyped(QMatmulSliceAssignParams, self.backend.qmatvec_slice_assign_pipeline, &buffers, params, 5, .{ .gx = linearGrid(q.N) }, WG_SIZE);
+        self.encodeKernel(.qmatvec_slice_assign_f32, &buffers, params, 5, .{ .gx = linearGrid(q.N) }, WG_SIZE);
         return true;
     }
 
@@ -3764,7 +4843,7 @@ const CompiledProgram = struct {
             .slice_dst_row_stride = sa.dst_row_stride,
             .slice_dst_col_stride = sa.dst_col_stride,
         };
-        self.encodeTyped(QMatmulSliceAssignParams, self.backend.qmatmul_slice_assign_pipeline, &buffers, params, 5, matmulGrid(q.M, q.N), MATMUL_THREADS);
+        self.encodeKernel(.qmatmul_slice_assign_f32, &buffers, params, 5, matmulGrid(q.M, q.N), MATMUL_THREADS);
         return true;
     }
 
@@ -3803,14 +4882,67 @@ const CompiledProgram = struct {
             .ew_dst_offset = e.dst_offset,
             .ew_secondary_offset = secondary_offset,
         };
-        self.encodeTyped(QMatmulElementwiseParams, self.backend.qmatmul_elementwise_pipeline, &buffers, params, 6, matmulGrid(q.M, q.N), MATMUL_THREADS);
+        self.encodeKernel(.qmatmul_elementwise_f32, &buffers, params, 6, matmulGrid(q.M, q.N), MATMUL_THREADS);
         return true;
     }
 
     fn canFuseQMatmulFusedElementwise(self: *CompiledProgram, q: anytype, fe: anytype) bool {
         if (@as(usize, q.weight_idx) >= self.qweight_views.len) return false;
         if (!canEncodeFusedElementwise(fe)) return false;
+        for (fe.steps) |step| {
+            if (step.op.isBinary() and step.secondary_buf == q.dst and step.secondary_offset != q.dst_offset) return false;
+        }
         return program_mod.qmatmulFusedElementwiseSidecarCompatible(q, fe);
+    }
+
+    fn bindQMatmulFusedSecondary(
+        self: *CompiledProgram,
+        buffers: *[5 + MAX_FUSED_EW_SECONDARIES]DeviceBuffer,
+        secondary_bufs: *[MAX_FUSED_EW_SECONDARIES]u16,
+        secondary_count: *usize,
+        params: *QMatmulFusedEwParams,
+        q: anytype,
+        step: backend_mod.FusedEwStep,
+        step_index: usize,
+        repeat_view: ?RepeatSecondaryView,
+    ) bool {
+        params.secondary_offset[step_index] = step.secondary_offset;
+        if (!step.op.isBinary()) return true;
+
+        if (step.secondary_buf == q.dst) {
+            if (step.secondary_offset != q.dst_offset) return false;
+            params.secondary_is_primary[step_index] = 1;
+            return true;
+        }
+
+        var secondary_buf = step.secondary_buf;
+        if (repeat_view) |rp| {
+            if (step.secondary_buf == rp.dst) {
+                if (step.secondary_offset < rp.dst_offset) return false;
+                const rel = step.secondary_offset - rp.dst_offset;
+                if (@as(u64, rel) + @as(u64, params.M * params.N) > @as(u64, rp.n)) return false;
+                secondary_buf = rp.src;
+                params.secondary_is_repeat[step_index] = 1;
+                params.secondary_repeat_dst_offset[step_index] = rel;
+                params.secondary_repeat_src_offset[step_index] = rp.src_offset;
+                params.secondary_repeat_src_ne[step_index] = rp.src_ne;
+                params.secondary_repeat_src_strides[step_index] = rp.src_strides;
+                params.secondary_repeat_dst_strides[step_index] = rp.dst_strides;
+            }
+        }
+
+        const slot = for (secondary_bufs[0..secondary_count.*], 0..) |buf_idx, slot_idx| {
+            if (buf_idx == secondary_buf) break slot_idx;
+        } else blk: {
+            if (secondary_count.* >= MAX_FUSED_EW_SECONDARIES) return false;
+            const next = secondary_count.*;
+            secondary_bufs[next] = secondary_buf;
+            buffers[5 + next] = self.device_bufs[secondary_buf];
+            secondary_count.* += 1;
+            break :blk next;
+        };
+        params.secondary_slot[step_index] = @intCast(slot);
+        return true;
     }
 
     fn encodeQMatmulFusedElementwise(self: *CompiledProgram, q: anytype, fe: anytype, write_primary: bool) bool {
@@ -3844,30 +4976,193 @@ const CompiledProgram = struct {
         for (fe.steps, 0..) |step, i| {
             params.op[i] = @intFromEnum(step.op);
             params.is_swapped[i] = @intFromBool(step.is_swapped);
-            params.secondary_offset[i] = step.secondary_offset;
-
-            if (step.op.isBinary()) {
-                const slot = for (secondary_bufs[0..secondary_count], 0..) |buf_idx, slot_idx| {
-                    if (buf_idx == step.secondary_buf) break slot_idx;
-                } else blk: {
-                    if (secondary_count >= MAX_FUSED_EW_SECONDARIES) return false;
-                    const next = secondary_count;
-                    secondary_bufs[next] = step.secondary_buf;
-                    buffers[5 + next] = self.device_bufs[step.secondary_buf];
-                    secondary_count += 1;
-                    break :blk next;
-                };
-                params.secondary_slot[i] = @intCast(slot);
-            }
+            if (!self.bindQMatmulFusedSecondary(&buffers, &secondary_bufs, &secondary_count, &params, q, step, i, null)) return false;
         }
 
-        self.encodeTyped(
-            QMatmulFusedEwParams,
-            self.backend.qmatmul_fused_ew_pipeline,
+        self.encodeKernel(
+            .qmatmul_fused_elementwise_f32,
             &buffers,
             params,
             13,
             matmulGrid(q.M, q.N),
+            MATMUL_THREADS,
+        );
+        return true;
+    }
+
+    fn encodeQMatmulFusedElementwiseChain(self: *CompiledProgram, q: anytype, first: anytype, rp: anytype, second: anytype) bool {
+        if (@as(usize, q.weight_idx) >= self.qweight_views.len) return false;
+        if (!program_mod.projectionFusedElementwiseChainCompatible(q, first, rp, second)) return false;
+        if (first.steps.len + second.steps.len > MAX_FUSED_EW_STEPS) return false;
+
+        const w = self.qweight_views[q.weight_idx];
+        const qparams = qmatmulParams(q, w.block_size);
+        var params = std.mem.zeroes(QMatmulFusedEwParams);
+        params.M = qparams.M;
+        params.N = qparams.N;
+        params.K = qparams.K;
+        params.block_size = qparams.block_size;
+        params.input_offset = qparams.input_offset;
+        params.input_row_stride = qparams.input_row_stride;
+        params.dst_offset = qparams.dst_offset;
+        params.dst_row_stride = qparams.dst_row_stride;
+        params.write_primary = 0;
+        params.n_steps = @intCast(first.steps.len + second.steps.len);
+        params.ew_dst_offset = second.dst_offset;
+
+        var buffers: [5 + MAX_FUSED_EW_SECONDARIES]DeviceBuffer = undefined;
+        buffers[0] = w.data;
+        buffers[1] = w.scales;
+        buffers[2] = self.device_bufs[q.input];
+        buffers[3] = self.device_bufs[q.dst];
+        buffers[4] = self.device_bufs[second.dst];
+        for (buffers[5..]) |*buf| buf.* = self.device_bufs[q.input];
+
+        var secondary_bufs: [MAX_FUSED_EW_SECONDARIES]u16 = undefined;
+        var secondary_count: usize = 0;
+
+        var step_index: usize = 0;
+        for (first.steps) |step| {
+            params.op[step_index] = @intFromEnum(step.op);
+            params.is_swapped[step_index] = @intFromBool(step.is_swapped);
+            if (!self.bindQMatmulFusedSecondary(&buffers, &secondary_bufs, &secondary_count, &params, q, step, step_index, null)) return false;
+            step_index += 1;
+        }
+        const repeat_view = repeatSecondaryView(rp);
+        for (second.steps) |step| {
+            params.op[step_index] = @intFromEnum(step.op);
+            params.is_swapped[step_index] = @intFromBool(step.is_swapped);
+            if (!self.bindQMatmulFusedSecondary(&buffers, &secondary_bufs, &secondary_count, &params, q, step, step_index, repeat_view)) return false;
+            step_index += 1;
+        }
+
+        self.encodeKernel(
+            .qmatmul_fused_elementwise_f32,
+            &buffers,
+            params,
+            13,
+            matmulGrid(q.M, q.N),
+            MATMUL_THREADS,
+        );
+        return true;
+    }
+
+    fn bindQMatmulPairFusedSecondary(
+        self: *CompiledProgram,
+        buffers: *[6 + MAX_FUSED_EW_SECONDARIES]DeviceBuffer,
+        secondary_bufs: *[MAX_FUSED_EW_SECONDARIES]u16,
+        secondary_count: *usize,
+        params: *QMatmulPairFusedEwParams,
+        gate: anytype,
+        up: anytype,
+        step: backend_mod.FusedEwStep,
+        step_index: usize,
+        repeat_view: ?RepeatSecondaryView,
+    ) bool {
+        params.secondary_offset[step_index] = step.secondary_offset;
+        if (!step.op.isBinary()) return true;
+
+        if (step.secondary_buf == gate.dst) {
+            if (step.secondary_offset != gate.dst_offset) return false;
+            params.secondary_is_primary[step_index] = 1;
+            return true;
+        }
+        if (step.secondary_buf == up.dst) return false;
+
+        var secondary_buf = step.secondary_buf;
+        if (repeat_view) |rp| {
+            if (step.secondary_buf == rp.dst) {
+                if (step.secondary_offset < rp.dst_offset) return false;
+                const rel = step.secondary_offset - rp.dst_offset;
+                if (@as(u64, rel) + @as(u64, params.M * params.N) > @as(u64, rp.n)) return false;
+                secondary_buf = rp.src;
+                params.secondary_is_repeat[step_index] = 1;
+                params.secondary_repeat_dst_offset[step_index] = rel;
+                params.secondary_repeat_src_offset[step_index] = rp.src_offset;
+                params.secondary_repeat_src_ne[step_index] = rp.src_ne;
+                params.secondary_repeat_src_strides[step_index] = rp.src_strides;
+                params.secondary_repeat_dst_strides[step_index] = rp.dst_strides;
+            }
+        }
+
+        const slot = for (secondary_bufs[0..secondary_count.*], 0..) |buf_idx, slot_idx| {
+            if (buf_idx == secondary_buf) break slot_idx;
+        } else blk: {
+            if (secondary_count.* >= MAX_FUSED_EW_SECONDARIES) return false;
+            const next = secondary_count.*;
+            secondary_bufs[next] = secondary_buf;
+            buffers[6 + next] = self.device_bufs[secondary_buf];
+            secondary_count.* += 1;
+            break :blk next;
+        };
+        params.secondary_slot[step_index] = @intCast(slot);
+        return true;
+    }
+
+    fn encodeQMatmulPairFusedElementwiseChain(
+        self: *CompiledProgram,
+        gate: anytype,
+        first: anytype,
+        rp: anytype,
+        second: anytype,
+        up: anytype,
+        product: anytype,
+    ) bool {
+        if (@as(usize, gate.weight_idx) >= self.qweight_views.len) return false;
+        if (@as(usize, up.weight_idx) >= self.qweight_views.len) return false;
+        if (!program_mod.projectionPairFusedElementwiseChainCompatible(gate, first, rp, second, up, product)) return false;
+        if (first.steps.len + second.steps.len > MAX_FUSED_EW_STEPS) return false;
+
+        const left_w = self.qweight_views[gate.weight_idx];
+        const right_w = self.qweight_views[up.weight_idx];
+        const gate_params = qmatmulParams(gate, left_w.block_size);
+        const up_params = qmatmulParams(up, right_w.block_size);
+        if (gate_params.M != up_params.M or gate_params.N != up_params.N or gate_params.K != up_params.K) return false;
+        if (gate_params.input_offset != up_params.input_offset or gate_params.input_row_stride != up_params.input_row_stride) return false;
+        var params = std.mem.zeroes(QMatmulPairFusedEwParams);
+        params.M = gate_params.M;
+        params.N = gate_params.N;
+        params.K = gate_params.K;
+        params.left_block_size = gate_params.block_size;
+        params.right_block_size = up_params.block_size;
+        params.input_offset = gate_params.input_offset;
+        params.input_row_stride = gate_params.input_row_stride;
+        params.dst_offset = product.dst_offset;
+        params.n_steps = @intCast(first.steps.len + second.steps.len);
+
+        var buffers: [6 + MAX_FUSED_EW_SECONDARIES]DeviceBuffer = undefined;
+        buffers[0] = left_w.data;
+        buffers[1] = left_w.scales;
+        buffers[2] = right_w.data;
+        buffers[3] = right_w.scales;
+        buffers[4] = self.device_bufs[gate.input];
+        buffers[5] = self.device_bufs[product.dst];
+        for (buffers[6..]) |*buf| buf.* = self.device_bufs[product.dst];
+
+        var secondary_bufs: [MAX_FUSED_EW_SECONDARIES]u16 = undefined;
+        var secondary_count: usize = 0;
+
+        var step_index: usize = 0;
+        for (first.steps) |step| {
+            params.op[step_index] = @intFromEnum(step.op);
+            params.is_swapped[step_index] = @intFromBool(step.is_swapped);
+            if (!self.bindQMatmulPairFusedSecondary(&buffers, &secondary_bufs, &secondary_count, &params, gate, up, step, step_index, null)) return false;
+            step_index += 1;
+        }
+        const repeat_view = repeatSecondaryView(rp);
+        for (second.steps) |step| {
+            params.op[step_index] = @intFromEnum(step.op);
+            params.is_swapped[step_index] = @intFromBool(step.is_swapped);
+            if (!self.bindQMatmulPairFusedSecondary(&buffers, &secondary_bufs, &secondary_count, &params, gate, up, step, step_index, repeat_view)) return false;
+            step_index += 1;
+        }
+
+        self.encodeKernel(
+            .qmatmul_pair_fused_elementwise_f32,
+            &buffers,
+            params,
+            14,
+            matmulGrid(gate.M, gate.N),
             MATMUL_THREADS,
         );
         return true;
@@ -3925,7 +5220,7 @@ const CompiledProgram = struct {
             params.src_col_stride[i] = sa.src_col_stride;
             params.max_n = @max(params.max_n, sa.rows * sa.cols);
         }
-        self.encodeTyped(SliceAssignBatchParams, self.backend.slice_assign_batch_pipeline, &buffers, params, 2, .{ .gx = linearGrid(params.max_n), .gy = @intCast(indices.len) }, WG_SIZE);
+        self.encodeKernel(.slice_assign_batch_f32, &buffers, params, 2, .{ .gx = linearGrid(params.max_n), .gy = @intCast(indices.len) }, WG_SIZE);
     }
 
     fn canFuseRmsnormRepeatMul(rn: anytype, rp: anytype, e: anytype) bool {
@@ -3955,7 +5250,7 @@ const CompiledProgram = struct {
             .scale_repeat_dst_offset = rp.dst_offset,
             .scaled_dst_offset = e.dst_offset,
         };
-        self.encodeTyped(RmsNormScaleParams, self.backend.rmsnorm_scale_pipeline, &buffers, params, 5, .{ .gx = linearGrid(rn.rows) }, WG_SIZE);
+        self.encodeKernel(.rmsnorm_scale_f32, &buffers, params, 5, .{ .gx = linearGrid(rn.rows) }, WG_SIZE);
         return true;
     }
 
@@ -3967,7 +5262,7 @@ const CompiledProgram = struct {
             self.device_bufs[att.mask],
             self.device_bufs[att.dst],
         };
-        self.encodeTyped(AttentionParams, self.backend.attention_pipeline, &buffers, attentionParams(att), 5, .{ .gx = att.seq_q }, WG_SIZE);
+        self.encodeKernel(.attention_f32, &buffers, attentionParams(att), 5, .{ .gx = att.seq_q }, WG_SIZE);
     }
 
     fn encodeAttentionSliceAssign(self: *CompiledProgram, sa: anytype, att: anytype) bool {
@@ -4004,7 +5299,7 @@ const CompiledProgram = struct {
                 params.v_cs = sa.src_col_stride;
             },
         }
-        self.encodeTyped(AttentionSliceAssignParams, self.backend.attention_slice_assign_pipeline, &buffers, params, 7, .{ .gx = att.seq_q }, WG_SIZE);
+        self.encodeKernel(.attention_slice_assign_f32, &buffers, params, 7, .{ .gx = att.seq_q }, WG_SIZE);
         return true;
     }
 
@@ -4019,7 +5314,7 @@ const CompiledProgram = struct {
             self.device_bufs[att.dst],
             self.device_bufs[sa.dst],
         };
-        self.encodeTyped(AttentionStoreParams, self.backend.attention_store_pipeline, &buffers, attentionStoreParams(att, sa), 6, .{ .gx = att.seq_q }, WG_SIZE);
+        self.encodeKernel(.attention_store_f32, &buffers, attentionStoreParams(att, sa), 6, .{ .gx = att.seq_q }, WG_SIZE);
         return true;
     }
 
@@ -4037,8 +5332,78 @@ const CompiledProgram = struct {
             self.device_bufs[att.dst],
             self.device_bufs[sa.dst],
         };
-        self.encodeTyped(AttentionRopeStoreParams, self.backend.attention_rope_store_pipeline, &buffers, attentionRopeStoreParams(rr, att, sa), 7, .{ .gx = att.seq_q }, WG_SIZE);
+        self.encodeKernel(.attention_rope_store_f32, &buffers, attentionRopeStoreParams(rr, att, sa), 7, .{ .gx = att.seq_q }, WG_SIZE);
         return true;
+    }
+
+    fn canEncodeAttentionRopeStoreSharedBatchCommand(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, command: program_mod.ProgramCommand) bool {
+        _ = self;
+        if (command.sidecar_count < 2 or command.sidecar_count > MAX_ATTENTION_ROPE_STORE_SHARED_BATCH_HEADS) return false;
+        if (!program_mod.ropeAttentionStoreCompactBatchCompatible(ops, &command)) return false;
+        var i: usize = 0;
+        while (i < command.sidecar_count) : (i += 1) {
+            const att_idx = command.indices[i * 2 + 1];
+            const sa_idx = command.sidecar_indices[i] orelse return false;
+            const att = switch (ops[att_idx]) {
+                .attention => |att| att,
+                else => return false,
+            };
+            const sa = switch (ops[sa_idx]) {
+                .slice_assign => |sa| sa,
+                else => return false,
+            };
+            if (!canEncodeAttention(att)) return false;
+            if (!program_mod.canFuseAttentionStoreSidecar(ops, att_idx, sa_idx, sa)) return false;
+        }
+        return true;
+    }
+
+    fn encodeAttentionRopeStoreSharedBatchCommand(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, command: program_mod.ProgramCommand) void {
+        const first_rope = ops[command.indices[0]].rope;
+        const first_att = ops[command.indices[1]].attention;
+        const first_sa = ops[command.sidecar_indices[0].?].slice_assign;
+        const buffers = [_]DeviceBuffer{
+            self.device_bufs[first_rope.src],
+            self.device_bufs[first_rope.cos_sin],
+            self.device_bufs[first_att.k],
+            self.device_bufs[first_att.v],
+            self.device_bufs[first_att.mask],
+            self.device_bufs[first_sa.dst],
+        };
+
+        var params = std.mem.zeroes(AttentionRopeStoreSharedBatchParams);
+        params.n_heads = @intCast(command.sidecar_count);
+        params.d_head = first_att.d_head;
+        params.seq_q = first_att.seq_q;
+        params.seq_kv = first_att.seq_kv;
+        params.scale = first_att.scale;
+        params.rope_half_d = first_rope.half_d;
+        params.rope_src_rs = first_rope.src_rs;
+        params.rope_src_cs = first_rope.src_cs;
+        params.rope_cs_cs = first_rope.cs_cs;
+        params.k_rs = first_att.k_rs;
+        params.k_cs = first_att.k_cs;
+        params.v_rs = first_att.v_rs;
+        params.v_cs = first_att.v_cs;
+        params.mask_rs = first_att.mask_rs;
+        params.mask_cs = first_att.mask_cs;
+        params.slice_dst_row_stride = first_sa.dst_row_stride;
+        params.slice_dst_col_stride = first_sa.dst_col_stride;
+
+        var i: usize = 0;
+        while (i < command.sidecar_count) : (i += 1) {
+            const rr = ops[command.indices[i * 2]].rope;
+            const att = ops[command.indices[i * 2 + 1]].attention;
+            const sa = ops[command.sidecar_indices[i].?].slice_assign;
+            params.rope_src_off[i] = rr.src_off;
+            params.rope_cs_off[i] = rr.cs_off;
+            params.k_off[i] = att.k_off;
+            params.v_off[i] = att.v_off;
+            params.mask_off[i] = att.mask_off;
+            params.slice_dst_offset[i] = sa.dst_offset;
+        }
+
+        self.encodeKernel(.attention_rope_store_shared_batch_f32, &buffers, params, @intCast(buffers.len), .{ .gx = first_att.seq_q, .gy = @intCast(command.sidecar_count) }, WG_SIZE);
     }
 
     fn canEncodeAttentionRopeStoreBatchCommand(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, command: program_mod.ProgramCommand) bool {
@@ -4160,7 +5525,7 @@ const CompiledProgram = struct {
             params.slice_dst_offset[i] = sa.dst_offset;
         }
 
-        self.encodeTyped(AttentionRopeStoreBatchParams, self.backend.attention_rope_store_batch_pipeline, &buffers, params, @intCast(buffers.len), .{ .gx = first_att.seq_q, .gy = @intCast(command.sidecar_count) }, WG_SIZE);
+        self.encodeKernel(.attention_rope_store_batch_f32, &buffers, params, @intCast(buffers.len), .{ .gx = first_att.seq_q, .gy = @intCast(command.sidecar_count) }, WG_SIZE);
     }
 
     fn canEncodeAttentionStoreBatchCommand(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, command: program_mod.ProgramCommand) bool {
@@ -4255,7 +5620,7 @@ const CompiledProgram = struct {
             params.dst_off[i] = att.dst_off;
             params.slice_dst_offset[i] = sa.dst_offset;
         }
-        self.encodeTyped(AttentionStoreBatchParams, self.backend.attention_store_batch_pipeline, &buffers, params, @intCast(buffers.len), .{ .gx = first.seq_q, .gy = @intCast(command.anchor_count) }, WG_SIZE);
+        self.encodeKernel(.attention_store_batch_f32, &buffers, params, @intCast(buffers.len), .{ .gx = first.seq_q, .gy = @intCast(command.anchor_count) }, WG_SIZE);
     }
 
     fn attentionBatchCompatible(first: anytype, next: anytype) bool {
@@ -4340,7 +5705,7 @@ const CompiledProgram = struct {
             params.mask_off[i] = att.mask_off;
             params.dst_off[i] = att.dst_off;
         }
-        self.encodeTyped(AttentionBatchParams, self.backend.attention_batch_pipeline, &buffers, params, 5, .{ .gx = first.seq_q, .gy = @intCast(indices.len) }, WG_SIZE);
+        self.encodeKernel(.attention_batch_f32, &buffers, params, 5, .{ .gx = first.seq_q, .gy = @intCast(indices.len) }, WG_SIZE);
     }
 
     fn canEncodeRegionGpuOp(self: *CompiledProgram, op: backend_mod.DeviceOp) bool {
@@ -4383,16 +5748,43 @@ const CompiledProgram = struct {
         }
     }
 
+    fn recordRegionFusedRunFromCommand(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, command: program_mod.ProgramCommand, elapsed_ns: u64) void {
+        var indices = command.coveredIndexIterator();
+        const count = indices.remainingCount();
+        if (count == 0) return;
+        const per_op = elapsed_ns / count;
+        var used: u64 = 0;
+        var i: usize = 0;
+        while (indices.next()) |idx| : (i += 1) {
+            if (idx >= ops.len) continue;
+            const t = if (i + 1 == count) elapsed_ns - used else per_op;
+            self.recordRegionBackendOp(ops[idx], t);
+            used += t;
+        }
+    }
+
     fn tryEncodeProjectionCommand(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, command: program_mod.ProgramCommand) bool {
         switch (command.projection_kind) {
             .qmatvec => {
                 for (command.anchorIndices()) |idx| {
                     if (!self.canEncodeQMatvecBatchOp(ops[idx].qmatmul)) return false;
                 }
+                for (command.sidecarIndices(), 0..) |maybe_idx, slot| {
+                    const idx = maybe_idx orelse continue;
+                    const q = ops[command.indices[slot]].qmatmul;
+                    switch (ops[idx]) {
+                        .slice_assign => |sa| if (!program_mod.qmatvecSliceSidecarCompatible(q, sa)) return false,
+                        .elementwise => |e| if (!self.canEncodeQMatvecElementwiseSidecar(q, e)) return false,
+                        else => return false,
+                    }
+                }
 
                 const t0 = nowNs();
-                self.encodeQMatvecBatch(ops, command.anchorIndices());
+                self.encodeQMatvecBatch(ops, command.anchorIndices(), command.sidecarIndices());
                 self.recordRegionFusedRunFromIndices(ops, command.anchorIndices(), @intCast(nowNs() - t0));
+                for (command.sidecarIndices()) |maybe_idx| {
+                    if (maybe_idx) |idx| self.recordRegionBackendOp(ops[idx], 0);
+                }
                 return true;
             },
             .qmatmul => {
@@ -4418,6 +5810,168 @@ const CompiledProgram = struct {
                 return true;
             },
         }
+    }
+
+    fn tryEncodeProjectionCacheCommand(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, command: program_mod.ProgramCommand) bool {
+        if (command.projection_kind == .qmatvec) return self.tryEncodeQMatvecProjectionCacheCommand(ops, command);
+        if (command.projection_kind != .qmatmul) return false;
+        if (command.anchor_count == 0 or command.anchor_count > MAX_QMATMUL_BATCH) return false;
+        for (command.anchorIndices()) |idx| {
+            if (idx >= ops.len) return false;
+            if (!self.canEncodeQMatmulBatchOp(ops[idx].qmatmul)) return false;
+        }
+
+        var direct_sidecars = QMatmulBatchSidecarPlan{};
+        var direct_sidecar_dst = [_]?u16{null} ** MAX_QMATMUL_BATCH;
+        var rope_pairs: [MAX_QMATMUL_ROPE_STORE_BATCH]QMatmulRopeStorePair = undefined;
+        var rope_pair_count: usize = 0;
+        var anchor_has_rope = [_]bool{false} ** MAX_QMATMUL_BATCH;
+
+        var flat_i: usize = 0;
+        while (flat_i < command.sidecar_count) : (flat_i += 1) {
+            const idx = command.sidecar_indices[flat_i] orelse continue;
+            if (idx >= ops.len) return false;
+            switch (ops[idx]) {
+                .slice_assign => |sa| {
+                    const slot = for (command.anchorIndices(), 0..) |anchor_idx, slot| {
+                        const q = ops[anchor_idx].qmatmul;
+                        if (program_mod.qmatmulSliceSidecarCompatible(q, sa)) break slot;
+                    } else return false;
+                    if (direct_sidecar_dst[slot]) |dst| {
+                        if (dst != sa.dst) return false;
+                    } else {
+                        direct_sidecar_dst[slot] = sa.dst;
+                    }
+                    if (!direct_sidecars.appendSlice(slot, idx)) return false;
+                },
+                .rope => |rr| {
+                    if (flat_i + 1 >= command.sidecar_count) return false;
+                    const store_idx = command.sidecar_indices[flat_i + 1] orelse return false;
+                    if (store_idx >= ops.len) return false;
+                    const sa = switch (ops[store_idx]) {
+                        .slice_assign => |sa| sa,
+                        else => return false,
+                    };
+                    const slot = for (command.anchorIndices(), 0..) |anchor_idx, slot| {
+                        const q = ops[anchor_idx].qmatmul;
+                        if (self.canEncodeQMatmulRopeStorePair(q, rr, sa)) break slot;
+                    } else return false;
+                    if (anchor_has_rope[slot]) return false;
+                    if (rope_pair_count >= MAX_QMATMUL_ROPE_STORE_BATCH) return false;
+                    rope_pairs[rope_pair_count] = .{
+                        .anchor_slot = slot,
+                        .q_index = command.indices[slot],
+                        .rope_index = idx,
+                        .store_index = store_idx,
+                    };
+                    rope_pair_count += 1;
+                    anchor_has_rope[slot] = true;
+                    flat_i += 1;
+                },
+                else => return false,
+            }
+        }
+
+        const t0 = nowNs();
+        if (rope_pair_count == 0) {
+            self.encodeQMatmulBatchWithSidecars(ops, command.anchorIndices(), &direct_sidecars);
+        } else {
+            var normal_indices: [MAX_QMATMUL_BATCH]usize = undefined;
+            var normal_slot_for_anchor = [_]?usize{null} ** MAX_QMATMUL_BATCH;
+            var normal_count: usize = 0;
+            for (command.anchorIndices(), 0..) |anchor_idx, anchor_slot| {
+                const has_direct_sidecars = direct_sidecars.counts[anchor_slot] != 0;
+                const primary_needed = program_mod.projectionPrimaryOutputHasExternalUsersExcept(ops, anchor_idx, command.carriedSidecarIndices());
+                if (!anchor_has_rope[anchor_slot] or has_direct_sidecars or primary_needed) {
+                    normal_slot_for_anchor[anchor_slot] = normal_count;
+                    normal_indices[normal_count] = anchor_idx;
+                    normal_count += 1;
+                }
+            }
+
+            var normal_sidecars = QMatmulBatchSidecarPlan{};
+            for (0..command.anchor_count) |anchor_slot| {
+                const normal_slot = normal_slot_for_anchor[anchor_slot] orelse {
+                    if (direct_sidecars.counts[anchor_slot] != 0) return false;
+                    continue;
+                };
+                for (direct_sidecars.slotIndices(anchor_slot)) |maybe_idx| {
+                    if (maybe_idx) |sidecar_idx| {
+                        if (!normal_sidecars.appendSlice(normal_slot, sidecar_idx)) return false;
+                    }
+                }
+            }
+
+            if (normal_count > 0) {
+                self.encodeQMatmulBatchWithSidecars(ops, normal_indices[0..normal_count], &normal_sidecars);
+            }
+            self.encodeQMatmulRopeStoreBatch(ops, rope_pairs[0..rope_pair_count]);
+        }
+        self.recordRegionFusedRunFromIndices(ops, command.anchorIndices(), @intCast(nowNs() - t0));
+        for (command.carriedSidecarIndices()) |maybe_idx| {
+            if (maybe_idx) |idx| self.recordRegionBackendOp(ops[idx], 0);
+        }
+        return true;
+    }
+
+    fn tryEncodeQMatvecProjectionCacheCommand(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, command: program_mod.ProgramCommand) bool {
+        if (command.anchor_count == 0 or command.anchor_count > MAX_QMATVEC_BATCH) return false;
+        for (command.anchorIndices()) |idx| {
+            if (idx >= ops.len) return false;
+            if (!self.canEncodeQMatvecBatchOp(ops[idx].qmatmul)) return false;
+        }
+
+        var sidecars = QMatvecBatchSidecarPlan{};
+        var flat_i: usize = 0;
+        while (flat_i < command.sidecar_count) : (flat_i += 1) {
+            const idx = command.sidecar_indices[flat_i] orelse continue;
+            if (idx >= ops.len) return false;
+            switch (ops[idx]) {
+                .slice_assign => |sa| {
+                    const slot = for (command.anchorIndices(), 0..) |anchor_idx, slot| {
+                        const q = ops[anchor_idx].qmatmul;
+                        if (program_mod.qmatvecSliceSidecarCompatible(q, sa)) break slot;
+                    } else return false;
+                    if (!sidecars.appendSlice(slot, idx)) return false;
+                },
+                .elementwise => |e| {
+                    const slot = for (command.anchorIndices(), 0..) |anchor_idx, slot| {
+                        const q = ops[anchor_idx].qmatmul;
+                        if (self.canEncodeQMatvecElementwiseSidecar(q, e)) break slot;
+                    } else return false;
+                    if (!sidecars.appendElementwise(slot, idx)) return false;
+                },
+                .rope => |rr| {
+                    var maybe_store_idx: ?usize = null;
+                    const slot = for (command.anchorIndices(), 0..) |anchor_idx, slot| {
+                        const q = ops[anchor_idx].qmatmul;
+                        if (program_mod.qmatvecRopeSidecarCompatible(q, rr)) break slot;
+                    } else return false;
+                    if (flat_i + 1 < command.sidecar_count) {
+                        const store_idx = command.sidecar_indices[flat_i + 1] orelse return false;
+                        if (store_idx >= ops.len) return false;
+                        if (ops[store_idx] == .slice_assign) {
+                            const store = ops[store_idx].slice_assign;
+                            const q = ops[command.indices[slot]].qmatmul;
+                            if (program_mod.qmatvecRopeStoreSidecarCompatible(q, rr, store)) {
+                                maybe_store_idx = store_idx;
+                                flat_i += 1;
+                            }
+                        }
+                    }
+                    if (!sidecars.appendRope(slot, idx, maybe_store_idx)) return false;
+                },
+                else => return false,
+            }
+        }
+
+        const t0 = nowNs();
+        self.encodeQMatvecBatchWithSidecars(ops, command.anchorIndices(), &sidecars);
+        self.recordRegionFusedRunFromIndices(ops, command.anchorIndices(), @intCast(nowNs() - t0));
+        for (command.carriedSidecarIndices()) |maybe_idx| {
+            if (maybe_idx) |idx| self.recordRegionBackendOp(ops[idx], 0);
+        }
+        return true;
     }
 
     fn tryEncodeProjectionChainCommand(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, command: program_mod.ProgramCommand) bool {
@@ -4450,7 +6004,7 @@ const CompiledProgram = struct {
                     self.device_bufs[m.b],
                     self.device_bufs[m.dst],
                 };
-                self.encodeTyped(MatMulParams, self.backend.matmul_pipeline, &buffers, matmulParams(m.geom), 3, matmulGrid(m.geom.M, m.geom.N), MATMUL_THREADS);
+                self.encodeKernel(.matmul_f32, &buffers, matmulParams(m.geom), 3, matmulGrid(m.geom.M, m.geom.N), MATMUL_THREADS);
                 break :blk true;
             },
             .qmatmul => |q| blk: {
@@ -4463,7 +6017,7 @@ const CompiledProgram = struct {
                     self.device_bufs[q.input],
                     self.device_bufs[q.dst],
                 };
-                self.encodeTyped(QMatMulParams, self.backend.qmatmul_pipeline, &buffers, qmatmulParams(q, w.block_size), 4, matmulGrid(q.M, q.N), MATMUL_THREADS);
+                self.encodeKernel(.qmatmul_f32, &buffers, qmatmulParams(q, w.block_size), 4, matmulGrid(q.M, q.N), MATMUL_THREADS);
                 break :blk true;
             },
             .rope => |rr| blk: {
@@ -4484,6 +6038,202 @@ const CompiledProgram = struct {
         return encoded;
     }
 
+    fn tryEncodeAttentionChainCommand(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, command: program_mod.ProgramCommand) bool {
+        if (command.anchor_count != 1 or command.sidecar_count != 1) return false;
+        const att_idx = command.indices[0];
+        const sa_idx = command.sidecar_indices[0] orelse return false;
+        const sa = deviceOpAt(.slice_assign, ops, sa_idx) orelse return false;
+        const att = deviceOpAt(.attention, ops, att_idx) orelse return false;
+        return self.encodeAttentionSliceAssign(sa, att);
+    }
+
+    fn tryEncodeAttentionStoreChainCommand(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, command: program_mod.ProgramCommand) bool {
+        if (command.anchor_count != 1 or command.sidecar_count != 1) return false;
+        const att_idx = command.indices[0];
+        const sa_idx = command.sidecar_indices[0] orelse return false;
+        const att = deviceOpAt(.attention, ops, att_idx) orelse return false;
+        const sa = deviceOpAt(.slice_assign, ops, sa_idx) orelse return false;
+        return self.encodeAttentionSliceStore(att, sa);
+    }
+
+    fn tryEncodeAttentionStoreGroupCommand(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, command: program_mod.ProgramCommand) bool {
+        if (!self.canEncodeAttentionStoreBatchCommand(ops, command)) return false;
+        self.encodeAttentionStoreBatchCommand(ops, command);
+        return true;
+    }
+
+    fn tryEncodeRopeAttentionStoreChainCommand(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, command: program_mod.ProgramCommand) bool {
+        if (command.anchor_count != 2 or command.sidecar_count != 1) return false;
+        const rope_idx = command.indices[0];
+        const att_idx = command.indices[1];
+        const sa_idx = command.sidecar_indices[0] orelse return false;
+        const rr = deviceOpAt(.rope, ops, rope_idx) orelse return false;
+        const att = deviceOpAt(.attention, ops, att_idx) orelse return false;
+        const sa = deviceOpAt(.slice_assign, ops, sa_idx) orelse return false;
+        return self.encodeAttentionRopeStore(rr, att, sa);
+    }
+
+    fn tryEncodeRopeAttentionStoreGroupCommand(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, command: program_mod.ProgramCommand) bool {
+        if (self.canEncodeAttentionRopeStoreSharedBatchCommand(ops, command)) {
+            self.encodeAttentionRopeStoreSharedBatchCommand(ops, command);
+            return true;
+        }
+        if (!self.canEncodeAttentionRopeStoreBatchCommand(ops, command)) return false;
+        self.encodeAttentionRopeStoreBatchCommand(ops, command);
+        return true;
+    }
+
+    fn tryEncodeAttentionBatchCommand(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, command: program_mod.ProgramCommand) bool {
+        const start: usize = @intCast(command.op_start);
+        const n: usize = @intCast(command.op_count);
+        if (self.attentionBatchRunLen(ops[start..]) < n) return false;
+        self.encodeAttentionBatch(ops[start..], n);
+        return true;
+    }
+
+    fn tryEncodeAttentionGroupCommand(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, command: program_mod.ProgramCommand) bool {
+        if (!self.canEncodeAttentionBatchIndices(ops, command.anchorIndices())) return false;
+        self.encodeAttentionBatchIndices(ops, command.anchorIndices());
+        return true;
+    }
+
+    fn tryEncodeRopeBatchCommand(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, command: program_mod.ProgramCommand) bool {
+        const start: usize = @intCast(command.op_start);
+        const n: usize = @intCast(command.op_count);
+        if (ropeBatchRunLen(ops[start..]) < n) return false;
+        self.encodeRopeBatch(ops[start..], n);
+        return true;
+    }
+
+    fn tryEncodeRopeStoreGroupCommand(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, command: program_mod.ProgramCommand) bool {
+        if (!self.canEncodeRopeStoreGroupCommand(ops, command)) return false;
+        self.encodeRopeStoreGroupCommand(ops, command);
+        return true;
+    }
+
+    fn tryEncodeMovementBatchCommand(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, command: program_mod.ProgramCommand) bool {
+        const start: usize = @intCast(command.op_start);
+        const n: usize = @intCast(command.op_count);
+        if (sliceAssignBatchRunLen(ops[start..]) < n) return false;
+        self.encodeSliceAssignBatch(ops[start..], n);
+        return true;
+    }
+
+    fn tryEncodeMovementGroupCommand(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, command: program_mod.ProgramCommand) bool {
+        if (!self.canEncodeSliceAssignBatchIndices(ops, command.anchorIndices())) return false;
+        self.encodeSliceAssignBatchIndices(ops, command.anchorIndices());
+        return true;
+    }
+
+    fn tryEncodeElementwiseBatchCommand(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, command: program_mod.ProgramCommand) bool {
+        for (command.anchorIndices()) |idx| {
+            const e = deviceOpAt(.elementwise, ops, idx) orelse return false;
+            if (!canEncodeElementwiseBatchOp(e)) return false;
+        }
+        self.encodeElementwiseBatch(ops, command.anchorIndices());
+        return true;
+    }
+
+    fn tryEncodeRepeatFusedElementwiseChainCommand(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, command: program_mod.ProgramCommand) bool {
+        const start: usize = @intCast(command.op_start);
+        const rp = deviceOpAt(.repeat, ops, start) orelse return false;
+        const fe = deviceOpAt(.fused_elementwise, ops, start + 1) orelse return false;
+        return self.encodeRepeatFusedElementwise(rp, fe);
+    }
+
+    fn tryEncodeProjectionFusedElementwiseChainCommand(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, command: program_mod.ProgramCommand) bool {
+        const start: usize = @intCast(command.op_start);
+        const q = deviceOpAt(.qmatmul, ops, start) orelse return false;
+        const first = deviceOpAt(.fused_elementwise, ops, start + 1) orelse return false;
+        const rp = deviceOpAt(.repeat, ops, start + 2) orelse return false;
+        const second = deviceOpAt(.fused_elementwise, ops, start + 3) orelse return false;
+        return self.encodeQMatmulFusedElementwiseChain(q, first, rp, second);
+    }
+
+    fn tryEncodeProjectionPairFusedElementwiseChainCommand(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, command: program_mod.ProgramCommand) bool {
+        const start: usize = @intCast(command.op_start);
+        const gate = deviceOpAt(.qmatmul, ops, start) orelse return false;
+        const first = deviceOpAt(.fused_elementwise, ops, start + 1) orelse return false;
+        const rp = deviceOpAt(.repeat, ops, start + 2) orelse return false;
+        const second = deviceOpAt(.fused_elementwise, ops, start + 3) orelse return false;
+        const up = deviceOpAt(.qmatmul, ops, start + 4) orelse return false;
+        const product = deviceOpAt(.elementwise, ops, start + 5) orelse return false;
+        return self.encodeQMatmulPairFusedElementwiseChain(gate, first, rp, second, up, product);
+    }
+
+    fn tryEncodeRowChainCommand(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, command: program_mod.ProgramCommand) bool {
+        const start: usize = @intCast(command.op_start);
+        const rn = deviceOpAt(.rmsnorm, ops, start) orelse return false;
+        const rp = deviceOpAt(.repeat, ops, start + 1) orelse return false;
+        const e = deviceOpAt(.elementwise, ops, start + 2) orelse return false;
+        return self.encodeRmsnormRepeatMul(rn, rp, e);
+    }
+
+    fn tryEncodeRopeChainCommand(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, command: program_mod.ProgramCommand) bool {
+        const start: usize = @intCast(command.op_start);
+        const rr = deviceOpAt(.rope, ops, start) orelse return false;
+        const sa = deviceOpAt(.slice_assign, ops, start + 1) orelse return false;
+        if (!canFuseRopeSliceAssign(rr, sa)) return false;
+        self.encodeRopeSliceAssign(rr, sa);
+        return true;
+    }
+
+    const ProgramCommandLoweringFn = *const fn (*CompiledProgram, []const backend_mod.DeviceOp, program_mod.ProgramCommand) bool;
+    const ProgramCommandLowering = struct {
+        kind: program_mod.ProgramCommandKind,
+        encode: ProgramCommandLoweringFn,
+        records_run: bool = false,
+    };
+
+    const exact_program_command_lowerings = [_]ProgramCommandLowering{
+        .{ .kind = .projection_group, .encode = tryEncodeProjectionCommand, .records_run = true },
+        .{ .kind = .projection_cache_group, .encode = tryEncodeProjectionCacheCommand, .records_run = true },
+        .{ .kind = .projection_chain, .encode = tryEncodeProjectionChainCommand },
+        .{ .kind = .attention_chain, .encode = tryEncodeAttentionChainCommand },
+        .{ .kind = .attention_store_chain, .encode = tryEncodeAttentionStoreChainCommand },
+        .{ .kind = .attention_store_group, .encode = tryEncodeAttentionStoreGroupCommand },
+        .{ .kind = .rope_attention_store_chain, .encode = tryEncodeRopeAttentionStoreChainCommand },
+        .{ .kind = .rope_attention_store_group, .encode = tryEncodeRopeAttentionStoreGroupCommand },
+        .{ .kind = .attention_batch, .encode = tryEncodeAttentionBatchCommand },
+        .{ .kind = .attention_group, .encode = tryEncodeAttentionGroupCommand },
+        .{ .kind = .rope_batch, .encode = tryEncodeRopeBatchCommand },
+        .{ .kind = .rope_store_group, .encode = tryEncodeRopeStoreGroupCommand },
+        .{ .kind = .movement_batch, .encode = tryEncodeMovementBatchCommand },
+        .{ .kind = .movement_group, .encode = tryEncodeMovementGroupCommand },
+        .{ .kind = .elementwise_batch, .encode = tryEncodeElementwiseBatchCommand },
+        .{ .kind = .repeat_fused_elementwise_chain, .encode = tryEncodeRepeatFusedElementwiseChainCommand },
+        .{ .kind = .projection_fused_elementwise_chain, .encode = tryEncodeProjectionFusedElementwiseChainCommand },
+        .{ .kind = .projection_pair_fused_elementwise_chain, .encode = tryEncodeProjectionPairFusedElementwiseChainCommand },
+        .{ .kind = .row_chain, .encode = tryEncodeRowChainCommand },
+        .{ .kind = .rope_chain, .encode = tryEncodeRopeChainCommand },
+    };
+
+    comptime {
+        const command_count = @typeInfo(program_mod.ProgramCommandKind).@"enum".fields.len;
+        var seen = [_]bool{false} ** command_count;
+        seen[@intFromEnum(program_mod.ProgramCommandKind.op)] = true;
+        for (exact_program_command_lowerings) |lowering| {
+            const idx = @intFromEnum(lowering.kind);
+            if (seen[idx]) @compileError("duplicate exact Metal command lowering: " ++ @tagName(lowering.kind));
+            seen[idx] = true;
+        }
+        for (@typeInfo(program_mod.ProgramCommandKind).@"enum".fields) |field| {
+            if (!seen[field.value]) @compileError("missing exact Metal command lowering: " ++ field.name);
+        }
+    }
+
+    fn exactProgramCommandLowering(kind: program_mod.ProgramCommandKind) ?ProgramCommandLowering {
+        inline for (exact_program_command_lowerings) |lowering| {
+            if (lowering.kind == kind) return lowering;
+        }
+        return null;
+    }
+
+    fn recordExactProgramCommandRun(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, command: program_mod.ProgramCommand, lowering: ProgramCommandLowering, elapsed_ns: u64) void {
+        if (lowering.records_run) return;
+        self.recordRegionFusedRunFromCommand(ops, command, elapsed_ns);
+    }
+
     fn tryEncodeExactProgramCommand(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, command: program_mod.ProgramCommand) bool {
         const start: usize = @intCast(command.op_start);
         const end = start + @as(usize, command.op_count);
@@ -4491,234 +6241,75 @@ const CompiledProgram = struct {
 
         self.runtime_profile.recordProgramCommandAttempt(command.kind);
         const t0 = nowNs();
-        const encoded = switch (command.kind) {
-            .op => false,
-            .projection_group => self.tryEncodeProjectionCommand(ops, command),
-            .projection_chain => self.tryEncodeProjectionChainCommand(ops, command),
-            .attention_chain => blk: {
-                if (command.anchor_count != 1 or command.sidecar_count != 1) break :blk false;
-                const att_idx = command.indices[0];
-                const sa_idx = command.sidecar_indices[0] orelse break :blk false;
-                if (att_idx >= ops.len or sa_idx >= ops.len) break :blk false;
-                const sa = switch (ops[sa_idx]) {
-                    .slice_assign => |sa| sa,
-                    else => break :blk false,
-                };
-                const att = switch (ops[att_idx]) {
-                    .attention => |att| att,
-                    else => break :blk false,
-                };
-                break :blk self.encodeAttentionSliceAssign(sa, att);
-            },
-            .attention_store_chain => blk: {
-                if (command.anchor_count != 1 or command.sidecar_count != 1) break :blk false;
-                const att_idx = command.indices[0];
-                const sa_idx = command.sidecar_indices[0] orelse break :blk false;
-                if (att_idx >= ops.len or sa_idx >= ops.len) break :blk false;
-                const att = switch (ops[att_idx]) {
-                    .attention => |att| att,
-                    else => break :blk false,
-                };
-                const sa = switch (ops[sa_idx]) {
-                    .slice_assign => |sa| sa,
-                    else => break :blk false,
-                };
-                break :blk self.encodeAttentionSliceStore(att, sa);
-            },
-            .attention_store_group => blk: {
-                if (!self.canEncodeAttentionStoreBatchCommand(ops, command)) break :blk false;
-                self.encodeAttentionStoreBatchCommand(ops, command);
-                break :blk true;
-            },
-            .rope_attention_store_chain => blk: {
-                if (command.anchor_count != 2 or command.sidecar_count != 1) break :blk false;
-                const rope_idx = command.indices[0];
-                const att_idx = command.indices[1];
-                const sa_idx = command.sidecar_indices[0] orelse break :blk false;
-                if (rope_idx >= ops.len or att_idx >= ops.len or sa_idx >= ops.len) break :blk false;
-                const rr = switch (ops[rope_idx]) {
-                    .rope => |rr| rr,
-                    else => break :blk false,
-                };
-                const att = switch (ops[att_idx]) {
-                    .attention => |att| att,
-                    else => break :blk false,
-                };
-                const sa = switch (ops[sa_idx]) {
-                    .slice_assign => |sa| sa,
-                    else => break :blk false,
-                };
-                break :blk self.encodeAttentionRopeStore(rr, att, sa);
-            },
-            .rope_attention_store_group => blk: {
-                if (!self.canEncodeAttentionRopeStoreBatchCommand(ops, command)) break :blk false;
-                self.encodeAttentionRopeStoreBatchCommand(ops, command);
-                break :blk true;
-            },
-            .attention_batch => blk: {
-                const n: usize = @intCast(command.op_count);
-                if (self.attentionBatchRunLen(ops[start..]) < n) break :blk false;
-                self.encodeAttentionBatch(ops[start..], n);
-                break :blk true;
-            },
-            .attention_group => blk: {
-                if (!self.canEncodeAttentionBatchIndices(ops, command.anchorIndices())) break :blk false;
-                const t_batch = nowNs();
-                self.encodeAttentionBatchIndices(ops, command.anchorIndices());
-                self.recordRegionFusedRunFromIndices(ops, command.anchorIndices(), @intCast(nowNs() - t_batch));
-                break :blk true;
-            },
-            .rope_batch => blk: {
-                const n: usize = @intCast(command.op_count);
-                if (ropeBatchRunLen(ops[start..]) < n) break :blk false;
-                self.encodeRopeBatch(ops[start..], n);
-                break :blk true;
-            },
-            .rope_store_group => blk: {
-                if (!self.canEncodeRopeStoreGroupCommand(ops, command)) break :blk false;
-                self.encodeRopeStoreGroupCommand(ops, command);
-                break :blk true;
-            },
-            .movement_batch => blk: {
-                const n: usize = @intCast(command.op_count);
-                if (sliceAssignBatchRunLen(ops[start..]) < n) break :blk false;
-                self.encodeSliceAssignBatch(ops[start..], n);
-                break :blk true;
-            },
-            .movement_group => blk: {
-                if (!self.canEncodeSliceAssignBatchIndices(ops, command.anchorIndices())) break :blk false;
-                const t_batch = nowNs();
-                self.encodeSliceAssignBatchIndices(ops, command.anchorIndices());
-                self.recordRegionFusedRunFromIndices(ops, command.anchorIndices(), @intCast(nowNs() - t_batch));
-                break :blk true;
-            },
-            .elementwise_batch => blk: {
-                for (command.anchorIndices()) |idx| {
-                    if (idx >= ops.len) break :blk false;
-                    const e = switch (ops[idx]) {
-                        .elementwise => |e| e,
-                        else => break :blk false,
-                    };
-                    if (!canEncodeElementwiseBatchOp(e)) break :blk false;
-                }
-                const t_batch = nowNs();
-                self.encodeElementwiseBatch(ops, command.anchorIndices());
-                self.recordRegionFusedRunFromIndices(ops, command.anchorIndices(), @intCast(nowNs() - t_batch));
-                break :blk true;
-            },
-            .row_chain => switch (ops[start]) {
-                .rmsnorm => |rn| switch (ops[start + 1]) {
-                    .repeat => |rp| switch (ops[start + 2]) {
-                        .elementwise => |e| self.encodeRmsnormRepeatMul(rn, rp, e),
-                        else => false,
-                    },
-                    else => false,
-                },
-                else => false,
-            },
-            .rope_chain => switch (ops[start]) {
-                .rope => |rr| switch (ops[start + 1]) {
-                    .slice_assign => |sa| blk: {
-                        if (!canFuseRopeSliceAssign(rr, sa)) break :blk false;
-                        self.encodeRopeSliceAssign(rr, sa);
-                        break :blk true;
-                    },
-                    else => false,
-                },
-                else => false,
-            },
-        };
+        const lowering = exactProgramCommandLowering(command.kind) orelse return false;
+        const encoded = lowering.encode(self, ops, command);
 
         if (!encoded) {
             self.runtime_profile.recordProgramCommandFailed(command.kind);
             return false;
         }
-        if (command.kind == .rope_store_group or command.kind == .attention_store_chain or command.kind == .attention_store_group or command.kind == .rope_attention_store_chain or command.kind == .rope_attention_store_group) {
-            var record_indices: [program_mod.max_projection_group_anchors * 2]usize = undefined;
-            var record_count: usize = 0;
-            for (command.anchorIndices()) |idx| appendCommandIndex(&record_indices, &record_count, idx);
-            for (command.sidecarIndices()) |maybe_idx| {
-                if (maybe_idx) |idx| appendCommandIndex(&record_indices, &record_count, idx);
-            }
-            self.recordRegionFusedRunFromIndices(ops, record_indices[0..record_count], @intCast(nowNs() - t0));
-        } else if (command.kind != .projection_group and command.kind != .elementwise_batch and command.kind != .attention_group and command.kind != .movement_group) {
-            self.recordRegionFusedRun(ops[start..end], @intCast(nowNs() - t0));
-        }
+        self.recordExactProgramCommandRun(ops, command, lowering, @intCast(nowNs() - t0));
         self.runtime_profile.recordProgramCommand(command.kind);
         return true;
     }
 
-    fn appendCommandIndex(indices: *[program_mod.max_projection_group_anchors * 2]usize, count: *usize, idx: usize) void {
-        for (indices[0..count.*]) |existing| {
-            if (existing == idx) return;
+    fn canEncodeRegionGpuOpDirect(self: *CompiledProgram, op: backend_mod.DeviceOp) bool {
+        if (computeDispatchSpec(op) != null) return true;
+
+        return switch (op) {
+            .matmul => true,
+            .qmatmul => |q| {
+                if (@as(usize, q.weight_idx) >= self.qweight_views.len) return false;
+                if (q.M == 1) return self.canEncodeQMatvecBatchOp(q);
+                return true;
+            },
+            .rope => true,
+            .attention => |att| canEncodeAttention(att),
+            .fused_elementwise => |fe| canEncodeFusedElementwise(fe),
+            else => false,
+        };
+    }
+
+    fn canEncodeRegionGpuOpsDirect(self: *CompiledProgram, ops: []const backend_mod.DeviceOp) bool {
+        for (ops) |op| {
+            if (!self.canEncodeRegionGpuOpDirect(op)) return false;
         }
-        if (count.* >= indices.len) return;
-        indices[count.*] = idx;
-        count.* += 1;
+        return true;
+    }
+
+    fn canEncodeProgramCommandIndividually(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, command: program_mod.ProgramCommand) bool {
+        var indices = command.coveredIndexIterator();
+        while (indices.next()) |idx| {
+            if (idx >= ops.len or !self.canEncodeRegionGpuOpDirect(ops[idx])) return false;
+        }
+        return true;
+    }
+
+    fn canEncodeProgramCommand(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, command: program_mod.ProgramCommand) bool {
+        return self.canEncodeProgramCommandIndividually(ops, command);
+    }
+
+    fn canEncodeProgramCommands(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, commands: []const program_mod.ProgramCommand) bool {
+        for (commands) |command| {
+            if (!self.canEncodeProgramCommand(ops, command)) return false;
+        }
+        return true;
     }
 
     fn tryEncodeProgramCommandIndividually(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, command: program_mod.ProgramCommand) bool {
-        switch (command.kind) {
-            .op, .row_chain, .rope_chain, .rope_batch, .movement_batch, .attention_batch => {
-                const start: usize = @intCast(command.op_start);
-                const end = start + @as(usize, command.op_count);
-                if (end > ops.len) return false;
-                for (ops[start..end]) |op| {
-                    if (!self.tryEncodeRegionGpuOp(op)) return false;
-                }
-                return true;
-            },
-            .projection_chain,
-            .projection_group,
-            .rope_store_group,
-            .attention_chain,
-            .attention_store_chain,
-            .attention_store_group,
-            .rope_attention_store_chain,
-            .rope_attention_store_group,
-            .attention_group,
-            .movement_group,
-            .elementwise_batch,
-            => {
-                var indices: [program_mod.max_projection_group_anchors * 2]usize = undefined;
-                var count: usize = 0;
-                for (command.anchorIndices()) |idx| {
-                    if (idx >= ops.len) return false;
-                    appendCommandIndex(&indices, &count, idx);
-                }
-                if (command.sidecar_count > 0) {
-                    for (command.sidecarIndices()) |maybe_idx| {
-                        if (maybe_idx) |idx| {
-                            if (idx >= ops.len) return false;
-                            appendCommandIndex(&indices, &count, idx);
-                        }
-                    }
-                }
-                std.mem.sort(usize, indices[0..count], {}, std.sort.asc(usize));
-                for (indices[0..count]) |idx| {
-                    if (!self.tryEncodeRegionGpuOp(ops[idx])) return false;
-                }
-                return true;
-            },
+        var indices = command.coveredIndexIterator();
+        while (indices.next()) |idx| {
+            if (idx >= ops.len) return false;
+            if (!self.tryEncodeRegionGpuOp(ops[idx])) return false;
         }
+        return true;
     }
 
-    fn tryEncodeRegionGpuOps(self: *CompiledProgram, ops: []const backend_mod.DeviceOp) bool {
-        if (ops.len > 256) {
-            for (ops) |op| {
-                if (!self.tryEncodeRegionGpuOp(op)) return false;
-            }
-            return true;
-        }
+    fn tryEncodeRegionGpuCommands(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, commands: []const program_mod.ProgramCommand) bool {
+        if (ops.len > 256) return false;
+        if (!self.canEncodeProgramCommands(ops, commands)) return false;
 
         var skipped = [_]bool{false} ** 256;
-        const commands = program_mod.buildProgramCommands(
-            self.alloc,
-            ops,
-            program_mod.CommandStreamPolicy.metal(MAX_QMATVEC_BATCH, MAX_QMATMUL_BATCH),
-        ) catch return false;
-        defer self.alloc.free(commands);
-
         for (commands) |command| {
             self.runtime_profile.recordProgramCommandPlanned(command.kind);
             const start: usize = @intCast(command.op_start);
@@ -4741,20 +6332,77 @@ const CompiledProgram = struct {
         return true;
     }
 
-    fn tryEncodePatternRegion(self: *CompiledProgram, unit: program_mod.ScheduleUnit) bool {
-        return switch (unit.pattern_index) {
-            metal_pattern_decode_layer_stage,
-            metal_pattern_prefill_layer_stage,
-            => self.tryEncodeGpuRegion(unit),
-            else => false,
-        };
+    fn tryEncodeRegionGpuOps(self: *CompiledProgram, ops: []const backend_mod.DeviceOp) bool {
+        if (ops.len > 256) {
+            if (!self.canEncodeRegionGpuOpsDirect(ops)) return false;
+            for (ops) |op| {
+                if (!self.tryEncodeRegionGpuOp(op)) return false;
+            }
+            return true;
+        }
+
+        const commands = program_mod.buildProgramCommands(self.alloc, ops, self.backend.commandStreamPolicy()) catch return false;
+        defer self.alloc.free(commands);
+        return self.tryEncodeRegionGpuCommands(ops, commands);
     }
 
-    fn tryEncodeGpuRegion(self: *CompiledProgram, unit: program_mod.ScheduleUnit) bool {
+    const RegionLoweringFn = *const fn (*CompiledProgram, program_mod.ScheduleUnit, []const program_mod.ProgramCommand) bool;
+    const RegionLowering = struct {
+        pattern: MetalRegionPattern,
+        encode: RegionLoweringFn,
+    };
+
+    const region_lowerings = [_]RegionLowering{
+        .{ .pattern = .decode_layer_stage, .encode = tryEncodeLayerStageRegion },
+        .{ .pattern = .prefill_layer_stage, .encode = tryEncodeLayerStageRegion },
+    };
+
+    comptime {
+        const pattern_count = @typeInfo(MetalRegionPattern).@"enum".fields.len;
+        var seen = [_]bool{false} ** pattern_count;
+        for (region_lowerings) |lowering| {
+            const idx = @intFromEnum(lowering.pattern);
+            if (seen[idx]) @compileError("duplicate Metal region lowering: " ++ @tagName(lowering.pattern));
+            seen[idx] = true;
+        }
+        for (@typeInfo(MetalRegionPattern).@"enum".fields) |field| {
+            if (!seen[field.value]) {
+                @compileError("missing Metal region lowering: " ++ field.name);
+            }
+        }
+    }
+
+    fn regionLowering(pattern_index: u32) ?RegionLowering {
+        inline for (region_lowerings) |lowering| {
+            if (@intFromEnum(lowering.pattern) == pattern_index) return lowering;
+        }
+        return null;
+    }
+
+    fn regionCommandPlan(self: *const CompiledProgram, unit_index: usize) []const program_mod.ProgramCommand {
+        return self.plan.regionCommandPlan(unit_index, self.backend.commandStreamPolicy());
+    }
+
+    fn tryEncodePatternRegion(self: *CompiledProgram, unit: program_mod.ScheduleUnit, unit_index: usize) bool {
+        self.runtime_profile.recordScheduleRegionAttempt(unit);
+        const lowering = regionLowering(unit.pattern_index) orelse {
+            self.runtime_profile.recordScheduleRegionFailed(unit);
+            return false;
+        };
+        const encoded = lowering.encode(self, unit, self.regionCommandPlan(unit_index));
+        if (encoded) {
+            self.runtime_profile.recordScheduleRegionLowered(unit);
+        } else {
+            self.runtime_profile.recordScheduleRegionFailed(unit);
+        }
+        return encoded;
+    }
+
+    fn tryEncodeLayerStageRegion(self: *CompiledProgram, unit: program_mod.ScheduleUnit, commands: []const program_mod.ProgramCommand) bool {
         const start_item: usize = @intCast(unit.start_item);
         const end_item = start_item + @as(usize, unit.item_count);
-        if (end_item > self.schedule.len) return false;
-        const items = self.schedule[start_item..end_item];
+        if (end_item > self.plan.schedule.len) return false;
+        const items = self.plan.schedule[start_item..end_item];
 
         for (items) |item| {
             const op_start: usize = @intCast(item.start);
@@ -4768,7 +6416,14 @@ const CompiledProgram = struct {
         const op_start: usize = @intCast(unit.op_start);
         const op_end = op_start + @as(usize, unit.op_count);
         if (op_end > self.ops.len) return false;
-        return self.tryEncodeRegionGpuOps(self.ops[op_start..op_end]);
+        const ops = self.ops[op_start..op_end];
+        if (commands.len > 0) {
+            self.runtime_profile.recordCachedRegionCommandPlan(commands.len);
+            return self.tryEncodeRegionGpuCommands(ops, commands);
+        }
+
+        self.runtime_profile.recordDynamicRegionCommandPlan();
+        return self.tryEncodeRegionGpuOps(ops);
     }
 
     fn tryEncodeGpuOp(self: *CompiledProgram, op: backend_mod.DeviceOp) bool {
@@ -4789,7 +6444,7 @@ const CompiledProgram = struct {
                     self.device_bufs[m.b],
                     self.device_bufs[m.dst],
                 };
-                self.encodeTyped(MatMulParams, self.backend.matmul_pipeline, &buffers, matmulParams(m.geom), 3, matmulGrid(m.geom.M, m.geom.N), MATMUL_THREADS);
+                self.encodeKernel(.matmul_f32, &buffers, matmulParams(m.geom), 3, matmulGrid(m.geom.M, m.geom.N), MATMUL_THREADS);
                 return true;
             },
             .qmatmul => |q| {
@@ -4804,7 +6459,7 @@ const CompiledProgram = struct {
                     return self.encodeQMatvec(q);
                 }
                 if (!fine_grained and q.M < 16) return false;
-                self.encodeTyped(QMatMulParams, self.backend.qmatmul_pipeline, &buffers, qmatmulParams(q, w.block_size), 4, matmulGrid(q.M, q.N), MATMUL_THREADS);
+                self.encodeKernel(.qmatmul_f32, &buffers, qmatmulParams(q, w.block_size), 4, matmulGrid(q.M, q.N), MATMUL_THREADS);
                 return true;
             },
             .rope => |rr| {
@@ -4825,33 +6480,28 @@ const CompiledProgram = struct {
 
     fn rebuildSchedule(self: *CompiledProgram, ops: []const backend_mod.DeviceOp) void {
         const policy = metalSchedulePolicy(self.backend.fine_grained_program_dispatch);
-        if (program_mod.scheduleShapeMatches(ops, self.schedule, policy)) {
+        if (self.plan.shapeMatches(ops, policy)) {
             self.ops = ops;
             self.runtime_profile.schedule_reuse_count +%= 1;
             return;
         }
 
-        const schedule = program_mod.buildKernelSchedule(
+        const plan = buildMetalExecutionPlan(
             self.alloc,
             ops,
             policy,
+            self.backend.commandStreamPolicy(),
         ) catch {
-            if (self.schedule.len > 0) self.alloc.free(self.schedule);
-            if (self.region_schedule.len > 0) self.alloc.free(self.region_schedule);
+            self.plan.deinit(self.alloc);
             self.ops = ops;
-            self.schedule = &.{};
-            self.region_schedule = &.{};
+            self.plan = .{};
             self.runtime_profile.schedule_rebuild_count +%= 1;
             return;
         };
 
-        const region_schedule = buildMetalRegionSchedule(self.alloc, schedule) catch &.{};
-
-        if (self.schedule.len > 0) self.alloc.free(self.schedule);
-        if (self.region_schedule.len > 0) self.alloc.free(self.region_schedule);
+        self.plan.deinit(self.alloc);
         self.ops = ops;
-        self.schedule = schedule;
-        self.region_schedule = region_schedule;
+        self.plan = plan;
         self.runtime_profile.schedule_rebuild_count +%= 1;
     }
 };
@@ -4925,15 +6575,13 @@ fn compileProgramFn(ctx: *anyopaque, program: backend_mod.DeviceProgram) ?backen
         rb.* = .{ .ptr = @ptrCast(@alignCast(c.mtl_buffer_contents(buf.ptr))), .len = buf.size / @sizeOf(f32) };
     }
 
-    const schedule = program_mod.buildKernelSchedule(
+    const plan = buildMetalExecutionPlan(
         alloc,
         program.ops,
         metalSchedulePolicy(self.fine_grained_program_dispatch),
+        self.commandStreamPolicy(),
     ) catch return null;
-    errdefer if (schedule.len > 0) alloc.free(schedule);
-
-    const region_schedule = buildMetalRegionSchedule(alloc, schedule) catch &.{};
-    errdefer if (region_schedule.len > 0) alloc.free(region_schedule);
+    errdefer plan.deinit(alloc);
 
     const compiled = alloc.create(CompiledProgram) catch return null;
     compiled.* = .{
@@ -4943,8 +6591,7 @@ fn compileProgramFn(ctx: *anyopaque, program: backend_mod.DeviceProgram) ?backen
         .qweight_views = qweight_views,
         .ref_qweights = ref_qweights,
         .ops = program.ops,
-        .schedule = schedule,
-        .region_schedule = region_schedule,
+        .plan = plan,
         .alloc = alloc,
     };
     return @ptrCast(compiled);
@@ -5064,6 +6711,18 @@ test "metal backend compiled program qmatvec" {
     try std.testing.expectEqual(@as(u64, 1), rt.backend_dispatch_count);
 }
 
+test "metal backend capabilities reflect projection rope cache sidecar knob" {
+    var metal = MetalBackend.init() catch |err| switch (err) {
+        error.MetalNotAvailable => return,
+        else => return err,
+    };
+    defer metal.deinit();
+
+    try std.testing.expect(!metal.backend().capabilities.command_stream.projection_rope_cache_sidecars);
+    metal.setProjectionRopeCacheSidecars(true);
+    try std.testing.expect(metal.backend().capabilities.command_stream.projection_rope_cache_sidecars);
+}
+
 test "metal backend region batches independent qmatvecs" {
     var metal = MetalBackend.init() catch |err| switch (err) {
         error.MetalNotAvailable => return,
@@ -5124,6 +6783,454 @@ test "metal backend region batches independent qmatvecs" {
     try std.testing.expectEqual(@as(u64, 7), rt.backend_op_count);
     try std.testing.expectEqual(@as(u64, 0), rt.fallback_op_count);
     try std.testing.expectEqual(@as(u64, 2), rt.backend_dispatch_count);
+    try std.testing.expectEqual(@as(u64, 1), rt.schedule_regions.attempted);
+    try std.testing.expectEqual(@as(u64, 1), rt.schedule_regions.lowered);
+    try std.testing.expectEqual(@as(u64, 0), rt.schedule_regions.failed);
+    try std.testing.expectEqual(@as(u64, 7), rt.schedule_regions.lowered_ops);
+    try std.testing.expectEqual(@as(u64, 1), rt.region_command_plan_cached_count);
+    try std.testing.expectEqual(@as(u64, 0), rt.region_command_plan_dynamic_count);
+    try std.testing.expect(rt.region_command_plan_cached_command_count > 0);
+    const decode_pattern = MetalRegionPattern.decode_layer_stage.index();
+    try std.testing.expectEqual(@as(u64, 1), rt.schedule_region_patterns[decode_pattern].attempted);
+    try std.testing.expectEqual(@as(u64, 1), rt.schedule_region_patterns[decode_pattern].lowered);
+    try std.testing.expectEqual(@as(u64, 7), rt.schedule_region_patterns[decode_pattern].lowered_ops);
+}
+
+test "metal backend qmatvec projection group carries cache store sidecars" {
+    var metal = MetalBackend.init() catch |err| switch (err) {
+        error.MetalNotAvailable => return,
+        else => return err,
+    };
+    defer metal.deinit();
+    metal.setRegionProgramDispatch(true);
+    const be = metal.backend();
+
+    var input = [_]f32{ 1, 2, 3, 4 };
+    const qdata = [_]i8{
+        1, 0, 0, 0,
+        0, 1, 0, 0,
+        0, 0, 1, 0,
+        0, 0, 0, 1,
+    };
+    const scales = [_]f32{ 1, 1, 1, 1 };
+    const qweights = [_]backend_mod.QuantizedWeightUpload{.{ .data = &qdata, .scales = &scales, .rows = 4, .cols = 4, .block_size = 4 }};
+
+    var ops: [8]backend_mod.DeviceOp = undefined;
+    ops[0] = .{ .qmatmul = .{
+        .dst = 1,
+        .input = 0,
+        .weight_idx = 0,
+        .M = 1,
+        .N = 4,
+        .K = 4,
+    } };
+    ops[1] = .{ .slice_assign = .{
+        .dst = 8,
+        .src = 1,
+        .rows = 4,
+        .cols = 1,
+        .dst_base_offset = 0,
+        .dst_offset = 0,
+        .dst_row_stride = 1,
+        .dst_col_stride = 4,
+        .src_offset = 0,
+        .src_row_stride = 1,
+        .src_col_stride = 4,
+        .patch_stride = 4,
+    } };
+    for (ops[2..], 0..) |*op, i| {
+        op.* = .{ .qmatmul = .{
+            .dst = @intCast(i + 2),
+            .input = 0,
+            .weight_idx = 0,
+            .M = 1,
+            .N = 4,
+            .K = 4,
+        } };
+    }
+
+    const buf_sizes = [_]usize{ 4, 4, 4, 4, 4, 4, 4, 4, 4 };
+    const uploads = [_]backend_mod.ProgramIO{
+        .{ .buf_idx = 0, .host_ptr = @ptrCast(&input), .size = 4 * 4 },
+    };
+    const program = backend_mod.DeviceProgram{
+        .ops = &ops,
+        .n_buffers = 9,
+        .buffer_sizes = &buf_sizes,
+        .initial_uploads = &uploads,
+        .qweights = &qweights,
+    };
+
+    const handle = be.compileProgram(program) orelse return error.CompileFailed;
+    defer be.freeProgram(handle);
+
+    var got: [7][4]f32 = undefined;
+    var outs: [7]backend_mod.ProgramIO = undefined;
+    for (outs[0..6], 0..) |*out, i| {
+        out.* = .{ .buf_idx = @intCast(i + 2), .host_ptr = @ptrCast(&got[i]), .size = 4 * 4 };
+    }
+    outs[6] = .{ .buf_idx = 8, .host_ptr = @ptrCast(&got[6]), .size = 4 * 4 };
+    be.executeProgram(handle, &.{}, &outs);
+
+    for (got) |row| {
+        try std.testing.expectEqualSlices(f32, &input, &row);
+    }
+
+    const rt = be.getRuntimeProfile(handle).?;
+    try std.testing.expectEqual(@as(u64, 8), rt.backend_op_count);
+    try std.testing.expectEqual(@as(u64, 0), rt.fallback_op_count);
+    try std.testing.expectEqual(@as(u64, 2), rt.backend_dispatch_count);
+    try std.testing.expectEqual(@as(u64, 1), rt.region_command_plan_cached_count);
+}
+
+test "metal backend qmatvec projection group carries elementwise sidecars" {
+    var metal = MetalBackend.init() catch |err| switch (err) {
+        error.MetalNotAvailable => return,
+        else => return err,
+    };
+    defer metal.deinit();
+    metal.setRegionProgramDispatch(true);
+    const be = metal.backend();
+
+    var input = [_]f32{ 1, 2, 3, 4 };
+    var bias = [_]f32{ 10, 20, 30, 40 };
+    const qdata = [_]i8{
+        1, 0, 0, 0,
+        0, 1, 0, 0,
+        0, 0, 1, 0,
+        0, 0, 0, 1,
+    };
+    const scales = [_]f32{ 1, 1, 1, 1 };
+    const qweights = [_]backend_mod.QuantizedWeightUpload{.{ .data = &qdata, .scales = &scales, .rows = 4, .cols = 4, .block_size = 4 }};
+
+    var ops: [8]backend_mod.DeviceOp = undefined;
+    ops[0] = .{ .qmatmul = .{
+        .dst = 1,
+        .input = 0,
+        .weight_idx = 0,
+        .M = 1,
+        .N = 4,
+        .K = 4,
+    } };
+    ops[1] = .{ .elementwise = .{
+        .op = .add,
+        .dst = 9,
+        .src0 = 1,
+        .src1 = 8,
+        .n = 4,
+    } };
+    for (ops[2..], 0..) |*op, i| {
+        op.* = .{ .qmatmul = .{
+            .dst = @intCast(i + 2),
+            .input = 0,
+            .weight_idx = 0,
+            .M = 1,
+            .N = 4,
+            .K = 4,
+        } };
+    }
+
+    const buf_sizes = [_]usize{ 4, 4, 4, 4, 4, 4, 4, 4, 4, 4 };
+    const uploads = [_]backend_mod.ProgramIO{
+        .{ .buf_idx = 0, .host_ptr = @ptrCast(&input), .size = input.len * 4 },
+        .{ .buf_idx = 8, .host_ptr = @ptrCast(&bias), .size = bias.len * 4 },
+    };
+    const program = backend_mod.DeviceProgram{
+        .ops = &ops,
+        .n_buffers = 10,
+        .buffer_sizes = &buf_sizes,
+        .initial_uploads = &uploads,
+        .qweights = &qweights,
+    };
+
+    const handle = be.compileProgram(program) orelse return error.CompileFailed;
+    defer be.freeProgram(handle);
+
+    var got: [4]f32 = undefined;
+    var out = [_]backend_mod.ProgramIO{.{ .buf_idx = 9, .host_ptr = @ptrCast(&got), .size = got.len * 4 }};
+    be.executeProgram(handle, &.{}, &out);
+
+    try std.testing.expectEqualSlices(f32, &.{ 11, 22, 33, 44 }, &got);
+
+    const rt = be.getRuntimeProfile(handle).?;
+    try std.testing.expectEqual(@as(u64, 8), rt.backend_op_count);
+    try std.testing.expectEqual(@as(u64, 0), rt.fallback_op_count);
+    try std.testing.expectEqual(@as(u64, 2), rt.backend_dispatch_count);
+    try std.testing.expectEqual(@as(u64, 1), rt.region_command_plan_cached_count);
+    try std.testing.expectEqual(@as(u64, 2), rt.program_command_counts[@intFromEnum(program_mod.ProgramCommandKind.projection_group)]);
+}
+
+test "metal backend qmatvec projection cache group carries rope store sidecars" {
+    var metal = MetalBackend.init() catch |err| switch (err) {
+        error.MetalNotAvailable => return,
+        else => return err,
+    };
+    defer metal.deinit();
+    metal.setRegionProgramDispatch(true);
+    metal.setProjectionRopeCacheSidecars(true);
+    const be = metal.backend();
+
+    var input = [_]f32{ 1, 2, 3, 4 };
+    var q_out_seed = [_]f32{99} ** 4;
+    var rope_out_seed = [_]f32{77} ** 4;
+    var cos_sin = [_]f32{ 0, 0, 1, 1 };
+    var cache = [_]f32{0} ** 4;
+    const qdata = [_]i8{
+        1, 0, 0, 0,
+        0, 1, 0, 0,
+        0, 0, 1, 0,
+        0, 0, 0, 1,
+    };
+    const scales = [_]f32{ 1, 1, 1, 1 };
+    const qweights = [_]backend_mod.QuantizedWeightUpload{.{ .data = &qdata, .scales = &scales, .rows = 4, .cols = 4, .block_size = 4 }};
+
+    var ops: [9]backend_mod.DeviceOp = undefined;
+    for (ops[0..7], 0..) |*op, i| {
+        op.* = .{ .qmatmul = .{
+            .dst = @intCast(i + 1),
+            .input = 0,
+            .weight_idx = 0,
+            .M = 1,
+            .N = 4,
+            .K = 4,
+        } };
+    }
+    ops[7] = .{ .rope = .{
+        .dst = 8,
+        .src = 7,
+        .cos_sin = 9,
+        .half_d = 2,
+        .seq_len = 1,
+        .src_off = 0,
+        .dst_off = 0,
+        .cs_off = 0,
+        .src_rs = 1,
+        .src_cs = 4,
+        .cs_cs = 4,
+    } };
+    ops[8] = .{ .slice_assign = .{
+        .dst = 10,
+        .src = 8,
+        .rows = 4,
+        .cols = 1,
+        .dst_base_offset = 0,
+        .dst_offset = 0,
+        .dst_row_stride = 1,
+        .dst_col_stride = 4,
+        .src_offset = 0,
+        .src_row_stride = 1,
+        .src_col_stride = 4,
+        .patch_stride = 4,
+    } };
+
+    const buf_sizes = [_]usize{ 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4 };
+    const uploads = [_]backend_mod.ProgramIO{
+        .{ .buf_idx = 0, .host_ptr = @ptrCast(&input), .size = input.len * 4 },
+        .{ .buf_idx = 7, .host_ptr = @ptrCast(&q_out_seed), .size = q_out_seed.len * 4 },
+        .{ .buf_idx = 8, .host_ptr = @ptrCast(&rope_out_seed), .size = rope_out_seed.len * 4 },
+        .{ .buf_idx = 9, .host_ptr = @ptrCast(&cos_sin), .size = cos_sin.len * 4 },
+        .{ .buf_idx = 10, .host_ptr = @ptrCast(&cache), .size = cache.len * 4 },
+    };
+    const program = backend_mod.DeviceProgram{
+        .ops = &ops,
+        .n_buffers = 11,
+        .buffer_sizes = &buf_sizes,
+        .initial_uploads = &uploads,
+        .qweights = &qweights,
+    };
+
+    const handle = be.compileProgram(program) orelse return error.CompileFailed;
+    defer be.freeProgram(handle);
+
+    var got_q: [4]f32 = undefined;
+    var got_rope: [4]f32 = undefined;
+    var got_cache: [4]f32 = undefined;
+    const outs = [_]backend_mod.ProgramIO{
+        .{ .buf_idx = 7, .host_ptr = @ptrCast(&got_q), .size = got_q.len * 4 },
+        .{ .buf_idx = 8, .host_ptr = @ptrCast(&got_rope), .size = got_rope.len * 4 },
+        .{ .buf_idx = 10, .host_ptr = @ptrCast(&got_cache), .size = got_cache.len * 4 },
+    };
+    be.executeProgram(handle, &.{}, &outs);
+
+    try std.testing.expectEqualSlices(f32, &q_out_seed, &got_q);
+    try std.testing.expectEqualSlices(f32, &rope_out_seed, &got_rope);
+    try std.testing.expectEqualSlices(f32, &.{ -3, -4, 1, 2 }, &got_cache);
+
+    const rt = be.getRuntimeProfile(handle).?;
+    try std.testing.expectEqual(@as(u64, 9), rt.backend_op_count);
+    try std.testing.expectEqual(@as(u64, 0), rt.fallback_op_count);
+    try std.testing.expectEqual(@as(u64, 2), rt.backend_dispatch_count);
+    try std.testing.expectEqual(@as(u64, 1), rt.region_command_plan_cached_count);
+}
+
+test "metal backend qmatvec projection cache group materializes rope sidecars" {
+    var metal = MetalBackend.init() catch |err| switch (err) {
+        error.MetalNotAvailable => return,
+        else => return err,
+    };
+    defer metal.deinit();
+    metal.setRegionProgramDispatch(true);
+    metal.setProjectionRopeCacheSidecars(true);
+    const be = metal.backend();
+
+    var input = [_]f32{ 1, 2, 3, 4 };
+    var q_out_seed = [_]f32{99} ** 4;
+    var rope_out_seed = [_]f32{77} ** 4;
+    var cos_sin = [_]f32{ 0, 0, 1, 1 };
+    const qdata = [_]i8{
+        1, 0, 0, 0,
+        0, 1, 0, 0,
+        0, 0, 1, 0,
+        0, 0, 0, 1,
+    };
+    const scales = [_]f32{ 1, 1, 1, 1 };
+    const qweights = [_]backend_mod.QuantizedWeightUpload{.{ .data = &qdata, .scales = &scales, .rows = 4, .cols = 4, .block_size = 4 }};
+
+    var ops: [8]backend_mod.DeviceOp = undefined;
+    ops[0] = .{ .qmatmul = .{
+        .dst = 1,
+        .input = 0,
+        .weight_idx = 0,
+        .M = 1,
+        .N = 4,
+        .K = 4,
+    } };
+    ops[1] = .{ .rope = .{
+        .dst = 8,
+        .src = 1,
+        .cos_sin = 9,
+        .half_d = 2,
+        .seq_len = 1,
+        .src_off = 0,
+        .dst_off = 0,
+        .cs_off = 0,
+        .src_rs = 1,
+        .src_cs = 4,
+        .cs_cs = 4,
+    } };
+    for (ops[2..], 0..) |*op, i| {
+        op.* = .{ .qmatmul = .{
+            .dst = @intCast(i + 2),
+            .input = 0,
+            .weight_idx = 0,
+            .M = 1,
+            .N = 4,
+            .K = 4,
+        } };
+    }
+
+    const buf_sizes = [_]usize{ 4, 4, 4, 4, 4, 4, 4, 4, 4, 4 };
+    const uploads = [_]backend_mod.ProgramIO{
+        .{ .buf_idx = 0, .host_ptr = @ptrCast(&input), .size = input.len * 4 },
+        .{ .buf_idx = 1, .host_ptr = @ptrCast(&q_out_seed), .size = q_out_seed.len * 4 },
+        .{ .buf_idx = 8, .host_ptr = @ptrCast(&rope_out_seed), .size = rope_out_seed.len * 4 },
+        .{ .buf_idx = 9, .host_ptr = @ptrCast(&cos_sin), .size = cos_sin.len * 4 },
+    };
+    const program = backend_mod.DeviceProgram{
+        .ops = &ops,
+        .n_buffers = 10,
+        .buffer_sizes = &buf_sizes,
+        .initial_uploads = &uploads,
+        .qweights = &qweights,
+    };
+
+    const handle = be.compileProgram(program) orelse return error.CompileFailed;
+    defer be.freeProgram(handle);
+
+    var got_q: [4]f32 = undefined;
+    var got_rope: [4]f32 = undefined;
+    const outs = [_]backend_mod.ProgramIO{
+        .{ .buf_idx = 1, .host_ptr = @ptrCast(&got_q), .size = got_q.len * 4 },
+        .{ .buf_idx = 8, .host_ptr = @ptrCast(&got_rope), .size = got_rope.len * 4 },
+    };
+    be.executeProgram(handle, &.{}, &outs);
+
+    try std.testing.expectEqualSlices(f32, &q_out_seed, &got_q);
+    try std.testing.expectEqualSlices(f32, &.{ -3, -4, 1, 2 }, &got_rope);
+
+    const rt = be.getRuntimeProfile(handle).?;
+    try std.testing.expectEqual(@as(u64, 8), rt.backend_op_count);
+    try std.testing.expectEqual(@as(u64, 0), rt.fallback_op_count);
+    try std.testing.expectEqual(@as(u64, 2), rt.backend_dispatch_count);
+    try std.testing.expectEqual(@as(u64, 1), rt.region_command_plan_cached_count);
+}
+
+test "metal backend region lowers mixed direct ops without fallback" {
+    var metal = MetalBackend.init() catch |err| switch (err) {
+        error.MetalNotAvailable => return,
+        else => return err,
+    };
+    defer metal.deinit();
+    metal.setRegionProgramDispatch(true);
+    const be = metal.backend();
+
+    var input = [_]f32{ 1, 2, 3, 4 };
+    const qdata = [_]i8{
+        1, 0, 0, 0,
+        0, 1, 0, 0,
+        0, 0, 1, 0,
+        0, 0, 0, 1,
+    };
+    const scales = [_]f32{ 1, 1, 1, 1 };
+    const qweights = [_]backend_mod.QuantizedWeightUpload{.{ .data = &qdata, .scales = &scales, .rows = 4, .cols = 4, .block_size = 4 }};
+
+    var ops: [8]backend_mod.DeviceOp = undefined;
+    for (ops[0..7], 0..) |*op, i| {
+        op.* = .{ .qmatmul = .{
+            .dst = @intCast(i + 1),
+            .input = 0,
+            .weight_idx = 0,
+            .M = 1,
+            .N = 4,
+            .K = 4,
+        } };
+    }
+    ops[7] = .{ .elementwise = .{
+        .op = .add,
+        .dst = 8,
+        .src0 = 1,
+        .src1 = 2,
+        .n = 4,
+    } };
+
+    const buf_sizes = [_]usize{ 4, 4, 4, 4, 4, 4, 4, 4, 4 };
+    const uploads = [_]backend_mod.ProgramIO{
+        .{ .buf_idx = 0, .host_ptr = @ptrCast(&input), .size = 4 * 4 },
+    };
+    const program = backend_mod.DeviceProgram{
+        .ops = &ops,
+        .n_buffers = 9,
+        .buffer_sizes = &buf_sizes,
+        .initial_uploads = &uploads,
+        .qweights = &qweights,
+    };
+
+    const handle = be.compileProgram(program) orelse return error.CompileFailed;
+    defer be.freeProgram(handle);
+
+    var got: [4]f32 = undefined;
+    var out = [_]backend_mod.ProgramIO{.{ .buf_idx = 8, .host_ptr = @ptrCast(&got), .size = 4 * 4 }};
+    be.executeProgram(handle, &.{}, &out);
+
+    for (got, [_]f32{ 2, 4, 6, 8 }) |actual, expected| {
+        try std.testing.expectApproxEqAbs(expected, actual, 1e-4);
+    }
+
+    const rt = be.getRuntimeProfile(handle).?;
+    try std.testing.expectEqual(@as(u64, 8), rt.backend_op_count);
+    try std.testing.expectEqual(@as(u64, 0), rt.fallback_op_count);
+    try std.testing.expectEqual(@as(u64, 1), rt.schedule_regions.attempted);
+    try std.testing.expectEqual(@as(u64, 1), rt.schedule_regions.lowered);
+    try std.testing.expectEqual(@as(u64, 0), rt.schedule_regions.failed);
+    try std.testing.expectEqual(@as(u64, 8), rt.schedule_regions.lowered_ops);
+    try std.testing.expectEqual(@as(u64, 1), rt.region_command_plan_cached_count);
+    try std.testing.expectEqual(@as(u64, 0), rt.region_command_plan_dynamic_count);
+    try std.testing.expect(rt.region_command_plan_cached_command_count > 0);
+    const decode_pattern = MetalRegionPattern.decode_layer_stage.index();
+    try std.testing.expectEqual(@as(u64, 1), rt.schedule_region_patterns[decode_pattern].attempted);
+    try std.testing.expectEqual(@as(u64, 1), rt.schedule_region_patterns[decode_pattern].lowered);
+    try std.testing.expectEqual(@as(u64, 0), rt.schedule_region_patterns[decode_pattern].failed);
+    try std.testing.expectEqual(@as(u64, 8), rt.schedule_region_patterns[decode_pattern].lowered_ops);
 }
 
 test "metal backend region batches independent qmatmuls" {
@@ -5186,6 +7293,17 @@ test "metal backend region batches independent qmatmuls" {
     try std.testing.expectEqual(@as(u64, 7), rt.backend_op_count);
     try std.testing.expectEqual(@as(u64, 0), rt.fallback_op_count);
     try std.testing.expectEqual(@as(u64, 2), rt.backend_dispatch_count);
+    try std.testing.expectEqual(@as(u64, 1), rt.schedule_regions.attempted);
+    try std.testing.expectEqual(@as(u64, 1), rt.schedule_regions.lowered);
+    try std.testing.expectEqual(@as(u64, 0), rt.schedule_regions.failed);
+    try std.testing.expectEqual(@as(u64, 7), rt.schedule_regions.lowered_ops);
+    try std.testing.expectEqual(@as(u64, 1), rt.region_command_plan_cached_count);
+    try std.testing.expectEqual(@as(u64, 0), rt.region_command_plan_dynamic_count);
+    try std.testing.expect(rt.region_command_plan_cached_command_count > 0);
+    const prefill_pattern = MetalRegionPattern.prefill_layer_stage.index();
+    try std.testing.expectEqual(@as(u64, 1), rt.schedule_region_patterns[prefill_pattern].attempted);
+    try std.testing.expectEqual(@as(u64, 1), rt.schedule_region_patterns[prefill_pattern].lowered);
+    try std.testing.expectEqual(@as(u64, 7), rt.schedule_region_patterns[prefill_pattern].lowered_ops);
 }
 
 test "metal backend qmatmul batch carries cache-store sidecars" {
@@ -5260,6 +7378,116 @@ test "metal backend qmatmul batch carries cache-store sidecars" {
     try std.testing.expectEqual(@as(u64, 8), rt.backend_op_count);
     try std.testing.expectEqual(@as(u64, 0), rt.fallback_op_count);
     try std.testing.expectEqual(@as(u64, 2), rt.backend_dispatch_count);
+}
+
+test "metal backend opt-in qmatmul rope cache store sidecar" {
+    var metal = MetalBackend.init() catch |err| switch (err) {
+        error.MetalNotAvailable => return,
+        else => return err,
+    };
+    defer metal.deinit();
+    metal.setFineGrainedProgramDispatch(true);
+    metal.setRegionProgramDispatch(true);
+    metal.setProjectionRopeCacheSidecars(true);
+    const be = metal.backend();
+
+    var input = [_]f32{ 1, 2 };
+    var q_out_seed = [_]f32{99} ** 128;
+    var rope_out_seed = [_]f32{77} ** 128;
+    var cos_sin = [_]f32{0} ** 128;
+    for (0..2) |row| {
+        const base = row * 64;
+        for (0..32) |i| cos_sin[base + i] = 1;
+    }
+    var cache = [_]f32{0} ** 128;
+    var qdata: [64]i8 = undefined;
+    for (&qdata, 0..) |*v, i| v.* = @intCast(i + 1);
+    const scales = [_]f32{1};
+    const qweights = [_]backend_mod.QuantizedWeightUpload{.{ .data = &qdata, .scales = &scales, .rows = 1, .cols = 64, .block_size = 64 }};
+
+    var ops: [9]backend_mod.DeviceOp = undefined;
+    for (ops[0..7], 0..) |*op, i| {
+        op.* = .{ .qmatmul = .{
+            .dst = @intCast(i + 1),
+            .input = 0,
+            .weight_idx = 0,
+            .M = 2,
+            .N = 64,
+            .K = 1,
+        } };
+    }
+    ops[7] =
+        .{ .rope = .{
+            .dst = 8,
+            .src = 7,
+            .cos_sin = 9,
+            .half_d = 32,
+            .seq_len = 2,
+            .src_off = 0,
+            .dst_off = 0,
+            .cs_off = 0,
+            .src_rs = 1,
+            .src_cs = 64,
+            .cs_cs = 64,
+        } };
+    ops[8] =
+        .{ .slice_assign = .{
+            .dst = 10,
+            .src = 8,
+            .rows = 64,
+            .cols = 2,
+            .dst_base_offset = 0,
+            .dst_offset = 0,
+            .dst_row_stride = 1,
+            .dst_col_stride = 64,
+            .src_offset = 0,
+            .src_row_stride = 1,
+            .src_col_stride = 64,
+            .patch_stride = 64,
+        } };
+
+    const buf_sizes = [_]usize{ 2, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128 };
+    const uploads = [_]backend_mod.ProgramIO{
+        .{ .buf_idx = 0, .host_ptr = @ptrCast(&input), .size = input.len * 4 },
+        .{ .buf_idx = 7, .host_ptr = @ptrCast(&q_out_seed), .size = q_out_seed.len * 4 },
+        .{ .buf_idx = 8, .host_ptr = @ptrCast(&rope_out_seed), .size = rope_out_seed.len * 4 },
+        .{ .buf_idx = 9, .host_ptr = @ptrCast(&cos_sin), .size = cos_sin.len * 4 },
+        .{ .buf_idx = 10, .host_ptr = @ptrCast(&cache), .size = cache.len * 4 },
+    };
+    const program = backend_mod.DeviceProgram{
+        .ops = &ops,
+        .n_buffers = 11,
+        .buffer_sizes = &buf_sizes,
+        .initial_uploads = &uploads,
+        .qweights = &qweights,
+    };
+
+    const handle = be.compileProgram(program) orelse return error.CompileFailed;
+    defer be.freeProgram(handle);
+
+    var got_q: [128]f32 = undefined;
+    var got_rope: [128]f32 = undefined;
+    var got_cache: [128]f32 = undefined;
+    const outs = [_]backend_mod.ProgramIO{
+        .{ .buf_idx = 7, .host_ptr = @ptrCast(&got_q), .size = got_q.len * 4 },
+        .{ .buf_idx = 8, .host_ptr = @ptrCast(&got_rope), .size = got_rope.len * 4 },
+        .{ .buf_idx = 10, .host_ptr = @ptrCast(&got_cache), .size = got_cache.len * 4 },
+    };
+    be.executeProgram(handle, &.{}, &outs);
+
+    for (got_q) |v| try std.testing.expectEqual(@as(f32, 99), v);
+    for (got_rope) |v| try std.testing.expectEqual(@as(f32, 77), v);
+    for (0..2) |row| {
+        for (0..64) |col| {
+            const expected: f32 = @floatFromInt((row + 1) * (col + 1));
+            try std.testing.expectEqual(expected, got_cache[row * 64 + col]);
+        }
+    }
+
+    const rt = be.getRuntimeProfile(handle).?;
+    try std.testing.expectEqual(@as(u64, 9), rt.backend_op_count);
+    try std.testing.expectEqual(@as(u64, 0), rt.fallback_op_count);
+    try std.testing.expectEqual(@as(u64, 3), rt.backend_dispatch_count);
 }
 
 test "metal backend qmatmul batch carries elementwise sidecars" {
@@ -5736,6 +7964,356 @@ test "metal backend region fuses qmatmul fused-elementwise sidecar" {
     try std.testing.expectEqual(@as(u64, 8), rt.backend_op_count);
     try std.testing.expectEqual(@as(u64, 0), rt.fallback_op_count);
     try std.testing.expectEqual(@as(u64, 4), rt.backend_dispatch_count);
+}
+
+test "metal backend region fuses qmatmul activation expression chain" {
+    var metal = MetalBackend.init() catch |err| switch (err) {
+        error.MetalNotAvailable => return,
+        else => return err,
+    };
+    defer metal.deinit();
+    metal.setRegionProgramDispatch(true);
+    const be = metal.backend();
+
+    var input = [_]f32{ 1, 2, 3, 4, 5, 6, 7, 8 };
+    var filler = [_]f32{0} ** 8;
+    var q_out = [_]f32{0} ** 8;
+    var exp_tmp = [_]f32{0} ** 8;
+    var one = [_]f32{1};
+    var repeat_out = [_]f32{0} ** 8;
+    var silu_out = [_]f32{0} ** 8;
+    const qdata = [_]i8{
+        1, 0, 0, 0,
+        0, 1, 0, 0,
+        0, 0, 1, 0,
+        0, 0, 0, 1,
+    };
+    const scales = [_]f32{ 1, 1, 1, 1 };
+    const qweights = [_]backend_mod.QuantizedWeightUpload{.{ .data = &qdata, .scales = &scales, .rows = 4, .cols = 4, .block_size = 4 }};
+    const exp_steps = [_]backend_mod.FusedEwStep{
+        .{ .op = .neg, .is_swapped = false, .secondary_buf = 0, .secondary_offset = 0 },
+        .{ .op = .exp, .is_swapped = false, .secondary_buf = 0, .secondary_offset = 0 },
+    };
+    const silu_steps = [_]backend_mod.FusedEwStep{
+        .{ .op = .add, .is_swapped = false, .secondary_buf = 7, .secondary_offset = 0 },
+        .{ .op = .recip, .is_swapped = false, .secondary_buf = 0, .secondary_offset = 0 },
+        .{ .op = .mul, .is_swapped = true, .secondary_buf = 5, .secondary_offset = 0 },
+    };
+
+    var ops: [10]backend_mod.DeviceOp = undefined;
+    for (ops[0..4]) |*op| {
+        op.* = .{ .qmatmul = .{
+            .dst = 1,
+            .input = 0,
+            .weight_idx = 0,
+            .M = 2,
+            .N = 4,
+            .K = 4,
+        } };
+    }
+    ops[4] = .{ .qmatmul = .{
+        .dst = 5,
+        .input = 0,
+        .weight_idx = 0,
+        .M = 2,
+        .N = 4,
+        .K = 4,
+    } };
+    ops[5] = .{ .fused_elementwise = .{
+        .steps = &exp_steps,
+        .n = 8,
+        .dst = 6,
+        .src = 5,
+        .dst_offset = 0,
+        .src_offset = 0,
+    } };
+    ops[6] = .{ .repeat = .{
+        .dst = 7,
+        .src = 8,
+        .n = 8,
+        .src_ne = .{ 1, 1, 1, 1 },
+        .dst_ne = .{ 4, 2, 1, 1 },
+        .src_strides = .{ 1, 1, 1, 1 },
+        .dst_strides = .{ 1, 4, 8, 8 },
+    } };
+    ops[7] = .{ .fused_elementwise = .{
+        .steps = &silu_steps,
+        .n = 8,
+        .dst = 9,
+        .src = 6,
+        .dst_offset = 0,
+        .src_offset = 0,
+    } };
+    for (ops[8..10]) |*op| {
+        op.* = .{ .qmatmul = .{
+            .dst = 1,
+            .input = 0,
+            .weight_idx = 0,
+            .M = 2,
+            .N = 4,
+            .K = 4,
+        } };
+    }
+
+    const buf_sizes = [_]usize{ 8, 8, 8, 8, 8, 8, 8, 8, 1, 8 };
+    const uploads = [_]backend_mod.ProgramIO{
+        .{ .buf_idx = 0, .host_ptr = @ptrCast(&input), .size = input.len * 4 },
+        .{ .buf_idx = 1, .host_ptr = @ptrCast(&filler), .size = filler.len * 4 },
+        .{ .buf_idx = 5, .host_ptr = @ptrCast(&q_out), .size = q_out.len * 4 },
+        .{ .buf_idx = 6, .host_ptr = @ptrCast(&exp_tmp), .size = exp_tmp.len * 4 },
+        .{ .buf_idx = 7, .host_ptr = @ptrCast(&repeat_out), .size = repeat_out.len * 4 },
+        .{ .buf_idx = 8, .host_ptr = @ptrCast(&one), .size = one.len * 4 },
+        .{ .buf_idx = 9, .host_ptr = @ptrCast(&silu_out), .size = silu_out.len * 4 },
+    };
+    const program = backend_mod.DeviceProgram{
+        .ops = &ops,
+        .n_buffers = 10,
+        .buffer_sizes = &buf_sizes,
+        .initial_uploads = &uploads,
+        .qweights = &qweights,
+    };
+
+    const handle = be.compileProgram(program) orelse return error.CompileFailed;
+    defer be.freeProgram(handle);
+
+    var got: [8]f32 = undefined;
+    var out = [_]backend_mod.ProgramIO{.{ .buf_idx = 9, .host_ptr = @ptrCast(&got), .size = got.len * 4 }};
+    be.executeProgram(handle, &.{}, &out);
+
+    for (input, got) |x, actual| {
+        const want = x / (1.0 + @exp(-x));
+        try std.testing.expectApproxEqAbs(want, actual, 1e-4);
+    }
+
+    const rt = be.getRuntimeProfile(handle).?;
+    try std.testing.expectEqual(@as(u64, 10), rt.backend_op_count);
+    try std.testing.expectEqual(@as(u64, 0), rt.fallback_op_count);
+}
+
+test "metal backend region fuses paired qmatmul activation product chain" {
+    var metal = MetalBackend.init() catch |err| switch (err) {
+        error.MetalNotAvailable => return,
+        else => return err,
+    };
+    defer metal.deinit();
+    metal.setRegionProgramDispatch(true);
+    const be = metal.backend();
+
+    var input = [_]f32{ 1, 2, 3, 4, 5, 6, 7, 8 };
+    var filler = [_]f32{0} ** 8;
+    var shared_q_out = [_]f32{0} ** 8;
+    var exp_tmp = [_]f32{0} ** 8;
+    var one = [_]f32{1};
+    var repeat_out = [_]f32{0} ** 8;
+    var silu_out = [_]f32{0} ** 8;
+    var product_out = [_]f32{0} ** 8;
+    const qdata = [_]i8{
+        1, 0, 0, 0,
+        0, 1, 0, 0,
+        0, 0, 1, 0,
+        0, 0, 0, 1,
+    };
+    const scales = [_]f32{ 1, 1, 1, 1 };
+    const qweights = [_]backend_mod.QuantizedWeightUpload{.{ .data = &qdata, .scales = &scales, .rows = 4, .cols = 4, .block_size = 4 }};
+    const exp_steps = [_]backend_mod.FusedEwStep{
+        .{ .op = .neg, .is_swapped = false, .secondary_buf = 0, .secondary_offset = 0 },
+        .{ .op = .exp, .is_swapped = false, .secondary_buf = 0, .secondary_offset = 0 },
+    };
+    const silu_steps = [_]backend_mod.FusedEwStep{
+        .{ .op = .add, .is_swapped = false, .secondary_buf = 7, .secondary_offset = 0 },
+        .{ .op = .recip, .is_swapped = false, .secondary_buf = 0, .secondary_offset = 0 },
+        .{ .op = .mul, .is_swapped = true, .secondary_buf = 5, .secondary_offset = 0 },
+    };
+
+    var ops: [11]backend_mod.DeviceOp = undefined;
+    ops[0] = .{ .qmatmul = .{
+        .dst = 5,
+        .input = 0,
+        .weight_idx = 0,
+        .M = 2,
+        .N = 4,
+        .K = 4,
+    } };
+    ops[1] = .{ .fused_elementwise = .{
+        .steps = &exp_steps,
+        .n = 8,
+        .dst = 6,
+        .src = 5,
+        .dst_offset = 0,
+        .src_offset = 0,
+    } };
+    ops[2] = .{ .repeat = .{
+        .dst = 7,
+        .src = 8,
+        .n = 8,
+        .src_ne = .{ 1, 1, 1, 1 },
+        .dst_ne = .{ 4, 2, 1, 1 },
+        .src_strides = .{ 1, 1, 1, 1 },
+        .dst_strides = .{ 1, 4, 8, 8 },
+    } };
+    ops[3] = .{ .fused_elementwise = .{
+        .steps = &silu_steps,
+        .n = 8,
+        .dst = 9,
+        .src = 6,
+        .dst_offset = 0,
+        .src_offset = 0,
+    } };
+    ops[4] = .{ .qmatmul = .{
+        .dst = 5,
+        .input = 0,
+        .weight_idx = 0,
+        .M = 2,
+        .N = 4,
+        .K = 4,
+    } };
+    ops[5] = .{ .elementwise = .{
+        .op = .mul,
+        .dst = 10,
+        .src0 = 9,
+        .src1 = 5,
+        .n = 8,
+    } };
+    for (ops[6..11]) |*op| {
+        op.* = .{ .qmatmul = .{
+            .dst = 1,
+            .input = 0,
+            .weight_idx = 0,
+            .M = 2,
+            .N = 4,
+            .K = 4,
+        } };
+    }
+
+    const buf_sizes = [_]usize{ 8, 8, 8, 8, 8, 8, 8, 8, 1, 8, 8 };
+    const uploads = [_]backend_mod.ProgramIO{
+        .{ .buf_idx = 0, .host_ptr = @ptrCast(&input), .size = input.len * 4 },
+        .{ .buf_idx = 1, .host_ptr = @ptrCast(&filler), .size = filler.len * 4 },
+        .{ .buf_idx = 5, .host_ptr = @ptrCast(&shared_q_out), .size = shared_q_out.len * 4 },
+        .{ .buf_idx = 6, .host_ptr = @ptrCast(&exp_tmp), .size = exp_tmp.len * 4 },
+        .{ .buf_idx = 7, .host_ptr = @ptrCast(&repeat_out), .size = repeat_out.len * 4 },
+        .{ .buf_idx = 8, .host_ptr = @ptrCast(&one), .size = one.len * 4 },
+        .{ .buf_idx = 9, .host_ptr = @ptrCast(&silu_out), .size = silu_out.len * 4 },
+        .{ .buf_idx = 10, .host_ptr = @ptrCast(&product_out), .size = product_out.len * 4 },
+    };
+    const program = backend_mod.DeviceProgram{
+        .ops = &ops,
+        .n_buffers = 11,
+        .buffer_sizes = &buf_sizes,
+        .initial_uploads = &uploads,
+        .qweights = &qweights,
+    };
+
+    const handle = be.compileProgram(program) orelse return error.CompileFailed;
+    defer be.freeProgram(handle);
+
+    var got: [8]f32 = undefined;
+    var out = [_]backend_mod.ProgramIO{.{ .buf_idx = 10, .host_ptr = @ptrCast(&got), .size = got.len * 4 }};
+    be.executeProgram(handle, &.{}, &out);
+
+    for (input, got) |x, actual| {
+        const want = x * x / (1.0 + @exp(-x));
+        try std.testing.expectApproxEqAbs(want, actual, 1e-4);
+    }
+
+    const rt = be.getRuntimeProfile(handle).?;
+    try std.testing.expectEqual(@as(u64, 11), rt.backend_op_count);
+    try std.testing.expectEqual(@as(u64, 0), rt.fallback_op_count);
+    try std.testing.expectEqual(@as(u64, 1), rt.program_command_counts[@intFromEnum(program_mod.ProgramCommandKind.projection_pair_fused_elementwise_chain)]);
+}
+
+test "metal backend region fuses repeated secondary into fused elementwise" {
+    var metal = MetalBackend.init() catch |err| switch (err) {
+        error.MetalNotAvailable => return,
+        else => return err,
+    };
+    defer metal.deinit();
+    metal.setRegionProgramDispatch(true);
+    const be = metal.backend();
+
+    var q_input = [_]f32{ 1, 2, 3, 4 };
+    var q_out = [_]f32{0} ** 4;
+    var one = [_]f32{1};
+    var x = [_]f32{ 1, 3, 7, 15 };
+    var repeat_out = [_]f32{0} ** 4;
+    var fused_out = [_]f32{0} ** 4;
+    const qdata = [_]i8{
+        1, 0, 0, 0,
+        0, 1, 0, 0,
+        0, 0, 1, 0,
+        0, 0, 0, 1,
+    };
+    const scales = [_]f32{ 1, 1, 1, 1 };
+    const qweights = [_]backend_mod.QuantizedWeightUpload{.{ .data = &qdata, .scales = &scales, .rows = 4, .cols = 4, .block_size = 4 }};
+    const fused_steps = [_]backend_mod.FusedEwStep{
+        .{ .op = .add, .is_swapped = false, .secondary_buf = 4, .secondary_offset = 0 },
+        .{ .op = .recip, .is_swapped = false, .secondary_buf = 0, .secondary_offset = 0 },
+        .{ .op = .mul, .is_swapped = true, .secondary_buf = 3, .secondary_offset = 0 },
+    };
+
+    var ops: [9]backend_mod.DeviceOp = undefined;
+    for (ops[0..7]) |*op| {
+        op.* = .{ .qmatmul = .{
+            .dst = 1,
+            .input = 0,
+            .weight_idx = 0,
+            .M = 1,
+            .N = 4,
+            .K = 4,
+        } };
+    }
+    ops[7] = .{ .repeat = .{
+        .dst = 4,
+        .src = 2,
+        .n = 4,
+        .src_ne = .{ 1, 1, 1, 1 },
+        .dst_ne = .{ 4, 1, 1, 1 },
+        .src_strides = .{ 1, 1, 1, 1 },
+        .dst_strides = .{ 1, 4, 4, 4 },
+    } };
+    ops[8] = .{ .fused_elementwise = .{
+        .steps = &fused_steps,
+        .n = 4,
+        .dst = 5,
+        .src = 3,
+        .dst_offset = 0,
+        .src_offset = 0,
+    } };
+
+    const buf_sizes = [_]usize{ 4, 4, 1, 4, 4, 4 };
+    const uploads = [_]backend_mod.ProgramIO{
+        .{ .buf_idx = 0, .host_ptr = @ptrCast(&q_input), .size = q_input.len * 4 },
+        .{ .buf_idx = 1, .host_ptr = @ptrCast(&q_out), .size = q_out.len * 4 },
+        .{ .buf_idx = 2, .host_ptr = @ptrCast(&one), .size = one.len * 4 },
+        .{ .buf_idx = 3, .host_ptr = @ptrCast(&x), .size = x.len * 4 },
+        .{ .buf_idx = 4, .host_ptr = @ptrCast(&repeat_out), .size = repeat_out.len * 4 },
+        .{ .buf_idx = 5, .host_ptr = @ptrCast(&fused_out), .size = fused_out.len * 4 },
+    };
+    const program = backend_mod.DeviceProgram{
+        .ops = &ops,
+        .n_buffers = 6,
+        .buffer_sizes = &buf_sizes,
+        .initial_uploads = &uploads,
+        .qweights = &qweights,
+    };
+
+    const handle = be.compileProgram(program) orelse return error.CompileFailed;
+    defer be.freeProgram(handle);
+
+    var got: [4]f32 = undefined;
+    var out = [_]backend_mod.ProgramIO{.{ .buf_idx = 5, .host_ptr = @ptrCast(&got), .size = got.len * 4 }};
+    be.executeProgram(handle, &.{}, &out);
+
+    const expected = [_]f32{ 0.5, 0.75, 0.875, 0.9375 };
+    for (expected, got) |want, actual| {
+        try std.testing.expectApproxEqAbs(want, actual, 1e-5);
+    }
+
+    const rt = be.getRuntimeProfile(handle).?;
+    try std.testing.expectEqual(@as(u64, 9), rt.backend_op_count);
+    try std.testing.expectEqual(@as(u64, 0), rt.fallback_op_count);
+    try std.testing.expectEqual(@as(u64, 8), rt.backend_dispatch_count);
+    try std.testing.expectEqual(@as(u64, 1), rt.program_command_counts[@intFromEnum(program_mod.ProgramCommandKind.repeat_fused_elementwise_chain)]);
 }
 
 test "metal backend region fuses cache-store sidecars" {

--- a/src/backend/metal.zig
+++ b/src/backend/metal.zig
@@ -3129,50 +3129,36 @@ const CompiledProgram = struct {
         }
     }
 
-    fn tryEncodeQMatvecBatchRun(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, start: usize, skipped: []bool) bool {
-        const selection = program_mod.findProjectionGroup(
-            ops,
-            start,
-            program_mod.ProjectionGroupPolicy.decodeQMatvec(MAX_QMATVEC_BATCH),
-            skipped,
-        ) orelse return false;
-        for (selection.anchorIndices()) |idx| {
-            if (!self.canEncodeQMatvecBatchOp(ops[idx].qmatmul)) return false;
-        }
+    fn tryEncodeProjectionCommand(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, command: program_mod.ProgramCommand) bool {
+        switch (command.projection_kind) {
+            .qmatvec => {
+                for (command.anchorIndices()) |idx| {
+                    if (!self.canEncodeQMatvecBatchOp(ops[idx].qmatmul)) return false;
+                }
 
-        const t0 = nowNs();
-        self.encodeQMatvecBatch(ops, selection.anchorIndices());
-        self.recordRegionFusedRunFromIndices(ops, selection.anchorIndices(), @intCast(nowNs() - t0));
-        for (selection.anchorIndices()) |idx| skipped[idx] = true;
-        return true;
-    }
+                const t0 = nowNs();
+                self.encodeQMatvecBatch(ops, command.anchorIndices());
+                self.recordRegionFusedRunFromIndices(ops, command.anchorIndices(), @intCast(nowNs() - t0));
+                return true;
+            },
+            .qmatmul => {
+                for (command.anchorIndices()) |idx| {
+                    if (!self.canEncodeQMatmulBatchOp(ops[idx].qmatmul)) return false;
+                }
+                for (command.sidecarIndices(), 0..) |maybe_idx, slot| {
+                    const idx = maybe_idx orelse continue;
+                    if (!self.canFuseQMatmulSliceAssign(ops[command.indices[slot]].qmatmul, ops[idx].slice_assign)) return false;
+                }
 
-    fn tryEncodeQMatmulBatchRun(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, start: usize, skipped: []bool) bool {
-        const selection = program_mod.findProjectionGroup(
-            ops,
-            start,
-            program_mod.ProjectionGroupPolicy.prefillQMatmul(MAX_QMATMUL_BATCH),
-            skipped,
-        ) orelse return false;
-        for (selection.anchorIndices()) |idx| {
-            if (!self.canEncodeQMatmulBatchOp(ops[idx].qmatmul)) return false;
+                const t0 = nowNs();
+                self.encodeQMatmulBatch(ops, command.anchorIndices(), command.sidecarIndices());
+                self.recordRegionFusedRunFromIndices(ops, command.anchorIndices(), @intCast(nowNs() - t0));
+                for (command.sidecarIndices()) |maybe_idx| {
+                    if (maybe_idx) |idx| self.recordRegionBackendOp(ops[idx], 0);
+                }
+                return true;
+            },
         }
-        for (selection.sidecarIndices(), 0..) |maybe_idx, slot| {
-            const idx = maybe_idx orelse continue;
-            if (!self.canFuseQMatmulSliceAssign(ops[selection.indices[slot]].qmatmul, ops[idx].slice_assign)) return false;
-        }
-
-        const t0 = nowNs();
-        self.encodeQMatmulBatch(ops, selection.anchorIndices(), selection.sidecarIndices());
-        self.recordRegionFusedRunFromIndices(ops, selection.anchorIndices(), @intCast(nowNs() - t0));
-        for (selection.anchorIndices()) |idx| skipped[idx] = true;
-        for (selection.sidecarIndices()) |maybe_idx| {
-            if (maybe_idx) |idx| {
-                self.recordRegionBackendOp(ops[idx], 0);
-                skipped[idx] = true;
-            }
-        }
-        return true;
     }
 
     fn tryEncodeElementwiseBatchRun(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, start: usize, skipped: []bool) bool {
@@ -3281,14 +3267,20 @@ const CompiledProgram = struct {
         return encoded;
     }
 
-    fn tryEncodeStageCommand(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, start: usize) usize {
-        const command = program_mod.findStageCommand(ops, start) orelse return 0;
+    fn tryEncodeProgramCommand(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, start: usize, skipped: []bool) usize {
+        const command = program_mod.findProgramCommand(
+            ops,
+            start,
+            program_mod.CommandStreamPolicy.metal(MAX_QMATVEC_BATCH, MAX_QMATMUL_BATCH),
+            skipped,
+        ) orelse return 0;
         const end = start + @as(usize, command.op_count);
         if (end > ops.len) return 0;
 
         const t0 = nowNs();
         const encoded = switch (command.kind) {
             .op => false,
+            .projection_group => self.tryEncodeProjectionCommand(ops, command),
             .row_chain => switch (ops[start]) {
                 .rmsnorm => |rn| switch (ops[start + 1]) {
                     .repeat => |rp| switch (ops[start + 2]) {
@@ -3313,8 +3305,11 @@ const CompiledProgram = struct {
         };
 
         if (!encoded) return 0;
-        self.recordRegionFusedRun(ops[start..end], @intCast(nowNs() - t0));
-        return command.op_count;
+        if (command.kind != .projection_group) {
+            self.recordRegionFusedRun(ops[start..end], @intCast(nowNs() - t0));
+        }
+        program_mod.markProgramCommandUsed(skipped, command);
+        return command.advanceCount();
     }
 
     fn tryEncodeAttentionBatchRun(self: *CompiledProgram, ops: []const backend_mod.DeviceOp) usize {
@@ -3369,22 +3364,14 @@ const CompiledProgram = struct {
                 i += slice_assign_batch_len;
                 continue;
             }
-            if (self.tryEncodeQMatmulBatchRun(ops, i, skipped[0..ops.len])) {
-                i += 1;
-                continue;
-            }
-            if (self.tryEncodeQMatvecBatchRun(ops, i, skipped[0..ops.len])) {
-                i += 1;
+            const command_advance = self.tryEncodeProgramCommand(ops, i, skipped[0..ops.len]);
+            if (command_advance > 0) {
+                i += command_advance;
                 continue;
             }
             const attention_batch_len = self.tryEncodeAttentionBatchRun(ops[i..]);
             if (attention_batch_len > 0) {
                 i += attention_batch_len;
-                continue;
-            }
-            const stage_command_len = self.tryEncodeStageCommand(ops, i);
-            if (stage_command_len > 0) {
-                i += stage_command_len;
                 continue;
             }
             if (i + 1 < ops.len and self.tryEncodeRegionFusedPair(ops[i], ops[i + 1])) {

--- a/src/backend/metal.zig
+++ b/src/backend/metal.zig
@@ -1230,6 +1230,156 @@ const shader_source =
     \\    }
     \\}
     \\
+    \\struct AttentionRopeStoreBatchParams {
+    \\    uint n_heads; uint d_head; uint seq_q; uint seq_kv;
+    \\    float scale;
+    \\    uint rope_half_d;
+    \\    uint rope_src_off[MAX_ATTENTION_STORE_BATCH_HEADS];
+    \\    uint rope_cs_off[MAX_ATTENTION_STORE_BATCH_HEADS];
+    \\    uint k_off[MAX_ATTENTION_STORE_BATCH_HEADS];
+    \\    uint v_off[MAX_ATTENTION_STORE_BATCH_HEADS];
+    \\    uint mask_off[MAX_ATTENTION_STORE_BATCH_HEADS];
+    \\    uint dst_off[MAX_ATTENTION_STORE_BATCH_HEADS];
+    \\    uint slice_dst_offset[MAX_ATTENTION_STORE_BATCH_HEADS];
+    \\    uint rope_src_rs; uint rope_src_cs; uint rope_cs_cs;
+    \\    uint k_rs; uint k_cs; uint v_rs; uint v_cs;
+    \\    uint mask_rs; uint mask_cs; uint dst_rs; uint dst_cs;
+    \\    uint slice_dst_row_stride; uint slice_dst_col_stride;
+    \\};
+    \\
+    \\inline float rope_batch_q_value(
+    \\    device const float* q_src,
+    \\    device const float* cos_sin,
+    \\    constant AttentionRopeStoreBatchParams& p,
+    \\    uint head,
+    \\    uint r,
+    \\    uint q_col
+    \\) {
+    \\    uint i = r;
+    \\    bool high = false;
+    \\    if (i >= p.rope_half_d) {
+    \\        i -= p.rope_half_d;
+    \\        high = true;
+    \\    }
+    \\    float cos_val = cos_sin[p.rope_cs_off[head] + q_col * p.rope_cs_cs + i];
+    \\    float sin_val = cos_sin[p.rope_cs_off[head] + q_col * p.rope_cs_cs + p.rope_half_d + i];
+    \\    float x_lo = q_src[p.rope_src_off[head] + q_col * p.rope_src_cs + i * p.rope_src_rs];
+    \\    float x_hi = q_src[p.rope_src_off[head] + q_col * p.rope_src_cs + (i + p.rope_half_d) * p.rope_src_rs];
+    \\    return high ? (x_hi * cos_val + x_lo * sin_val) : (x_lo * cos_val - x_hi * sin_val);
+    \\}
+    \\
+    \\kernel void attention_rope_store_batch_f32(
+    \\    device const float* q_src0     [[buffer(0)]],
+    \\    device const float* q_src1     [[buffer(1)]],
+    \\    device const float* q_src2     [[buffer(2)]],
+    \\    device const float* q_src3     [[buffer(3)]],
+    \\    device const float* cos_sin0   [[buffer(4)]],
+    \\    device const float* cos_sin1   [[buffer(5)]],
+    \\    device const float* cos_sin2   [[buffer(6)]],
+    \\    device const float* cos_sin3   [[buffer(7)]],
+    \\    device const float* K0         [[buffer(8)]],
+    \\    device const float* K1         [[buffer(9)]],
+    \\    device const float* K2         [[buffer(10)]],
+    \\    device const float* K3         [[buffer(11)]],
+    \\    device const float* V0         [[buffer(12)]],
+    \\    device const float* V1         [[buffer(13)]],
+    \\    device const float* V2         [[buffer(14)]],
+    \\    device const float* V3         [[buffer(15)]],
+    \\    device const float* mask0      [[buffer(16)]],
+    \\    device const float* mask1      [[buffer(17)]],
+    \\    device const float* mask2      [[buffer(18)]],
+    \\    device const float* mask3      [[buffer(19)]],
+    \\    device float*       dst0       [[buffer(20)]],
+    \\    device float*       dst1       [[buffer(21)]],
+    \\    device float*       dst2       [[buffer(22)]],
+    \\    device float*       dst3       [[buffer(23)]],
+    \\    device float*       slice_dst0 [[buffer(24)]],
+    \\    device float*       slice_dst1 [[buffer(25)]],
+    \\    device float*       slice_dst2 [[buffer(26)]],
+    \\    device float*       slice_dst3 [[buffer(27)]],
+    \\    constant AttentionRopeStoreBatchParams& p [[buffer(28)]],
+    \\    uint2 group [[threadgroup_position_in_grid]],
+    \\    uint tid     [[thread_index_in_threadgroup]]
+    \\) {
+    \\    uint q_col = group.x;
+    \\    uint head = group.y;
+    \\    if (q_col >= p.seq_q) return;
+    \\    if (head >= p.n_heads) return;
+    \\    const uint tg_size = 256;
+    \\
+    \\    device const float* q_src = q_src0;
+    \\    device const float* cos_sin = cos_sin0;
+    \\    device const float* K = K0;
+    \\    device const float* V = V0;
+    \\    device const float* mask = mask0;
+    \\    device float* dst = dst0;
+    \\    device float* slice_dst = slice_dst0;
+    \\    if (head == 1) {
+    \\        q_src = q_src1; cos_sin = cos_sin1; K = K1; V = V1; mask = mask1; dst = dst1; slice_dst = slice_dst1;
+    \\    } else if (head == 2) {
+    \\        q_src = q_src2; cos_sin = cos_sin2; K = K2; V = V2; mask = mask2; dst = dst2; slice_dst = slice_dst2;
+    \\    } else if (head == 3) {
+    \\        q_src = q_src3; cos_sin = cos_sin3; K = K3; V = V3; mask = mask3; dst = dst3; slice_dst = slice_dst3;
+    \\    }
+    \\
+    \\    threadgroup float scores[MAX_SEQ];
+    \\    threadgroup float scratch[256];
+    \\
+    \\    uint k_off = p.k_off[head];
+    \\    uint v_off = p.v_off[head];
+    \\    uint mask_off = p.mask_off[head];
+    \\    uint dst_off = p.dst_off[head];
+    \\    uint slice_dst_off = p.slice_dst_offset[head];
+    \\
+    \\    for (uint s = tid; s < p.seq_kv; s += tg_size) {
+    \\        float mv = mask[mask_off + s * p.mask_rs + q_col * p.mask_cs];
+    \\        if (!isfinite(mv)) { scores[s] = -INFINITY; continue; }
+    \\        float dot = 0.0f;
+    \\        for (uint r = 0; r < p.d_head; r++)
+    \\            dot += rope_batch_q_value(q_src, cos_sin, p, head, r, q_col) * K[k_off + r * p.k_rs + s * p.k_cs];
+    \\        scores[s] = dot * p.scale + mv;
+    \\    }
+    \\    threadgroup_barrier(mem_flags::mem_threadgroup);
+    \\
+    \\    float local_max = -INFINITY;
+    \\    for (uint s = tid; s < p.seq_kv; s += tg_size)
+    \\        local_max = max(local_max, scores[s]);
+    \\    scratch[tid] = local_max;
+    \\    threadgroup_barrier(mem_flags::mem_threadgroup);
+    \\    for (uint stride = tg_size / 2; stride > 0; stride /= 2) {
+    \\        if (tid < stride) scratch[tid] = max(scratch[tid], scratch[tid + stride]);
+    \\        threadgroup_barrier(mem_flags::mem_threadgroup);
+    \\    }
+    \\    float global_max = scratch[0];
+    \\    threadgroup_barrier(mem_flags::mem_threadgroup);
+    \\
+    \\    float local_sum = 0.0f;
+    \\    for (uint s = tid; s < p.seq_kv; s += tg_size) {
+    \\        float w = (scores[s] == -INFINITY) ? 0.0f : exp(scores[s] - global_max);
+    \\        scores[s] = w;
+    \\        local_sum += w;
+    \\    }
+    \\    scratch[tid] = local_sum;
+    \\    threadgroup_barrier(mem_flags::mem_threadgroup);
+    \\    for (uint stride = tg_size / 2; stride > 0; stride /= 2) {
+    \\        if (tid < stride) scratch[tid] += scratch[tid + stride];
+    \\        threadgroup_barrier(mem_flags::mem_threadgroup);
+    \\    }
+    \\    float inv_sum = (scratch[0] > 0.0f) ? 1.0f / scratch[0] : 0.0f;
+    \\    threadgroup_barrier(mem_flags::mem_threadgroup);
+    \\
+    \\    for (uint s = tid; s < p.seq_kv; s += tg_size)
+    \\        scores[s] *= inv_sum;
+    \\    threadgroup_barrier(mem_flags::mem_threadgroup);
+    \\
+    \\    for (uint r = tid; r < p.d_head; r += tg_size) {
+    \\        float val = 0.0f;
+    \\        for (uint s = 0; s < p.seq_kv; s++)
+    \\            val += scores[s] * V[v_off + r * p.v_rs + s * p.v_cs];
+    \\        slice_dst[slice_dst_off + r * p.slice_dst_row_stride + q_col * p.slice_dst_col_stride] = val;
+    \\    }
+    \\}
+    \\
     \\struct AttentionBatchParams {
     \\    uint n_heads; uint d_head; uint seq_q; uint seq_kv;
     \\    float scale;
@@ -2123,6 +2273,35 @@ const AttentionRopeStoreParams = extern struct {
 const MAX_ATTENTION_BATCH_HEADS: usize = 16;
 const MAX_ATTENTION_STORE_BATCH_HEADS: usize = 4;
 
+const AttentionRopeStoreBatchParams = extern struct {
+    n_heads: u32,
+    d_head: u32,
+    seq_q: u32,
+    seq_kv: u32,
+    scale: f32,
+    rope_half_d: u32,
+    rope_src_off: [MAX_ATTENTION_STORE_BATCH_HEADS]u32,
+    rope_cs_off: [MAX_ATTENTION_STORE_BATCH_HEADS]u32,
+    k_off: [MAX_ATTENTION_STORE_BATCH_HEADS]u32,
+    v_off: [MAX_ATTENTION_STORE_BATCH_HEADS]u32,
+    mask_off: [MAX_ATTENTION_STORE_BATCH_HEADS]u32,
+    dst_off: [MAX_ATTENTION_STORE_BATCH_HEADS]u32,
+    slice_dst_offset: [MAX_ATTENTION_STORE_BATCH_HEADS]u32,
+    rope_src_rs: u32,
+    rope_src_cs: u32,
+    rope_cs_cs: u32,
+    k_rs: u32,
+    k_cs: u32,
+    v_rs: u32,
+    v_cs: u32,
+    mask_rs: u32,
+    mask_cs: u32,
+    dst_rs: u32,
+    dst_cs: u32,
+    slice_dst_row_stride: u32,
+    slice_dst_col_stride: u32,
+};
+
 const AttentionBatchParams = extern struct {
     n_heads: u32,
     d_head: u32,
@@ -2563,6 +2742,7 @@ pub const MetalBackend = struct {
     attention_slice_assign_pipeline: *anyopaque,
     attention_store_pipeline: *anyopaque,
     attention_rope_store_pipeline: *anyopaque,
+    attention_rope_store_batch_pipeline: *anyopaque,
     attention_store_batch_pipeline: *anyopaque,
     attention_batch_pipeline: *anyopaque,
     compute_pipeline: *anyopaque,
@@ -2623,6 +2803,8 @@ pub const MetalBackend = struct {
         errdefer c.mtl_release(attention_store_pipeline);
         const attention_rope_store_pipeline = c.mtl_create_pipeline(device, library, "attention_rope_store_f32") orelse return error.PipelineCreateFailed;
         errdefer c.mtl_release(attention_rope_store_pipeline);
+        const attention_rope_store_batch_pipeline = c.mtl_create_pipeline(device, library, "attention_rope_store_batch_f32") orelse return error.PipelineCreateFailed;
+        errdefer c.mtl_release(attention_rope_store_batch_pipeline);
         const attention_store_batch_pipeline = c.mtl_create_pipeline(device, library, "attention_store_batch_f32") orelse return error.PipelineCreateFailed;
         errdefer c.mtl_release(attention_store_batch_pipeline);
         const attention_batch_pipeline = c.mtl_create_pipeline(device, library, "attention_batch_f32") orelse return error.PipelineCreateFailed;
@@ -2656,6 +2838,7 @@ pub const MetalBackend = struct {
             .attention_slice_assign_pipeline = attention_slice_assign_pipeline,
             .attention_store_pipeline = attention_store_pipeline,
             .attention_rope_store_pipeline = attention_rope_store_pipeline,
+            .attention_rope_store_batch_pipeline = attention_rope_store_batch_pipeline,
             .attention_store_batch_pipeline = attention_store_batch_pipeline,
             .attention_batch_pipeline = attention_batch_pipeline,
             .compute_pipeline = compute_pipeline,
@@ -2672,6 +2855,7 @@ pub const MetalBackend = struct {
         c.mtl_release(self.compute_pipeline);
         c.mtl_release(self.attention_batch_pipeline);
         c.mtl_release(self.attention_store_batch_pipeline);
+        c.mtl_release(self.attention_rope_store_batch_pipeline);
         c.mtl_release(self.attention_rope_store_pipeline);
         c.mtl_release(self.attention_store_pipeline);
         c.mtl_release(self.attention_slice_assign_pipeline);
@@ -3645,6 +3829,128 @@ const CompiledProgram = struct {
         return true;
     }
 
+    fn canEncodeAttentionRopeStoreBatchCommand(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, command: program_mod.ProgramCommand) bool {
+        _ = self;
+        if (command.sidecar_count < 2 or command.sidecar_count > MAX_ATTENTION_STORE_BATCH_HEADS) return false;
+        if (command.anchor_count != command.sidecar_count * 2) return false;
+        const first_rope_idx = command.indices[0];
+        const first_att_idx = command.indices[1];
+        const first_sa_idx = command.sidecar_indices[0] orelse return false;
+        if (first_rope_idx >= ops.len or first_att_idx >= ops.len or first_sa_idx >= ops.len) return false;
+        const first_rope = switch (ops[first_rope_idx]) {
+            .rope => |rr| rr,
+            else => return false,
+        };
+        const first_att = switch (ops[first_att_idx]) {
+            .attention => |att| att,
+            else => return false,
+        };
+        const first_sa = switch (ops[first_sa_idx]) {
+            .slice_assign => |sa| sa,
+            else => return false,
+        };
+        if (!canEncodeAttention(first_att)) return false;
+        if (!program_mod.ropeAttentionCompatible(first_rope, first_att)) return false;
+        if (!program_mod.attentionSliceStoreCompatible(first_att, first_sa)) return false;
+        if (!program_mod.canFuseAttentionStoreSidecar(ops, first_att_idx, first_sa_idx, first_sa)) return false;
+
+        var i: usize = 1;
+        while (i < command.sidecar_count) : (i += 1) {
+            const rope_idx = command.indices[i * 2];
+            const att_idx = command.indices[i * 2 + 1];
+            const sa_idx = command.sidecar_indices[i] orelse return false;
+            if (rope_idx >= ops.len or att_idx >= ops.len or sa_idx >= ops.len) return false;
+            const rr = switch (ops[rope_idx]) {
+                .rope => |rr| rr,
+                else => return false,
+            };
+            const att = switch (ops[att_idx]) {
+                .attention => |att| att,
+                else => return false,
+            };
+            const sa = switch (ops[sa_idx]) {
+                .slice_assign => |sa| sa,
+                else => return false,
+            };
+            if (!canEncodeAttention(att)) return false;
+            if (!program_mod.ropeAttentionCompatible(rr, att)) return false;
+            if (!program_mod.ropeStoreBatchGeometryCompatible(first_rope, rr)) return false;
+            if (!program_mod.attentionGeometryCompatible(first_att, att)) return false;
+            if (!program_mod.attentionSliceStoreCompatible(att, sa)) return false;
+            if (!program_mod.canFuseAttentionStoreSidecar(ops, att_idx, sa_idx, sa)) return false;
+            if (sa.dst_row_stride != first_sa.dst_row_stride or
+                sa.dst_col_stride != first_sa.dst_col_stride) return false;
+        }
+        return true;
+    }
+
+    fn encodeAttentionRopeStoreBatchCommand(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, command: program_mod.ProgramCommand) void {
+        const first_rope = ops[command.indices[0]].rope;
+        const first_att = ops[command.indices[1]].attention;
+        const first_sa = ops[command.sidecar_indices[0].?].slice_assign;
+        const q_src_base = 0;
+        const cos_sin_base = q_src_base + MAX_ATTENTION_STORE_BATCH_HEADS;
+        const k_base = cos_sin_base + MAX_ATTENTION_STORE_BATCH_HEADS;
+        const v_base = k_base + MAX_ATTENTION_STORE_BATCH_HEADS;
+        const mask_base = v_base + MAX_ATTENTION_STORE_BATCH_HEADS;
+        const dst_base = mask_base + MAX_ATTENTION_STORE_BATCH_HEADS;
+        const slice_dst_base = dst_base + MAX_ATTENTION_STORE_BATCH_HEADS;
+        var buffers: [MAX_ATTENTION_STORE_BATCH_HEADS * 7]DeviceBuffer = undefined;
+        for (0..MAX_ATTENTION_STORE_BATCH_HEADS) |i| {
+            buffers[q_src_base + i] = self.device_bufs[first_rope.src];
+            buffers[cos_sin_base + i] = self.device_bufs[first_rope.cos_sin];
+            buffers[k_base + i] = self.device_bufs[first_att.k];
+            buffers[v_base + i] = self.device_bufs[first_att.v];
+            buffers[mask_base + i] = self.device_bufs[first_att.mask];
+            buffers[dst_base + i] = self.device_bufs[first_att.dst];
+            buffers[slice_dst_base + i] = self.device_bufs[first_sa.dst];
+        }
+
+        var params = std.mem.zeroes(AttentionRopeStoreBatchParams);
+        params.n_heads = @intCast(command.sidecar_count);
+        params.d_head = first_att.d_head;
+        params.seq_q = first_att.seq_q;
+        params.seq_kv = first_att.seq_kv;
+        params.scale = first_att.scale;
+        params.rope_half_d = first_rope.half_d;
+        params.rope_src_rs = first_rope.src_rs;
+        params.rope_src_cs = first_rope.src_cs;
+        params.rope_cs_cs = first_rope.cs_cs;
+        params.k_rs = first_att.k_rs;
+        params.k_cs = first_att.k_cs;
+        params.v_rs = first_att.v_rs;
+        params.v_cs = first_att.v_cs;
+        params.mask_rs = first_att.mask_rs;
+        params.mask_cs = first_att.mask_cs;
+        params.dst_rs = first_att.dst_rs;
+        params.dst_cs = first_att.dst_cs;
+        params.slice_dst_row_stride = first_sa.dst_row_stride;
+        params.slice_dst_col_stride = first_sa.dst_col_stride;
+
+        var i: usize = 0;
+        while (i < command.sidecar_count) : (i += 1) {
+            const rr = ops[command.indices[i * 2]].rope;
+            const att = ops[command.indices[i * 2 + 1]].attention;
+            const sa = ops[command.sidecar_indices[i].?].slice_assign;
+            buffers[q_src_base + i] = self.device_bufs[rr.src];
+            buffers[cos_sin_base + i] = self.device_bufs[rr.cos_sin];
+            buffers[k_base + i] = self.device_bufs[att.k];
+            buffers[v_base + i] = self.device_bufs[att.v];
+            buffers[mask_base + i] = self.device_bufs[att.mask];
+            buffers[dst_base + i] = self.device_bufs[att.dst];
+            buffers[slice_dst_base + i] = self.device_bufs[sa.dst];
+            params.rope_src_off[i] = rr.src_off;
+            params.rope_cs_off[i] = rr.cs_off;
+            params.k_off[i] = att.k_off;
+            params.v_off[i] = att.v_off;
+            params.mask_off[i] = att.mask_off;
+            params.dst_off[i] = att.dst_off;
+            params.slice_dst_offset[i] = sa.dst_offset;
+        }
+
+        self.encodeTyped(AttentionRopeStoreBatchParams, self.backend.attention_rope_store_batch_pipeline, &buffers, params, @intCast(buffers.len), .{ .gx = first_att.seq_q, .gy = @intCast(command.sidecar_count) }, WG_SIZE);
+    }
+
     fn canEncodeAttentionStoreBatchCommand(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, command: program_mod.ProgramCommand) bool {
         _ = self;
         if (command.anchor_count < 2 or command.anchor_count > MAX_ATTENTION_STORE_BATCH_HEADS) return false;
@@ -4026,6 +4332,11 @@ const CompiledProgram = struct {
                 };
                 break :blk self.encodeAttentionRopeStore(rr, att, sa);
             },
+            .rope_attention_store_group => blk: {
+                if (!self.canEncodeAttentionRopeStoreBatchCommand(ops, command)) break :blk false;
+                self.encodeAttentionRopeStoreBatchCommand(ops, command);
+                break :blk true;
+            },
             .attention_batch => blk: {
                 const n: usize = @intCast(command.op_count);
                 if (self.attentionBatchRunLen(ops[start..]) < n) break :blk false;
@@ -4099,7 +4410,7 @@ const CompiledProgram = struct {
             self.runtime_profile.recordProgramCommandFailed(command.kind);
             return false;
         }
-        if (command.kind == .attention_store_chain or command.kind == .attention_store_group or command.kind == .rope_attention_store_chain) {
+        if (command.kind == .attention_store_chain or command.kind == .attention_store_group or command.kind == .rope_attention_store_chain or command.kind == .rope_attention_store_group) {
             var record_indices: [program_mod.max_projection_group_anchors * 2]usize = undefined;
             var record_count: usize = 0;
             for (command.anchorIndices()) |idx| appendCommandIndex(&record_indices, &record_count, idx);
@@ -4140,6 +4451,7 @@ const CompiledProgram = struct {
             .attention_store_chain,
             .attention_store_group,
             .rope_attention_store_chain,
+            .rope_attention_store_group,
             .attention_group,
             .movement_group,
             .elementwise_batch,
@@ -5655,4 +5967,155 @@ test "metal backend fuses rope attention output store chains" {
     const rt = be.getRuntimeProfile(handle).?;
     try std.testing.expectEqual(@as(u64, 0), rt.fallback_op_count);
     try std.testing.expectEqual(@as(u64, 1), rt.program_command_counts[@intFromEnum(program_mod.ProgramCommandKind.rope_attention_store_chain)]);
+}
+
+test "metal backend groups rope attention output stores with aliased scratch" {
+    var metal = MetalBackend.init() catch |err| switch (err) {
+        error.MetalNotAvailable => return,
+        else => return err,
+    };
+    defer metal.deinit();
+    metal.setRegionProgramDispatch(true);
+    const be = metal.backend();
+
+    var q0 = [_]f32{ 1, 0 };
+    var q1 = [_]f32{ 0, 1 };
+    var cos_sin = [_]f32{ 1, 0 };
+    var k_cache = [_]f32{ 1, 0, 0, 1 };
+    var v_cache = [_]f32{ 10, 20, 30, 40 };
+    var mask = [_]f32{ 0, 0 };
+    var scratch = [_]f32{ -9, -9 };
+    var slice_dst = [_]f32{ -1, -1, -1, -1 };
+    var unused = [_]f32{0} ** 2;
+    const qdata = [_]i8{
+        1, 0,
+        0, 1,
+    };
+    const scales = [_]f32{ 1, 1 };
+    const qweights = [_]backend_mod.QuantizedWeightUpload{.{ .data = &qdata, .scales = &scales, .rows = 2, .cols = 2, .block_size = 2 }};
+
+    var ops: [13]backend_mod.DeviceOp = undefined;
+    for (ops[0..7]) |*op| {
+        op.* = .{ .qmatmul = .{
+            .dst = 8,
+            .input = 0,
+            .weight_idx = 0,
+            .M = 1,
+            .N = 2,
+            .K = 2,
+        } };
+    }
+    ops[7] = .{ .rope = .{
+        .dst = 6,
+        .src = 0,
+        .cos_sin = 2,
+        .half_d = 1,
+        .seq_len = 1,
+        .src_off = 0,
+        .cs_off = 0,
+        .dst_off = 0,
+        .src_rs = 1,
+        .src_cs = 2,
+        .cs_cs = 1,
+    } };
+    ops[8] = .{ .attention = .{
+        .dst = 6,
+        .q = 6,
+        .k = 3,
+        .v = 4,
+        .mask = 5,
+        .has_mask = true,
+        .d_head = 2,
+        .seq_q = 1,
+        .seq_kv = 2,
+        .scale = 1,
+        .q_off = 0,
+        .k_off = 0,
+        .v_off = 0,
+        .mask_off = 0,
+        .dst_off = 0,
+        .q_rs = 1,
+        .q_cs = 2,
+        .k_rs = 1,
+        .k_cs = 2,
+        .v_rs = 1,
+        .v_cs = 2,
+        .mask_rs = 1,
+        .mask_cs = 2,
+        .dst_rs = 1,
+        .dst_cs = 2,
+    } };
+    ops[9] = .{ .slice_assign = .{
+        .dst = 7,
+        .src = 6,
+        .rows = 2,
+        .cols = 1,
+        .dst_base_offset = 0,
+        .dst_offset = 0,
+        .dst_row_stride = 1,
+        .dst_col_stride = 4,
+        .src_offset = 0,
+        .src_row_stride = 1,
+        .src_col_stride = 2,
+        .patch_stride = 4,
+    } };
+    ops[10] = .{ .rope = .{
+        .dst = 6,
+        .src = 1,
+        .cos_sin = 2,
+        .half_d = 1,
+        .seq_len = 1,
+        .src_off = 0,
+        .cs_off = 0,
+        .dst_off = 0,
+        .src_rs = 1,
+        .src_cs = 2,
+        .cs_cs = 1,
+    } };
+    ops[11] = ops[8];
+    ops[12] = ops[9];
+    ops[12].slice_assign.dst_offset = 2;
+
+    const buf_sizes = [_]usize{ 2, 2, 2, 4, 4, 2, 2, 4, 2 };
+    const uploads = [_]backend_mod.ProgramIO{
+        .{ .buf_idx = 0, .host_ptr = @ptrCast(&q0), .size = 2 * 4 },
+        .{ .buf_idx = 1, .host_ptr = @ptrCast(&q1), .size = 2 * 4 },
+        .{ .buf_idx = 2, .host_ptr = @ptrCast(&cos_sin), .size = 2 * 4 },
+        .{ .buf_idx = 3, .host_ptr = @ptrCast(&k_cache), .size = 4 * 4 },
+        .{ .buf_idx = 4, .host_ptr = @ptrCast(&v_cache), .size = 4 * 4 },
+        .{ .buf_idx = 5, .host_ptr = @ptrCast(&mask), .size = 2 * 4 },
+        .{ .buf_idx = 6, .host_ptr = @ptrCast(&scratch), .size = 2 * 4 },
+        .{ .buf_idx = 7, .host_ptr = @ptrCast(&slice_dst), .size = 4 * 4 },
+        .{ .buf_idx = 8, .host_ptr = @ptrCast(&unused), .size = 2 * 4 },
+    };
+    const program = backend_mod.DeviceProgram{
+        .ops = &ops,
+        .n_buffers = 9,
+        .buffer_sizes = &buf_sizes,
+        .initial_uploads = &uploads,
+        .qweights = &qweights,
+    };
+
+    const handle = be.compileProgram(program) orelse return error.CompileFailed;
+    defer be.freeProgram(handle);
+
+    var got_slice: [4]f32 = undefined;
+    var out = [_]backend_mod.ProgramIO{.{ .buf_idx = 7, .host_ptr = @ptrCast(&got_slice), .size = 4 * 4 }};
+    be.executeProgram(handle, &.{}, &out);
+
+    const hi: f32 = @exp(@as(f32, 1.0)) / (@exp(@as(f32, 1.0)) + 1.0);
+    const lo: f32 = 1.0 / (@exp(@as(f32, 1.0)) + 1.0);
+    const expected = [_]f32{
+        hi * 10 + lo * 30,
+        hi * 20 + lo * 40,
+        lo * 10 + hi * 30,
+        lo * 20 + hi * 40,
+    };
+    for (expected, got_slice) |want, actual| {
+        try std.testing.expectApproxEqAbs(want, actual, 1e-4);
+    }
+
+    const rt = be.getRuntimeProfile(handle).?;
+    try std.testing.expectEqual(@as(u64, 0), rt.fallback_op_count);
+    try std.testing.expectEqual(@as(u64, 1), rt.program_command_counts[@intFromEnum(program_mod.ProgramCommandKind.rope_attention_store_group)]);
 }

--- a/src/backend/metal.zig
+++ b/src/backend/metal.zig
@@ -3412,12 +3412,6 @@ const CompiledProgram = struct {
         self.runtime_profile.time_ns[tag] +%= elapsed_ns;
     }
 
-    fn recordRegionFusedPair(self: *CompiledProgram, a: backend_mod.DeviceOp, b: backend_mod.DeviceOp, elapsed_ns: u64) void {
-        const first = elapsed_ns / 2;
-        self.recordRegionBackendOp(a, first);
-        self.recordRegionBackendOp(b, elapsed_ns - first);
-    }
-
     fn recordRegionFusedRun(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, elapsed_ns: u64) void {
         if (ops.len == 0) return;
         const per_op = elapsed_ns / ops.len;
@@ -3489,41 +3483,6 @@ const CompiledProgram = struct {
         };
     }
 
-    fn tryEncodeElementwiseBatchRun(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, start: usize, skipped: []bool) bool {
-        if (start >= ops.len or skipped[start]) return false;
-        const first = switch (ops[start]) {
-            .elementwise => |e| e,
-            else => return false,
-        };
-        if (!canEncodeElementwiseBatchOp(first)) return false;
-
-        var indices: [MAX_ELEMENTWISE_BATCH]usize = undefined;
-        indices[0] = start;
-        var count: usize = 1;
-
-        var scan = start + 1;
-        while (scan < ops.len and count < MAX_ELEMENTWISE_BATCH) : (scan += 1) {
-            if (skipped[scan]) continue;
-            const e = switch (ops[scan]) {
-                .elementwise => |e| e,
-                else => continue,
-            };
-            if (!canEncodeElementwiseBatchOp(e)) continue;
-            if (!program_mod.canHoistElementwiseTo(ops, start, scan, e)) continue;
-            if (program_mod.elementwiseConflictsSelected(ops, indices[0..count], e)) continue;
-            indices[count] = scan;
-            count += 1;
-        }
-
-        if (count < 2) return false;
-
-        const t0 = nowNs();
-        self.encodeElementwiseBatch(ops, indices[0..count]);
-        self.recordRegionFusedRunFromIndices(ops, indices[0..count], @intCast(nowNs() - t0));
-        for (indices[0..count]) |idx| skipped[idx] = true;
-        return true;
-    }
-
     fn tryEncodeRegionGpuOp(self: *CompiledProgram, op: backend_mod.DeviceOp) bool {
         const t0 = nowNs();
         const encoded = if (computeDispatchSpec(op)) |spec| blk: {
@@ -3570,41 +3529,12 @@ const CompiledProgram = struct {
         return encoded;
     }
 
-    fn tryEncodeRegionFusedPair(self: *CompiledProgram, a: backend_mod.DeviceOp, b: backend_mod.DeviceOp) bool {
-        const t0 = nowNs();
-        const encoded = switch (a) {
-            .qmatmul => |q| switch (b) {
-                .slice_assign => |sa| if (q.M == 1) self.encodeQMatvecSliceAssign(q, sa) else self.encodeQMatmulSliceAssign(q, sa),
-                .elementwise => |e| self.encodeQMatmulElementwise(q, e),
-                .fused_elementwise => |fe| self.encodeQMatmulFusedElementwise(q, fe),
-                else => false,
-            },
-            .rope => |rr| switch (b) {
-                .slice_assign => |sa| blk: {
-                    if (!canFuseRopeSliceAssign(rr, sa)) break :blk false;
-                    self.encodeRopeSliceAssign(rr, sa);
-                    break :blk true;
-                },
-                else => false,
-            },
-            else => false,
-        };
-        if (encoded) {
-            self.recordRegionFusedPair(a, b, @intCast(nowNs() - t0));
-        }
-        return encoded;
-    }
-
-    fn tryEncodeProgramCommand(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, start: usize, skipped: []bool) usize {
-        const command = program_mod.findProgramCommand(
-            ops,
-            start,
-            program_mod.CommandStreamPolicy.metal(MAX_QMATVEC_BATCH, MAX_QMATMUL_BATCH),
-            skipped,
-        ) orelse return 0;
+    fn tryEncodeExactProgramCommand(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, command: program_mod.ProgramCommand) bool {
+        const start: usize = @intCast(command.op_start);
         const end = start + @as(usize, command.op_count);
-        if (end > ops.len) return 0;
+        if (end > ops.len) return false;
 
+        self.runtime_profile.recordProgramCommandAttempt(command.kind);
         const t0 = nowNs();
         const encoded = switch (command.kind) {
             .op => false,
@@ -3709,42 +3639,69 @@ const CompiledProgram = struct {
             },
         };
 
-        if (!encoded) return 0;
+        if (!encoded) {
+            self.runtime_profile.recordProgramCommandFailed(command.kind);
+            return false;
+        }
         if (command.kind == .attention_store_chain) {
             const record_indices = [_]usize{ command.indices[0], command.sidecar_indices[0] orelse command.indices[0] };
             self.recordRegionFusedRunFromIndices(ops, record_indices[0..], @intCast(nowNs() - t0));
         } else if (command.kind != .projection_group and command.kind != .elementwise_batch and command.kind != .attention_group and command.kind != .movement_group) {
             self.recordRegionFusedRun(ops[start..end], @intCast(nowNs() - t0));
         }
-        program_mod.markProgramCommandUsed(skipped, command);
-        return command.advanceCount();
+        self.runtime_profile.recordProgramCommand(command.kind);
+        return true;
     }
 
-    fn tryEncodeAttentionBatchRun(self: *CompiledProgram, ops: []const backend_mod.DeviceOp) usize {
-        const n = self.attentionBatchRunLen(ops);
-        if (n == 0) return 0;
-        const t0 = nowNs();
-        self.encodeAttentionBatch(ops, n);
-        self.recordRegionFusedRun(ops[0..n], @intCast(nowNs() - t0));
-        return n;
+    fn appendCommandIndex(indices: *[program_mod.max_projection_group_anchors * 2]usize, count: *usize, idx: usize) void {
+        for (indices[0..count.*]) |existing| {
+            if (existing == idx) return;
+        }
+        if (count.* >= indices.len) return;
+        indices[count.*] = idx;
+        count.* += 1;
     }
 
-    fn tryEncodeRopeBatchRun(self: *CompiledProgram, ops: []const backend_mod.DeviceOp) usize {
-        const n = ropeBatchRunLen(ops);
-        if (n == 0) return 0;
-        const t0 = nowNs();
-        self.encodeRopeBatch(ops, n);
-        self.recordRegionFusedRun(ops[0..n], @intCast(nowNs() - t0));
-        return n;
-    }
-
-    fn tryEncodeSliceAssignBatchRun(self: *CompiledProgram, ops: []const backend_mod.DeviceOp) usize {
-        const n = sliceAssignBatchRunLen(ops);
-        if (n == 0) return 0;
-        const t0 = nowNs();
-        self.encodeSliceAssignBatch(ops, n);
-        self.recordRegionFusedRun(ops[0..n], @intCast(nowNs() - t0));
-        return n;
+    fn tryEncodeProgramCommandIndividually(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, command: program_mod.ProgramCommand) bool {
+        switch (command.kind) {
+            .op, .row_chain, .rope_chain, .rope_batch, .movement_batch, .attention_batch => {
+                const start: usize = @intCast(command.op_start);
+                const end = start + @as(usize, command.op_count);
+                if (end > ops.len) return false;
+                for (ops[start..end]) |op| {
+                    if (!self.tryEncodeRegionGpuOp(op)) return false;
+                }
+                return true;
+            },
+            .projection_chain,
+            .projection_group,
+            .attention_chain,
+            .attention_store_chain,
+            .attention_group,
+            .movement_group,
+            .elementwise_batch,
+            => {
+                var indices: [program_mod.max_projection_group_anchors * 2]usize = undefined;
+                var count: usize = 0;
+                for (command.anchorIndices()) |idx| {
+                    if (idx >= ops.len) return false;
+                    appendCommandIndex(&indices, &count, idx);
+                }
+                if (command.sidecar_count > 0) {
+                    for (command.sidecarIndices()) |maybe_idx| {
+                        if (maybe_idx) |idx| {
+                            if (idx >= ops.len) return false;
+                            appendCommandIndex(&indices, &count, idx);
+                        }
+                    }
+                }
+                std.mem.sort(usize, indices[0..count], {}, std.sort.asc(usize));
+                for (indices[0..count]) |idx| {
+                    if (!self.tryEncodeRegionGpuOp(ops[idx])) return false;
+                }
+                return true;
+            },
+        }
     }
 
     fn tryEncodeRegionGpuOps(self: *CompiledProgram, ops: []const backend_mod.DeviceOp) bool {
@@ -3756,42 +3713,31 @@ const CompiledProgram = struct {
         }
 
         var skipped = [_]bool{false} ** 256;
-        var i: usize = 0;
-        while (i < ops.len) {
-            if (skipped[i]) {
-                i += 1;
+        const commands = program_mod.buildProgramCommands(
+            self.alloc,
+            ops,
+            program_mod.CommandStreamPolicy.metal(MAX_QMATVEC_BATCH, MAX_QMATMUL_BATCH),
+        ) catch return false;
+        defer self.alloc.free(commands);
+
+        for (commands) |command| {
+            self.runtime_profile.recordProgramCommandPlanned(command.kind);
+            const start: usize = @intCast(command.op_start);
+            if (start >= ops.len) return false;
+            if (command.kind == .op) {
+                if (skipped[start]) continue;
+                if (!self.tryEncodeRegionGpuOp(ops[start])) return false;
+                program_mod.markProgramCommandUsed(skipped[0..ops.len], command);
                 continue;
             }
-            const command_advance = self.tryEncodeProgramCommand(ops, i, skipped[0..ops.len]);
-            if (command_advance > 0) {
-                i += command_advance;
+
+            if (self.tryEncodeExactProgramCommand(ops, command)) {
+                program_mod.markProgramCommandUsed(skipped[0..ops.len], command);
                 continue;
             }
-            const rope_batch_len = self.tryEncodeRopeBatchRun(ops[i..]);
-            if (rope_batch_len > 0) {
-                i += rope_batch_len;
-                continue;
-            }
-            const slice_assign_batch_len = self.tryEncodeSliceAssignBatchRun(ops[i..]);
-            if (slice_assign_batch_len > 0) {
-                i += slice_assign_batch_len;
-                continue;
-            }
-            const attention_batch_len = self.tryEncodeAttentionBatchRun(ops[i..]);
-            if (attention_batch_len > 0) {
-                i += attention_batch_len;
-                continue;
-            }
-            if (i + 1 < ops.len and self.tryEncodeRegionFusedPair(ops[i], ops[i + 1])) {
-                i += 2;
-                continue;
-            }
-            if (self.tryEncodeElementwiseBatchRun(ops, i, skipped[0..ops.len])) {
-                i += 1;
-                continue;
-            }
-            if (!self.tryEncodeRegionGpuOp(ops[i])) return false;
-            i += 1;
+
+            if (!self.tryEncodeProgramCommandIndividually(ops, command)) return false;
+            program_mod.markProgramCommandUsed(skipped[0..ops.len], command);
         }
         return true;
     }

--- a/src/backend/metal.zig
+++ b/src/backend/metal.zig
@@ -2640,31 +2640,11 @@ const CompiledProgram = struct {
     }
 
     fn ropeBatchCompatible(first: anytype, next: anytype) bool {
-        return first.src == next.src and
-            first.cos_sin == next.cos_sin and
-            first.dst == next.dst and
-            first.half_d == next.half_d and
-            first.seq_len == next.seq_len and
-            first.src_rs == next.src_rs and
-            first.src_cs == next.src_cs and
-            first.cs_cs == next.cs_cs;
+        return program_mod.ropeBatchCompatible(first, next);
     }
 
     fn ropeBatchRunLen(ops: []const backend_mod.DeviceOp) usize {
-        if (ops.len < 2) return 0;
-        const first = switch (ops[0]) {
-            .rope => |rr| rr,
-            else => return 0,
-        };
-        var n: usize = 1;
-        while (n < ops.len and n < MAX_ROPE_BATCH) : (n += 1) {
-            const next = switch (ops[n]) {
-                .rope => |rr| rr,
-                else => break,
-            };
-            if (!ropeBatchCompatible(first, next)) break;
-        }
-        return if (n >= 2) n else 0;
+        return program_mod.ropeBatchRunLen(ops, MAX_ROPE_BATCH);
     }
 
     fn encodeRopeBatch(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, n: usize) void {
@@ -2900,24 +2880,11 @@ const CompiledProgram = struct {
     }
 
     fn sliceAssignBatchCompatible(first: anytype, next: anytype) bool {
-        return first.src == next.src and first.dst == next.dst;
+        return program_mod.sliceAssignBatchCompatible(first, next);
     }
 
     fn sliceAssignBatchRunLen(ops: []const backend_mod.DeviceOp) usize {
-        if (ops.len < 2) return 0;
-        const first = switch (ops[0]) {
-            .slice_assign => |sa| sa,
-            else => return 0,
-        };
-        var n: usize = 1;
-        while (n < ops.len and n < MAX_SLICE_ASSIGN_BATCH) : (n += 1) {
-            const next = switch (ops[n]) {
-                .slice_assign => |sa| sa,
-                else => break,
-            };
-            if (!sliceAssignBatchCompatible(first, next)) break;
-        }
-        return if (n >= 2) n else 0;
+        return program_mod.sliceAssignBatchRunLen(ops, MAX_SLICE_ASSIGN_BATCH);
     }
 
     fn encodeSliceAssignBatch(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, n: usize) void {
@@ -2986,46 +2953,26 @@ const CompiledProgram = struct {
     }
 
     fn attentionBatchCompatible(first: anytype, next: anytype) bool {
-        return first.q == next.q and
-            first.k == next.k and
-            first.v == next.v and
-            first.mask == next.mask and
-            first.dst == next.dst and
-            first.has_mask == next.has_mask and
-            first.d_head == next.d_head and
-            first.seq_q == next.seq_q and
-            first.seq_kv == next.seq_kv and
-            first.scale == next.scale and
-            first.q_rs == next.q_rs and
-            first.q_cs == next.q_cs and
-            first.k_rs == next.k_rs and
-            first.k_cs == next.k_cs and
-            first.v_rs == next.v_rs and
-            first.v_cs == next.v_cs and
-            first.mask_rs == next.mask_rs and
-            first.mask_cs == next.mask_cs and
-            first.dst_rs == next.dst_rs and
-            first.dst_cs == next.dst_cs;
+        return program_mod.attentionBatchCompatible(first, next);
     }
 
     fn attentionBatchRunLen(self: *CompiledProgram, ops: []const backend_mod.DeviceOp) usize {
         _ = self;
-        if (ops.len < 2) return 0;
+        const n = program_mod.attentionBatchRunLen(ops, MAX_ATTENTION_BATCH_HEADS);
+        if (n == 0) return 0;
         const first = switch (ops[0]) {
             .attention => |att| att,
             else => return 0,
         };
         if (!canEncodeAttention(first)) return 0;
-
-        var n: usize = 1;
-        while (n < ops.len and n < MAX_ATTENTION_BATCH_HEADS) : (n += 1) {
-            const next = switch (ops[n]) {
+        for (ops[1..n]) |op| {
+            const next = switch (op) {
                 .attention => |att| att,
-                else => break,
+                else => return 0,
             };
-            if (!canEncodeAttention(next) or !attentionBatchCompatible(first, next)) break;
+            if (!canEncodeAttention(next) or !attentionBatchCompatible(first, next)) return 0;
         }
-        return if (n >= 2) n else 0;
+        return n;
     }
 
     fn encodeAttentionBatch(self: *CompiledProgram, ops: []const backend_mod.DeviceOp, n: usize) void {
@@ -3281,6 +3228,24 @@ const CompiledProgram = struct {
         const encoded = switch (command.kind) {
             .op => false,
             .projection_group => self.tryEncodeProjectionCommand(ops, command),
+            .attention_batch => blk: {
+                const n: usize = @intCast(command.op_count);
+                if (self.attentionBatchRunLen(ops[start..]) < n) break :blk false;
+                self.encodeAttentionBatch(ops[start..], n);
+                break :blk true;
+            },
+            .rope_batch => blk: {
+                const n: usize = @intCast(command.op_count);
+                if (ropeBatchRunLen(ops[start..]) < n) break :blk false;
+                self.encodeRopeBatch(ops[start..], n);
+                break :blk true;
+            },
+            .movement_batch => blk: {
+                const n: usize = @intCast(command.op_count);
+                if (sliceAssignBatchRunLen(ops[start..]) < n) break :blk false;
+                self.encodeSliceAssignBatch(ops[start..], n);
+                break :blk true;
+            },
             .row_chain => switch (ops[start]) {
                 .rmsnorm => |rn| switch (ops[start + 1]) {
                     .repeat => |rp| switch (ops[start + 2]) {
@@ -3354,6 +3319,11 @@ const CompiledProgram = struct {
                 i += 1;
                 continue;
             }
+            const command_advance = self.tryEncodeProgramCommand(ops, i, skipped[0..ops.len]);
+            if (command_advance > 0) {
+                i += command_advance;
+                continue;
+            }
             const rope_batch_len = self.tryEncodeRopeBatchRun(ops[i..]);
             if (rope_batch_len > 0) {
                 i += rope_batch_len;
@@ -3362,11 +3332,6 @@ const CompiledProgram = struct {
             const slice_assign_batch_len = self.tryEncodeSliceAssignBatchRun(ops[i..]);
             if (slice_assign_batch_len > 0) {
                 i += slice_assign_batch_len;
-                continue;
-            }
-            const command_advance = self.tryEncodeProgramCommand(ops, i, skipped[0..ops.len]);
-            if (command_advance > 0) {
-                i += command_advance;
                 continue;
             }
             const attention_batch_len = self.tryEncodeAttentionBatchRun(ops[i..]);

--- a/src/backend/program.zig
+++ b/src/backend/program.zig
@@ -299,6 +299,7 @@ pub const ProgramCommandKind = enum {
     rope_batch,
     movement_batch,
     attention_batch,
+    attention_group,
     elementwise_batch,
     projection_chain,
     projection_group,
@@ -311,6 +312,7 @@ pub const ProgramCommandKind = enum {
             .rope_batch => "rope_batch",
             .movement_batch => "movement_batch",
             .attention_batch => "attention_batch",
+            .attention_group => "attention_group",
             .elementwise_batch => "elementwise_batch",
             .projection_chain => "projection_chain",
             .projection_group => "projection_group",
@@ -428,6 +430,7 @@ pub const ProgramCommand = struct {
     pub fn coveredOpCount(self: ProgramCommand) u32 {
         return switch (self.kind) {
             .projection_group, .projection_chain => self.anchor_count + self.sidecar_count,
+            .attention_group => self.anchor_count,
             .elementwise_batch => self.anchor_count,
             else => self.op_count,
         };
@@ -435,7 +438,7 @@ pub const ProgramCommand = struct {
 
     pub fn advanceCount(self: ProgramCommand) u32 {
         return switch (self.kind) {
-            .projection_group, .elementwise_batch => 1,
+            .projection_group, .elementwise_batch, .attention_group => 1,
             else => self.op_count,
         };
     }
@@ -460,6 +463,8 @@ pub const ProgramCommandSummary = struct {
     rope_batches: u32 = 0,
     movement_batches: u32 = 0,
     attention_batches: u32 = 0,
+    attention_groups: u32 = 0,
+    attention_group_ops: u32 = 0,
     elementwise_batches: u32 = 0,
     elementwise_ops: u32 = 0,
     projection_chains: u32 = 0,
@@ -845,7 +850,59 @@ pub fn findProgramCommand(
         return command;
     }
 
+    if (op == .attention and policy.max_attention_batch >= 2) {
+        if (findAttentionGroupCommand(ops, start, policy, used)) |command| {
+            return command;
+        }
+    }
+
     return null;
+}
+
+fn findAttentionGroupCommand(
+    ops: []const backend_mod.DeviceOp,
+    start: usize,
+    policy: CommandStreamPolicy,
+    used: ?[]const bool,
+) ?ProgramCommand {
+    if (start >= ops.len) return null;
+    if (used) |used_ops| {
+        if (start >= used_ops.len or used_ops[start]) return null;
+    }
+    const first = switch (ops[start]) {
+        .attention => |att| att,
+        else => return null,
+    };
+
+    const max_ops: usize = @intCast(@min(policy.max_attention_batch, max_projection_group_anchors));
+    if (max_ops < 2) return null;
+
+    var command = ProgramCommand{
+        .kind = .attention_group,
+        .op_start = @intCast(start),
+        .op_count = 1,
+        .anchor_count = 1,
+    };
+    command.indices[0] = start;
+
+    var scan = start + 1;
+    while (scan < ops.len and command.anchor_count < max_ops) : (scan += 1) {
+        if (used) |used_ops| {
+            if (scan >= used_ops.len or used_ops[scan]) continue;
+        }
+        const next = switch (ops[scan]) {
+            .attention => |att| att,
+            else => continue,
+        };
+        if (!attentionBatchCompatible(first, next)) continue;
+        if (!canHoistOpTo(ops, start, scan, .{ .attention = next })) continue;
+        if (opConflictsSelected(ops, command.anchorIndices(), .{ .attention = next })) continue;
+        command.indices[command.anchor_count] = scan;
+        command.anchor_count += 1;
+        command.op_count = @intCast(scan - start + 1);
+    }
+
+    return if (command.anchor_count >= 2) command else null;
 }
 
 fn findProjectionChainCommand(
@@ -969,6 +1026,10 @@ pub fn summarizeProgramCommands(commands: []const ProgramCommand) ProgramCommand
             .rope_batch => summary.rope_batches += 1,
             .movement_batch => summary.movement_batches += 1,
             .attention_batch => summary.attention_batches += 1,
+            .attention_group => {
+                summary.attention_groups += 1;
+                summary.attention_group_ops += command.anchor_count;
+            },
             .elementwise_batch => {
                 summary.elementwise_batches += 1;
                 summary.elementwise_ops += command.anchor_count;
@@ -990,7 +1051,7 @@ pub fn summarizeProgramCommands(commands: []const ProgramCommand) ProgramCommand
 
 pub fn markProgramCommandUsed(used: []bool, command: ProgramCommand) void {
     switch (command.kind) {
-        .projection_group, .elementwise_batch => {
+        .projection_group, .elementwise_batch, .attention_group => {
             for (command.anchorIndices()) |idx| {
                 if (idx < used.len) used[idx] = true;
             }
@@ -2762,6 +2823,33 @@ test "program command stream emits contiguous batch commands" {
     try std.testing.expectEqual(@as(u32, 1), summary.rope_batches);
     try std.testing.expectEqual(@as(u32, 1), summary.movement_batches);
     try std.testing.expectEqual(@as(u32, 1), summary.attention_batches);
+}
+
+test "program command stream emits noncontiguous attention groups" {
+    const ops = [_]backend_mod.DeviceOp{
+        testAttention(0),
+        testQMatmulWith(9, 8, 2),
+        testAttention(8),
+    };
+
+    const commands = try buildProgramCommands(std.testing.allocator, &ops, CommandStreamPolicy.metal(4, 4));
+    defer std.testing.allocator.free(commands);
+
+    try std.testing.expectEqual(@as(usize, 2), commands.len);
+    try std.testing.expectEqual(ProgramCommandKind.attention_group, commands[0].kind);
+    try std.testing.expectEqual(@as(u32, 2), commands[0].anchor_count);
+    try std.testing.expectEqual(@as(usize, 0), commands[0].indices[0]);
+    try std.testing.expectEqual(@as(usize, 2), commands[0].indices[1]);
+    try std.testing.expectEqual(ProgramCommandKind.op, commands[1].kind);
+    try std.testing.expectEqual(@as(u32, 1), commands[1].op_start);
+
+    const summary = summarizeProgramCommands(commands);
+    try std.testing.expectEqual(@as(u32, 2), summary.commands);
+    try std.testing.expectEqual(@as(u32, 3), summary.covered_ops);
+    try std.testing.expectEqual(@as(u32, 2), summary.estimated_dispatches);
+    try std.testing.expectEqual(@as(u32, 1), summary.estimated_saved_dispatches);
+    try std.testing.expectEqual(@as(u32, 1), summary.attention_groups);
+    try std.testing.expectEqual(@as(u32, 2), summary.attention_group_ops);
 }
 
 test "program command stream emits noncontiguous elementwise batch commands" {

--- a/src/backend/program.zig
+++ b/src/backend/program.zig
@@ -303,6 +303,7 @@ pub const ProgramCommandKind = enum {
     attention_store_chain,
     attention_store_group,
     rope_attention_store_chain,
+    rope_attention_store_group,
     attention_batch,
     attention_group,
     elementwise_batch,
@@ -321,6 +322,7 @@ pub const ProgramCommandKind = enum {
             .attention_store_chain => "attention_store_chain",
             .attention_store_group => "attention_store_group",
             .rope_attention_store_chain => "rope_attention_store_chain",
+            .rope_attention_store_group => "rope_attention_store_group",
             .attention_batch => "attention_batch",
             .attention_group => "attention_group",
             .elementwise_batch => "elementwise_batch",
@@ -441,7 +443,7 @@ pub const ProgramCommand = struct {
     pub fn coveredOpCount(self: ProgramCommand) u32 {
         return switch (self.kind) {
             .projection_group, .projection_chain => self.anchor_count + self.sidecar_count,
-            .attention_chain, .attention_store_chain, .attention_store_group, .rope_attention_store_chain => self.anchor_count + self.sidecar_count,
+            .attention_chain, .attention_store_chain, .attention_store_group, .rope_attention_store_chain, .rope_attention_store_group => self.anchor_count + self.sidecar_count,
             .attention_group => self.anchor_count,
             .movement_group => self.anchor_count,
             .elementwise_batch => self.anchor_count,
@@ -451,7 +453,7 @@ pub const ProgramCommand = struct {
 
     pub fn advanceCount(self: ProgramCommand) u32 {
         return switch (self.kind) {
-            .projection_group, .elementwise_batch, .attention_store_chain, .attention_store_group, .rope_attention_store_chain, .attention_group, .movement_group => 1,
+            .projection_group, .elementwise_batch, .attention_store_chain, .attention_store_group, .rope_attention_store_chain, .rope_attention_store_group, .attention_group, .movement_group => 1,
             else => self.op_count,
         };
     }
@@ -486,6 +488,9 @@ pub const ProgramCommandSummary = struct {
     attention_store_group_sidecars: u32 = 0,
     rope_attention_store_chains: u32 = 0,
     rope_attention_store_chain_sidecars: u32 = 0,
+    rope_attention_store_groups: u32 = 0,
+    rope_attention_store_group_ops: u32 = 0,
+    rope_attention_store_group_sidecars: u32 = 0,
     attention_batches: u32 = 0,
     attention_groups: u32 = 0,
     attention_group_ops: u32 = 0,
@@ -511,6 +516,36 @@ pub const AttentionStoreGroupCandidateSummary = struct {
     formed_groups: u32 = 0,
     grouped_anchors: u32 = 0,
     max_group_anchors: u32 = 0,
+};
+
+pub const RopeAttentionStoreGroupCandidateSummary = struct {
+    anchors: u32 = 0,
+    first_pair_missing: u32 = 0,
+    candidate_ropes: u32 = 0,
+    geometry_rejects: u32 = 0,
+    pair_missing_rejects: u32 = 0,
+    before_emit_rejects: u32 = 0,
+    delay_rejects: u32 = 0,
+    attention_hoist_rejects: u32 = 0,
+    sidecar_hoist_rejects: u32 = 0,
+    selected_conflict_rejects: u32 = 0,
+    formed_groups: u32 = 0,
+    grouped_pairs: u32 = 0,
+    max_group_pairs: u32 = 0,
+};
+
+pub const EarlyRopeAttentionStoreGroupCandidateSummary = struct {
+    anchors: u32 = 0,
+    first_pair_missing: u32 = 0,
+    candidate_ropes: u32 = 0,
+    geometry_rejects: u32 = 0,
+    pair_missing_rejects: u32 = 0,
+    rope_hoist_rejects: u32 = 0,
+    attention_hoist_rejects: u32 = 0,
+    selected_conflict_rejects: u32 = 0,
+    formed_groups: u32 = 0,
+    grouped_pairs: u32 = 0,
+    max_group_pairs: u32 = 0,
 };
 
 pub const max_projection_group_anchors = 8;
@@ -819,20 +854,34 @@ pub fn buildProgramCommands(
 ) ![]ProgramCommand {
     var commands: std.ArrayListUnmanaged(ProgramCommand) = .empty;
     errdefer commands.deinit(alloc);
+    var pending: std.ArrayListUnmanaged(PendingProgramCommand) = .empty;
+    defer pending.deinit(alloc);
 
     const used = try alloc.alloc(bool, ops.len);
     defer alloc.free(used);
     @memset(used, false);
+    const executed = try alloc.alloc(bool, ops.len);
+    defer alloc.free(executed);
+    @memset(executed, false);
 
     var i: usize = 0;
     while (i < ops.len) {
+        try emitPendingProgramCommandsAt(alloc, &commands, &pending, used, executed, i);
         if (used[i]) {
             i += 1;
             continue;
         }
 
-        if (findProgramCommand(ops, i, policy, used)) |command| {
+        if (findDelayedRopeAttentionStoreGroupCommand(ops, i, policy, used, executed)) |command| {
             markProgramCommandUsed(used, command);
+            try pending.append(alloc, .{ .emit_at = command.op_start, .command = command });
+            i += 1;
+            continue;
+        }
+
+        if (findProgramCommandWithExecuted(ops, i, policy, used, executed)) |command| {
+            markProgramCommandUsed(used, command);
+            markProgramCommandUsed(executed, command);
             try commands.append(alloc, command);
             i += command.advanceCount();
             continue;
@@ -840,11 +889,42 @@ pub fn buildProgramCommands(
 
         const command = ProgramCommand.op(i);
         markProgramCommandUsed(used, command);
+        markProgramCommandUsed(executed, command);
         try commands.append(alloc, command);
         i += 1;
     }
+    while (pending.items.len != 0) {
+        const pending_command = pending.orderedRemove(0);
+        try commands.append(alloc, pending_command.command);
+    }
 
     return commands.toOwnedSlice(alloc);
+}
+
+const PendingProgramCommand = struct {
+    emit_at: u32,
+    command: ProgramCommand,
+};
+
+fn emitPendingProgramCommandsAt(
+    alloc: std.mem.Allocator,
+    commands: *std.ArrayListUnmanaged(ProgramCommand),
+    pending: *std.ArrayListUnmanaged(PendingProgramCommand),
+    used: []bool,
+    executed: []bool,
+    index: usize,
+) !void {
+    var p: usize = 0;
+    while (p < pending.items.len) {
+        if (pending.items[p].emit_at != index) {
+            p += 1;
+            continue;
+        }
+        const pending_command = pending.orderedRemove(p);
+        markProgramCommandUsed(used, pending_command.command);
+        markProgramCommandUsed(executed, pending_command.command);
+        try commands.append(alloc, pending_command.command);
+    }
 }
 
 pub fn findProgramCommand(
@@ -852,6 +932,16 @@ pub fn findProgramCommand(
     start: usize,
     policy: CommandStreamPolicy,
     used: ?[]const bool,
+) ?ProgramCommand {
+    return findProgramCommandWithExecuted(ops, start, policy, used, null);
+}
+
+fn findProgramCommandWithExecuted(
+    ops: []const backend_mod.DeviceOp,
+    start: usize,
+    policy: CommandStreamPolicy,
+    used: ?[]const bool,
+    executed: ?[]const bool,
 ) ?ProgramCommand {
     if (start >= ops.len) return null;
     if (used) |used_ops| {
@@ -889,7 +979,12 @@ pub fn findProgramCommand(
     }
 
     if (op == .rope) {
-        if (findRopeAttentionStoreChainCommand(ops, start, used)) |command| {
+        if (policy.max_attention_store_batch >= 2) {
+            if (findRopeAttentionStoreGroupCommand(ops, start, policy, used, executed)) |command| {
+                return command;
+            }
+        }
+        if (findRopeAttentionStoreChainCommand(ops, start, used, executed)) |command| {
             return command;
         }
     }
@@ -902,7 +997,7 @@ pub fn findProgramCommand(
 
     if (op == .attention) {
         if (policy.max_attention_batch >= 2) {
-            if (findAttentionStoreGroupCommand(ops, start, policy, used)) |command| {
+            if (findAttentionStoreGroupCommand(ops, start, policy, used, executed)) |command| {
                 return command;
             }
         }
@@ -1035,6 +1130,7 @@ fn findAttentionStoreGroupCommand(
     start: usize,
     policy: CommandStreamPolicy,
     used: ?[]const bool,
+    executed: ?[]const bool,
 ) ?ProgramCommand {
     if (start >= ops.len) return null;
     if (used) |used_ops| {
@@ -1067,7 +1163,7 @@ fn findAttentionStoreGroupCommand(
             else => continue,
         };
         if (!attentionGeometryCompatible(first, next)) continue;
-        if (!canHoistAttentionForStoreGroup(ops, start, scan, next, &command)) continue;
+        if (!canHoistAttentionForStoreGroup(ops, start, scan, next, &command, executed)) continue;
         if (opConflictsSelected(ops, command.anchorIndices(), .{ .attention = next })) continue;
         if (!appendAttentionStorePair(ops, &command, scan, next, start, used)) continue;
     }
@@ -1079,6 +1175,7 @@ fn findRopeAttentionStoreChainCommand(
     ops: []const backend_mod.DeviceOp,
     start: usize,
     used: ?[]const bool,
+    executed: ?[]const bool,
 ) ?ProgramCommand {
     if (start >= ops.len) return null;
     if (used) |used_ops| {
@@ -1110,7 +1207,7 @@ fn findRopeAttentionStoreChainCommand(
         command.indices[0] = start;
         command.indices[1] = scan;
         if (ropeOutputHasExternalUsers(ops, start, scan, rr)) continue;
-        if (!canHoistAttentionForStoreGroup(ops, start, scan, att, &command)) continue;
+        if (!canHoistAttentionForStoreGroup(ops, start, scan, att, &command, executed)) continue;
 
         const sidecar_index = findAttentionStoreSidecarIndex(ops, scan, att, used) orelse return null;
         command.sidecar_indices[0] = sidecar_index;
@@ -1119,6 +1216,310 @@ fn findRopeAttentionStoreChainCommand(
         return command;
     }
     return null;
+}
+
+fn findRopeAttentionStoreGroupCommand(
+    ops: []const backend_mod.DeviceOp,
+    start: usize,
+    policy: CommandStreamPolicy,
+    used: ?[]const bool,
+    executed: ?[]const bool,
+) ?ProgramCommand {
+    if (start >= ops.len) return null;
+    if (used) |used_ops| {
+        if (start >= used_ops.len or used_ops[start]) return null;
+    }
+    const max_pairs: usize = @intCast(@min(policy.max_attention_store_batch, max_projection_group_anchors / 2));
+    if (max_pairs < 2) return null;
+
+    const first_pair = findRopeAttentionStorePair(ops, start, used, executed) orelse return null;
+    var command = ProgramCommand{
+        .kind = .rope_attention_store_group,
+        .op_start = @intCast(start),
+        .op_count = 1,
+        .anchor_count = 0,
+        .sidecar_count = 0,
+    };
+    appendRopeAttentionStorePair(&command, start, first_pair.attention_index, first_pair.sidecar_index, start);
+
+    const first_att = ops[first_pair.attention_index].attention;
+    const first_rope = ops[start].rope;
+    var scan = start + 1;
+    while (scan < ops.len and command.sidecar_count < max_pairs) : (scan += 1) {
+        if (used) |used_ops| {
+            if (scan >= used_ops.len or used_ops[scan]) continue;
+        }
+        const rr = switch (ops[scan]) {
+            .rope => |rr| rr,
+            else => continue,
+        };
+        if (!ropeStoreBatchGeometryCompatible(first_rope, rr)) continue;
+        const pair = findRopeAttentionStorePair(ops, scan, used, executed) orelse continue;
+        const att = ops[pair.attention_index].attention;
+        if (!attentionGeometryCompatible(first_att, att)) continue;
+
+        var candidate = command;
+        const slot = candidate.anchor_count;
+        if (slot + 2 > max_projection_group_anchors) break;
+        candidate.indices[slot] = scan;
+        candidate.indices[slot + 1] = pair.attention_index;
+        candidate.anchor_count += 2;
+        if (!canHoistOpToRopeAttentionStoreGroup(ops, start, scan, .{ .rope = rr }, &candidate, executed)) continue;
+        if (!canHoistAttentionForStoreGroup(ops, start, pair.attention_index, att, &candidate, executed)) continue;
+        if (ropeAttentionStorePairConflictsSelected(ops, &command, scan, pair.attention_index, ops[pair.sidecar_index].slice_assign)) continue;
+
+        appendRopeAttentionStorePair(&command, scan, pair.attention_index, pair.sidecar_index, start);
+    }
+
+    return if (command.sidecar_count >= 2) command else null;
+}
+
+fn findDelayedRopeAttentionStoreGroupCommand(
+    ops: []const backend_mod.DeviceOp,
+    start: usize,
+    policy: CommandStreamPolicy,
+    used: ?[]const bool,
+    executed: ?[]const bool,
+) ?ProgramCommand {
+    if (start >= ops.len) return null;
+    if (used) |used_ops| {
+        if (start >= used_ops.len or used_ops[start]) return null;
+    }
+    const max_pairs: usize = @intCast(@min(policy.max_attention_store_batch, max_projection_group_anchors / 2));
+    if (max_pairs < 2) return null;
+
+    const first_pair = findDelayableRopeAttentionStorePair(ops, start, used, executed) orelse return null;
+    const emit_at = first_pair.attention_index;
+    if (emit_at <= start) return null;
+
+    var command = ProgramCommand{
+        .kind = .rope_attention_store_group,
+        .op_start = @intCast(emit_at),
+        .op_count = 1,
+        .anchor_count = 0,
+        .sidecar_count = 0,
+    };
+    appendRopeAttentionStorePair(&command, start, first_pair.attention_index, first_pair.sidecar_index, emit_at);
+
+    const first_att = ops[first_pair.attention_index].attention;
+    const first_rope = ops[start].rope;
+    var scan = start + 1;
+    while (scan < emit_at and command.sidecar_count < max_pairs) : (scan += 1) {
+        if (used) |used_ops| {
+            if (scan >= used_ops.len or used_ops[scan]) continue;
+        }
+        const rr = switch (ops[scan]) {
+            .rope => |rr| rr,
+            else => continue,
+        };
+        if (!ropeStoreBatchGeometryCompatible(first_rope, rr)) continue;
+        const pair = findDelayableRopeAttentionStorePair(ops, scan, used, executed) orelse continue;
+        if (pair.attention_index < emit_at) continue;
+        const att = ops[pair.attention_index].attention;
+        if (!attentionGeometryCompatible(first_att, att)) continue;
+        const sa = ops[pair.sidecar_index].slice_assign;
+
+        var candidate = command;
+        if (candidate.anchor_count + 2 > max_projection_group_anchors) break;
+        appendRopeAttentionStorePair(&candidate, scan, pair.attention_index, pair.sidecar_index, emit_at);
+        if (!canDelayOpToCommand(ops, scan, emit_at, .{ .rope = rr }, &candidate)) continue;
+        if (!canHoistAttentionForStoreGroup(ops, emit_at, pair.attention_index, att, &candidate, executed)) continue;
+        if (!canHoistOpToRopeAttentionStoreGroup(ops, emit_at, pair.sidecar_index, .{ .slice_assign = sa }, &candidate, executed)) continue;
+        if (ropeAttentionStorePairConflictsSelected(ops, &command, scan, pair.attention_index, sa)) continue;
+
+        command = candidate;
+    }
+
+    return if (command.sidecar_count >= 2) command else null;
+}
+
+const RopeAttentionStorePair = struct {
+    attention_index: usize,
+    sidecar_index: usize,
+};
+
+fn findRopeAttentionStorePair(
+    ops: []const backend_mod.DeviceOp,
+    rope_index: usize,
+    used: ?[]const bool,
+    executed: ?[]const bool,
+) ?RopeAttentionStorePair {
+    const rr = switch (ops[rope_index]) {
+        .rope => |rr| rr,
+        else => return null,
+    };
+    var scan = rope_index + 1;
+    while (scan < ops.len) : (scan += 1) {
+        if (used) |used_ops| {
+            if (scan >= used_ops.len or used_ops[scan]) continue;
+        }
+        const att = switch (ops[scan]) {
+            .attention => |att| att,
+            else => continue,
+        };
+        if (!ropeAttentionCompatible(rr, att)) continue;
+        if (ropeOutputHasExternalUsers(ops, rope_index, scan, rr)) continue;
+        var command = ProgramCommand{
+            .kind = .rope_attention_store_chain,
+            .op_start = @intCast(rope_index),
+            .op_count = @intCast(scan - rope_index + 1),
+            .anchor_count = 2,
+            .sidecar_count = 0,
+        };
+        command.indices[0] = rope_index;
+        command.indices[1] = scan;
+        if (!canHoistAttentionForStoreGroup(ops, rope_index, scan, att, &command, executed)) continue;
+        const sidecar_index = findAttentionStoreSidecarIndex(ops, scan, att, used) orelse return null;
+        return .{ .attention_index = scan, .sidecar_index = sidecar_index };
+    }
+    return null;
+}
+
+fn findDelayableRopeAttentionStorePair(
+    ops: []const backend_mod.DeviceOp,
+    rope_index: usize,
+    used: ?[]const bool,
+    executed: ?[]const bool,
+) ?RopeAttentionStorePair {
+    const rr = switch (ops[rope_index]) {
+        .rope => |rr| rr,
+        else => return null,
+    };
+    var scan = rope_index + 1;
+    while (scan < ops.len) : (scan += 1) {
+        if (used) |used_ops| {
+            if (scan >= used_ops.len or used_ops[scan]) continue;
+        }
+        const att = switch (ops[scan]) {
+            .attention => |att| att,
+            else => continue,
+        };
+        if (!ropeAttentionCompatible(rr, att)) continue;
+        if (ropeOutputHasExternalUsers(ops, rope_index, scan, rr)) continue;
+
+        var command = ProgramCommand{
+            .kind = .rope_attention_store_group,
+            .op_start = @intCast(scan),
+            .op_count = 1,
+            .anchor_count = 2,
+            .sidecar_count = 0,
+        };
+        command.indices[0] = rope_index;
+        command.indices[1] = scan;
+        if (!canDelayOpToCommand(ops, rope_index, scan, .{ .rope = rr }, &command)) continue;
+
+        const sidecar_index = findAttentionStoreSidecarIndex(ops, scan, att, used) orelse return null;
+        command.sidecar_indices[0] = sidecar_index;
+        command.sidecar_count = 1;
+        const sa = ops[sidecar_index].slice_assign;
+        if (!canHoistOpToRopeAttentionStoreGroup(ops, scan, sidecar_index, .{ .slice_assign = sa }, &command, executed)) continue;
+        return .{ .attention_index = scan, .sidecar_index = sidecar_index };
+    }
+    return null;
+}
+
+fn appendRopeAttentionStorePair(
+    command: *ProgramCommand,
+    rope_index: usize,
+    attention_index: usize,
+    sidecar_index: usize,
+    group_start: usize,
+) void {
+    const slot = command.anchor_count;
+    command.indices[slot] = rope_index;
+    command.indices[slot + 1] = attention_index;
+    command.sidecar_indices[command.sidecar_count] = sidecar_index;
+    command.anchor_count += 2;
+    command.sidecar_count += 1;
+    command.op_count = @intCast(@max(
+        group_start + @as(usize, command.op_count),
+        sidecar_index + 1,
+    ) - group_start);
+}
+
+fn canDelayOpToCommand(
+    ops: []const backend_mod.DeviceOp,
+    candidate_index: usize,
+    emit_at: usize,
+    candidate: backend_mod.DeviceOp,
+    command: *const ProgramCommand,
+) bool {
+    if (candidate_index > emit_at) return false;
+    const candidate_access = opAccessSpans(candidate);
+    for (ops[candidate_index + 1 .. emit_at + 1], candidate_index + 1..) |op, idx| {
+        if (commandContainsIndex(command, idx)) continue;
+        for (candidate_access.readSpans()) |read| {
+            if (opWritesSpan(op, read)) return false;
+        }
+        for (candidate_access.writeSpans()) |write| {
+            if (opTouchesSpan(op, write)) return false;
+        }
+        if (candidate_access.read_overflow or candidate_access.write_overflow) {
+            if (opAccessConflicts(op, candidate)) return false;
+        }
+    }
+    return true;
+}
+
+fn canHoistOpToRopeAttentionStoreGroup(
+    ops: []const backend_mod.DeviceOp,
+    group_start: usize,
+    candidate_index: usize,
+    candidate: backend_mod.DeviceOp,
+    command: *const ProgramCommand,
+    executed: ?[]const bool,
+) bool {
+    const candidate_access = opAccessSpans(candidate);
+    for (ops[group_start..candidate_index], group_start..) |op, idx| {
+        if (commandContainsIndex(command, idx)) continue;
+        if (executed) |executed_ops| {
+            if (idx < executed_ops.len and executed_ops[idx]) continue;
+        }
+        for (candidate_access.readSpans()) |read| {
+            if (opWritesSpan(op, read)) return false;
+        }
+        for (candidate_access.writeSpans()) |write| {
+            if (opTouchesSpan(op, write)) return false;
+        }
+        if (candidate_access.read_overflow or candidate_access.write_overflow) {
+            if (opAccessConflicts(op, candidate)) return false;
+        }
+    }
+    return true;
+}
+
+fn ropeAttentionStorePairConflictsSelected(
+    ops: []const backend_mod.DeviceOp,
+    command: *const ProgramCommand,
+    rope_index: usize,
+    attention_index: usize,
+    sa: anytype,
+) bool {
+    const rope_op = ops[rope_index];
+    const attention_op = ops[attention_index];
+    const sidecar_op: backend_mod.DeviceOp = .{ .slice_assign = sa };
+    const sidecar_access = opAccessSpans(sidecar_op);
+    for (command.anchorIndices()) |idx| {
+        for (sidecar_access.writeSpans()) |write| {
+            if (opReadsSpan(ops[idx], write)) return true;
+        }
+        if (sidecar_access.write_overflow and opReadsBuffer(ops[idx], sa.dst)) return true;
+    }
+    for (command.sidecarIndices()) |maybe_idx| {
+        const idx = maybe_idx orelse continue;
+        const selected_sa = switch (ops[idx]) {
+            .slice_assign => |selected| selected,
+            else => return true,
+        };
+        if (sliceAssignWritesMayOverlap(selected_sa, sa)) return true;
+        const selected_access = opAccessSpans(ops[idx]);
+        for (selected_access.writeSpans()) |write| {
+            if (opReadsSpan(rope_op, write) or opReadsSpan(attention_op, write)) return true;
+        }
+        if (selected_access.write_overflow and
+            (opReadsBuffer(rope_op, selected_sa.dst) or opReadsBuffer(attention_op, selected_sa.dst))) return true;
+    }
+    return false;
 }
 
 fn ropeOutputHasExternalUsers(
@@ -1138,16 +1539,37 @@ fn ropeOutputHasExternalUsers(
     return false;
 }
 
+fn attentionOutputHasExternalUsers(
+    ops: []const backend_mod.DeviceOp,
+    attention_index: usize,
+    sidecar_index: usize,
+    att: anytype,
+) bool {
+    const attention_access = opAccessSpans(.{ .attention = att });
+    for (ops[attention_index + 1 ..], attention_index + 1..) |op, idx| {
+        if (idx == sidecar_index) continue;
+        for (attention_access.writeSpans()) |write| {
+            if (opReadsSpan(op, write)) return true;
+        }
+        if (attention_access.write_overflow and opReadsBuffer(op, att.dst)) return true;
+    }
+    return false;
+}
+
 fn canHoistAttentionForStoreGroup(
     ops: []const backend_mod.DeviceOp,
     group_start: usize,
     attention_index: usize,
     att: anytype,
     command: *const ProgramCommand,
+    executed: ?[]const bool,
 ) bool {
     const candidate_access = opAccessSpans(.{ .attention = att });
     for (ops[group_start..attention_index], group_start..) |op, idx| {
         if (commandContainsIndex(command, idx)) continue;
+        if (executed) |executed_ops| {
+            if (idx < executed_ops.len and executed_ops[idx]) continue;
+        }
         for (candidate_access.readSpans()) |read| {
             if (opWritesSpan(op, read)) return false;
         }
@@ -1280,7 +1702,7 @@ pub fn summarizeAttentionStoreGroupCandidates(
                 summary.geometry_rejects += 1;
                 continue;
             }
-            if (!canHoistAttentionForStoreGroup(ops, start, scan, next, &command)) {
+            if (!canHoistAttentionForStoreGroup(ops, start, scan, next, &command, null)) {
                 summary.hoist_rejects += 1;
                 continue;
             }
@@ -1304,6 +1726,180 @@ pub fn summarizeAttentionStoreGroupCandidates(
             summary.formed_groups += 1;
             summary.grouped_anchors += command.anchor_count;
             summary.max_group_anchors = @max(summary.max_group_anchors, command.anchor_count);
+        }
+    }
+
+    return summary;
+}
+
+pub fn summarizeRopeAttentionStoreGroupCandidates(
+    ops: []const backend_mod.DeviceOp,
+    policy: CommandStreamPolicy,
+) RopeAttentionStoreGroupCandidateSummary {
+    var summary = RopeAttentionStoreGroupCandidateSummary{};
+    const max_pairs: usize = @intCast(@min(policy.max_attention_store_batch, max_projection_group_anchors / 2));
+    if (max_pairs < 2) return summary;
+
+    for (ops, 0..) |op, start| {
+        const first_rope = switch (op) {
+            .rope => |rr| rr,
+            else => continue,
+        };
+        summary.anchors += 1;
+
+        const first_pair = findDelayableRopeAttentionStorePair(ops, start, null, null) orelse {
+            summary.first_pair_missing += 1;
+            continue;
+        };
+        const emit_at = first_pair.attention_index;
+        if (emit_at <= start) {
+            summary.first_pair_missing += 1;
+            continue;
+        }
+
+        var command = ProgramCommand{
+            .kind = .rope_attention_store_group,
+            .op_start = @intCast(emit_at),
+            .op_count = 1,
+            .anchor_count = 0,
+            .sidecar_count = 0,
+        };
+        appendRopeAttentionStorePair(&command, start, first_pair.attention_index, first_pair.sidecar_index, emit_at);
+        const first_att = ops[first_pair.attention_index].attention;
+
+        var scan = start + 1;
+        while (scan < emit_at and command.sidecar_count < max_pairs) : (scan += 1) {
+            const rr = switch (ops[scan]) {
+                .rope => |rr| rr,
+                else => continue,
+            };
+            summary.candidate_ropes += 1;
+            if (!ropeStoreBatchGeometryCompatible(first_rope, rr)) {
+                summary.geometry_rejects += 1;
+                continue;
+            }
+            const pair = findDelayableRopeAttentionStorePair(ops, scan, null, null) orelse {
+                summary.pair_missing_rejects += 1;
+                continue;
+            };
+            if (pair.attention_index < emit_at) {
+                summary.before_emit_rejects += 1;
+                continue;
+            }
+            const att = ops[pair.attention_index].attention;
+            if (!attentionGeometryCompatible(first_att, att)) {
+                summary.geometry_rejects += 1;
+                continue;
+            }
+            const sa = ops[pair.sidecar_index].slice_assign;
+
+            var candidate = command;
+            if (candidate.anchor_count + 2 > max_projection_group_anchors) break;
+            appendRopeAttentionStorePair(&candidate, scan, pair.attention_index, pair.sidecar_index, emit_at);
+            if (!canDelayOpToCommand(ops, scan, emit_at, .{ .rope = rr }, &candidate)) {
+                summary.delay_rejects += 1;
+                continue;
+            }
+            if (!canHoistAttentionForStoreGroup(ops, emit_at, pair.attention_index, att, &candidate, null)) {
+                summary.attention_hoist_rejects += 1;
+                continue;
+            }
+            if (!canHoistOpToRopeAttentionStoreGroup(ops, emit_at, pair.sidecar_index, .{ .slice_assign = sa }, &candidate, null)) {
+                summary.sidecar_hoist_rejects += 1;
+                continue;
+            }
+            if (ropeAttentionStorePairConflictsSelected(ops, &command, scan, pair.attention_index, sa)) {
+                summary.selected_conflict_rejects += 1;
+                continue;
+            }
+            command = candidate;
+        }
+
+        if (command.sidecar_count >= 2) {
+            summary.formed_groups += 1;
+            summary.grouped_pairs += command.sidecar_count;
+            summary.max_group_pairs = @max(summary.max_group_pairs, command.sidecar_count);
+        }
+    }
+
+    return summary;
+}
+
+pub fn summarizeEarlyRopeAttentionStoreGroupCandidates(
+    ops: []const backend_mod.DeviceOp,
+    policy: CommandStreamPolicy,
+) EarlyRopeAttentionStoreGroupCandidateSummary {
+    var summary = EarlyRopeAttentionStoreGroupCandidateSummary{};
+    const max_pairs: usize = @intCast(@min(policy.max_attention_store_batch, max_projection_group_anchors / 2));
+    if (max_pairs < 2) return summary;
+
+    for (ops, 0..) |op, start| {
+        const first_rope = switch (op) {
+            .rope => |rr| rr,
+            else => continue,
+        };
+        summary.anchors += 1;
+
+        const first_pair = findRopeAttentionStorePair(ops, start, null, null) orelse {
+            summary.first_pair_missing += 1;
+            continue;
+        };
+        var command = ProgramCommand{
+            .kind = .rope_attention_store_group,
+            .op_start = @intCast(start),
+            .op_count = 1,
+            .anchor_count = 0,
+            .sidecar_count = 0,
+        };
+        appendRopeAttentionStorePair(&command, start, first_pair.attention_index, first_pair.sidecar_index, start);
+
+        const first_att = ops[first_pair.attention_index].attention;
+        var scan = start + 1;
+        while (scan < ops.len and command.sidecar_count < max_pairs) : (scan += 1) {
+            const rr = switch (ops[scan]) {
+                .rope => |rr| rr,
+                else => continue,
+            };
+            summary.candidate_ropes += 1;
+            if (!ropeStoreBatchGeometryCompatible(first_rope, rr)) {
+                summary.geometry_rejects += 1;
+                continue;
+            }
+            const pair = findRopeAttentionStorePair(ops, scan, null, null) orelse {
+                summary.pair_missing_rejects += 1;
+                continue;
+            };
+            const att = ops[pair.attention_index].attention;
+            if (!attentionGeometryCompatible(first_att, att)) {
+                summary.geometry_rejects += 1;
+                continue;
+            }
+
+            var candidate = command;
+            const slot = candidate.anchor_count;
+            if (slot + 2 > max_projection_group_anchors) break;
+            candidate.indices[slot] = scan;
+            candidate.indices[slot + 1] = pair.attention_index;
+            candidate.anchor_count += 2;
+            if (!canHoistOpToRopeAttentionStoreGroup(ops, start, scan, .{ .rope = rr }, &candidate, null)) {
+                summary.rope_hoist_rejects += 1;
+                continue;
+            }
+            if (!canHoistAttentionForStoreGroup(ops, start, pair.attention_index, att, &candidate, null)) {
+                summary.attention_hoist_rejects += 1;
+                continue;
+            }
+            if (ropeAttentionStorePairConflictsSelected(ops, &command, scan, pair.attention_index, ops[pair.sidecar_index].slice_assign)) {
+                summary.selected_conflict_rejects += 1;
+                continue;
+            }
+            appendRopeAttentionStorePair(&command, scan, pair.attention_index, pair.sidecar_index, start);
+        }
+
+        if (command.sidecar_count >= 2) {
+            summary.formed_groups += 1;
+            summary.grouped_pairs += command.sidecar_count;
+            summary.max_group_pairs = @max(summary.max_group_pairs, command.sidecar_count);
         }
     }
 
@@ -1543,6 +2139,11 @@ pub fn summarizeProgramCommands(commands: []const ProgramCommand) ProgramCommand
                 summary.rope_attention_store_chains += 1;
                 summary.rope_attention_store_chain_sidecars += command.sidecar_count;
             },
+            .rope_attention_store_group => {
+                summary.rope_attention_store_groups += 1;
+                summary.rope_attention_store_group_ops += command.anchor_count;
+                summary.rope_attention_store_group_sidecars += command.sidecar_count;
+            },
             .attention_batch => summary.attention_batches += 1,
             .attention_group => {
                 summary.attention_groups += 1;
@@ -1569,11 +2170,11 @@ pub fn summarizeProgramCommands(commands: []const ProgramCommand) ProgramCommand
 
 pub fn markProgramCommandUsed(used: []bool, command: ProgramCommand) void {
     switch (command.kind) {
-        .projection_group, .elementwise_batch, .attention_store_chain, .attention_store_group, .rope_attention_store_chain, .attention_group, .movement_group => {
+        .projection_group, .elementwise_batch, .attention_store_chain, .attention_store_group, .rope_attention_store_chain, .rope_attention_store_group, .attention_group, .movement_group => {
             for (command.anchorIndices()) |idx| {
                 if (idx < used.len) used[idx] = true;
             }
-            if (command.kind == .projection_group or command.kind == .attention_store_chain or command.kind == .attention_store_group or command.kind == .rope_attention_store_chain) {
+            if (command.kind == .projection_group or command.kind == .attention_store_chain or command.kind == .attention_store_group or command.kind == .rope_attention_store_chain or command.kind == .rope_attention_store_group) {
                 for (command.sidecarIndices()) |maybe_idx| {
                     if (maybe_idx) |idx| {
                         if (idx < used.len) used[idx] = true;
@@ -2017,6 +2618,14 @@ pub fn ropeAttentionCompatible(rr: anytype, att: anytype) bool {
         rr.seq_len == att.seq_q and
         att.q_rs == 1 and
         att.q_cs == d;
+}
+
+pub fn ropeStoreBatchGeometryCompatible(first: anytype, next: anytype) bool {
+    return first.half_d == next.half_d and
+        first.seq_len == next.seq_len and
+        first.src_rs == next.src_rs and
+        first.src_cs == next.src_cs and
+        first.cs_cs == next.cs_cs;
 }
 
 fn attentionSliceMatches(
@@ -3745,6 +4354,191 @@ test "program command stream emits rope attention output store chains" {
     try std.testing.expectEqual(@as(u32, 1), summary.rope_attention_store_chain_sidecars);
     try std.testing.expectEqual(@as(u32, 3), summary.covered_ops);
     try std.testing.expectEqual(@as(u32, 1), summary.estimated_dispatches);
+}
+
+test "program command stream groups rope attention output stores" {
+    var att0 = testAttention(0);
+    var att1 = testAttention(8);
+    att0.attention.q = 4;
+    att0.attention.dst = 5;
+    att1.attention.q = 6;
+    att1.attention.dst = 7;
+
+    const ops = [_]backend_mod.DeviceOp{
+        .{ .rope = .{
+            .dst = 4,
+            .src = 0,
+            .cos_sin = 1,
+            .half_d = 2,
+            .seq_len = 2,
+            .src_off = 0,
+            .cs_off = 0,
+            .dst_off = 0,
+            .src_rs = 1,
+            .src_cs = 4,
+            .cs_cs = 4,
+        } },
+        att0,
+        .{ .slice_assign = .{
+            .dst = 9,
+            .src = 5,
+            .rows = 4,
+            .cols = 2,
+            .dst_base_offset = 0,
+            .dst_offset = 0,
+            .dst_row_stride = 1,
+            .dst_col_stride = 8,
+            .src_offset = 0,
+            .src_row_stride = 1,
+            .src_col_stride = 4,
+            .patch_stride = 0,
+        } },
+        .{ .rope = .{
+            .dst = 6,
+            .src = 10,
+            .cos_sin = 1,
+            .half_d = 2,
+            .seq_len = 2,
+            .src_off = 8,
+            .cs_off = 0,
+            .dst_off = 8,
+            .src_rs = 1,
+            .src_cs = 4,
+            .cs_cs = 4,
+        } },
+        att1,
+        .{ .slice_assign = .{
+            .dst = 9,
+            .src = 7,
+            .rows = 4,
+            .cols = 2,
+            .dst_base_offset = 0,
+            .dst_offset = 4,
+            .dst_row_stride = 1,
+            .dst_col_stride = 8,
+            .src_offset = 8,
+            .src_row_stride = 1,
+            .src_col_stride = 4,
+            .patch_stride = 0,
+        } },
+    };
+
+    const commands = try buildProgramCommands(std.testing.allocator, &ops, CommandStreamPolicy.metal(4, 4));
+    defer std.testing.allocator.free(commands);
+
+    try std.testing.expectEqual(@as(usize, 1), commands.len);
+    try std.testing.expectEqual(ProgramCommandKind.rope_attention_store_group, commands[0].kind);
+    try std.testing.expectEqual(@as(u32, 4), commands[0].anchor_count);
+    try std.testing.expectEqual(@as(u32, 2), commands[0].sidecar_count);
+    try std.testing.expectEqual(@as(usize, 0), commands[0].indices[0]);
+    try std.testing.expectEqual(@as(usize, 1), commands[0].indices[1]);
+    try std.testing.expectEqual(@as(usize, 3), commands[0].indices[2]);
+    try std.testing.expectEqual(@as(usize, 4), commands[0].indices[3]);
+    try std.testing.expectEqual(@as(?usize, 2), commands[0].sidecar_indices[0]);
+    try std.testing.expectEqual(@as(?usize, 5), commands[0].sidecar_indices[1]);
+
+    const summary = summarizeProgramCommands(commands);
+    try std.testing.expectEqual(@as(u32, 1), summary.rope_attention_store_groups);
+    try std.testing.expectEqual(@as(u32, 4), summary.rope_attention_store_group_ops);
+    try std.testing.expectEqual(@as(u32, 2), summary.rope_attention_store_group_sidecars);
+    try std.testing.expectEqual(@as(u32, 6), summary.covered_ops);
+    try std.testing.expectEqual(@as(u32, 1), summary.estimated_dispatches);
+}
+
+test "program command stream delays rope attention groups until inputs are ready" {
+    var att0 = testAttention(0);
+    var att1 = testAttention(8);
+    att0.attention.q = 4;
+    att0.attention.dst = 5;
+    att1.attention.q = 6;
+    att1.attention.dst = 7;
+
+    const ops = [_]backend_mod.DeviceOp{
+        .{ .rope = .{
+            .dst = 4,
+            .src = 0,
+            .cos_sin = 1,
+            .half_d = 2,
+            .seq_len = 2,
+            .src_off = 0,
+            .cs_off = 0,
+            .dst_off = 0,
+            .src_rs = 1,
+            .src_cs = 4,
+            .cs_cs = 4,
+        } },
+        testQMatmulWith(10, 8, 2),
+        .{ .rope = .{
+            .dst = 6,
+            .src = 10,
+            .cos_sin = 1,
+            .half_d = 2,
+            .seq_len = 2,
+            .src_off = 0,
+            .cs_off = 0,
+            .dst_off = 8,
+            .src_rs = 1,
+            .src_cs = 4,
+            .cs_cs = 4,
+        } },
+        att0,
+        .{ .slice_assign = .{
+            .dst = 9,
+            .src = 5,
+            .rows = 4,
+            .cols = 2,
+            .dst_base_offset = 0,
+            .dst_offset = 0,
+            .dst_row_stride = 1,
+            .dst_col_stride = 8,
+            .src_offset = 0,
+            .src_row_stride = 1,
+            .src_col_stride = 4,
+            .patch_stride = 0,
+        } },
+        att1,
+        .{ .slice_assign = .{
+            .dst = 9,
+            .src = 7,
+            .rows = 4,
+            .cols = 2,
+            .dst_base_offset = 0,
+            .dst_offset = 4,
+            .dst_row_stride = 1,
+            .dst_col_stride = 8,
+            .src_offset = 8,
+            .src_row_stride = 1,
+            .src_col_stride = 4,
+            .patch_stride = 0,
+        } },
+    };
+
+    const commands = try buildProgramCommands(std.testing.allocator, &ops, CommandStreamPolicy.metal(4, 4));
+    defer std.testing.allocator.free(commands);
+
+    try std.testing.expectEqual(@as(usize, 2), commands.len);
+    try std.testing.expectEqual(ProgramCommandKind.op, commands[0].kind);
+    try std.testing.expectEqual(@as(u32, 1), commands[0].op_start);
+    try std.testing.expectEqual(ProgramCommandKind.rope_attention_store_group, commands[1].kind);
+    try std.testing.expectEqual(@as(u32, 3), commands[1].op_start);
+    try std.testing.expectEqual(@as(u32, 4), commands[1].anchor_count);
+    try std.testing.expectEqual(@as(u32, 2), commands[1].sidecar_count);
+    try std.testing.expectEqual(@as(usize, 0), commands[1].indices[0]);
+    try std.testing.expectEqual(@as(usize, 3), commands[1].indices[1]);
+    try std.testing.expectEqual(@as(usize, 2), commands[1].indices[2]);
+    try std.testing.expectEqual(@as(usize, 5), commands[1].indices[3]);
+    try std.testing.expectEqual(@as(?usize, 4), commands[1].sidecar_indices[0]);
+    try std.testing.expectEqual(@as(?usize, 6), commands[1].sidecar_indices[1]);
+
+    const summary = summarizeProgramCommands(commands);
+    try std.testing.expectEqual(@as(u32, 2), summary.commands);
+    try std.testing.expectEqual(@as(u32, 7), summary.covered_ops);
+    try std.testing.expectEqual(@as(u32, 2), summary.estimated_dispatches);
+    try std.testing.expectEqual(@as(u32, 5), summary.estimated_saved_dispatches);
+    try std.testing.expectEqual(@as(u32, 1), summary.op_commands);
+    try std.testing.expectEqual(@as(u32, 1), summary.rope_attention_store_groups);
+    try std.testing.expectEqual(@as(u32, 4), summary.rope_attention_store_group_ops);
+    try std.testing.expectEqual(@as(u32, 2), summary.rope_attention_store_group_sidecars);
 }
 
 test "program command stream carries delayed attention output stores" {

--- a/src/backend/program.zig
+++ b/src/backend/program.zig
@@ -301,6 +301,8 @@ pub const ProgramCommandKind = enum {
     movement_group,
     attention_chain,
     attention_store_chain,
+    attention_store_group,
+    rope_attention_store_chain,
     attention_batch,
     attention_group,
     elementwise_batch,
@@ -317,6 +319,8 @@ pub const ProgramCommandKind = enum {
             .movement_group => "movement_group",
             .attention_chain => "attention_chain",
             .attention_store_chain => "attention_store_chain",
+            .attention_store_group => "attention_store_group",
+            .rope_attention_store_chain => "rope_attention_store_chain",
             .attention_batch => "attention_batch",
             .attention_group => "attention_group",
             .elementwise_batch => "elementwise_batch",
@@ -356,6 +360,7 @@ pub const CommandStreamPolicy = struct {
     max_rope_batch: u32 = 16,
     max_movement_batch: u32 = 16,
     max_attention_batch: u32 = 16,
+    max_attention_store_batch: u32 = 4,
     max_elementwise_batch: u32 = 8,
 
     pub fn metal(qmatvec_group_size: u32, qmatmul_group_size: u32) CommandStreamPolicy {
@@ -436,7 +441,7 @@ pub const ProgramCommand = struct {
     pub fn coveredOpCount(self: ProgramCommand) u32 {
         return switch (self.kind) {
             .projection_group, .projection_chain => self.anchor_count + self.sidecar_count,
-            .attention_chain, .attention_store_chain => self.anchor_count + self.sidecar_count,
+            .attention_chain, .attention_store_chain, .attention_store_group, .rope_attention_store_chain => self.anchor_count + self.sidecar_count,
             .attention_group => self.anchor_count,
             .movement_group => self.anchor_count,
             .elementwise_batch => self.anchor_count,
@@ -446,7 +451,7 @@ pub const ProgramCommand = struct {
 
     pub fn advanceCount(self: ProgramCommand) u32 {
         return switch (self.kind) {
-            .projection_group, .elementwise_batch, .attention_store_chain, .attention_group, .movement_group => 1,
+            .projection_group, .elementwise_batch, .attention_store_chain, .attention_store_group, .rope_attention_store_chain, .attention_group, .movement_group => 1,
             else => self.op_count,
         };
     }
@@ -476,6 +481,11 @@ pub const ProgramCommandSummary = struct {
     attention_chain_sidecars: u32 = 0,
     attention_store_chains: u32 = 0,
     attention_store_chain_sidecars: u32 = 0,
+    attention_store_groups: u32 = 0,
+    attention_store_group_ops: u32 = 0,
+    attention_store_group_sidecars: u32 = 0,
+    rope_attention_store_chains: u32 = 0,
+    rope_attention_store_chain_sidecars: u32 = 0,
     attention_batches: u32 = 0,
     attention_groups: u32 = 0,
     attention_group_ops: u32 = 0,
@@ -487,6 +497,20 @@ pub const ProgramCommandSummary = struct {
     projection_anchors: u32 = 0,
     projection_sidecars: u32 = 0,
     max_projection_span_ops: u32 = 0,
+};
+
+pub const AttentionStoreGroupCandidateSummary = struct {
+    anchors: u32 = 0,
+    first_store_missing: u32 = 0,
+    candidate_attentions: u32 = 0,
+    geometry_rejects: u32 = 0,
+    hoist_rejects: u32 = 0,
+    selected_conflict_rejects: u32 = 0,
+    no_store_rejects: u32 = 0,
+    pair_conflict_rejects: u32 = 0,
+    formed_groups: u32 = 0,
+    grouped_anchors: u32 = 0,
+    max_group_anchors: u32 = 0,
 };
 
 pub const max_projection_group_anchors = 8;
@@ -864,6 +888,12 @@ pub fn findProgramCommand(
         return command;
     }
 
+    if (op == .rope) {
+        if (findRopeAttentionStoreChainCommand(ops, start, used)) |command| {
+            return command;
+        }
+    }
+
     if (op == .slice_assign) {
         if (findAttentionChainCommand(ops, start, used)) |command| {
             return command;
@@ -871,6 +901,11 @@ pub fn findProgramCommand(
     }
 
     if (op == .attention) {
+        if (policy.max_attention_batch >= 2) {
+            if (findAttentionStoreGroupCommand(ops, start, policy, used)) |command| {
+                return command;
+            }
+        }
         if (findAttentionStoreChainCommand(ops, start, used)) |command| {
             return command;
         }
@@ -993,6 +1028,286 @@ fn findAttentionStoreChainCommand(
     command.indices[0] = start;
     command.sidecar_indices[0] = found;
     return command;
+}
+
+fn findAttentionStoreGroupCommand(
+    ops: []const backend_mod.DeviceOp,
+    start: usize,
+    policy: CommandStreamPolicy,
+    used: ?[]const bool,
+) ?ProgramCommand {
+    if (start >= ops.len) return null;
+    if (used) |used_ops| {
+        if (start >= used_ops.len or used_ops[start]) return null;
+    }
+    const first = switch (ops[start]) {
+        .attention => |att| att,
+        else => return null,
+    };
+
+    const max_ops: usize = @intCast(@min(policy.max_attention_store_batch, max_projection_group_anchors));
+    if (max_ops < 2) return null;
+
+    var command = ProgramCommand{
+        .kind = .attention_store_group,
+        .op_start = @intCast(start),
+        .op_count = 1,
+        .anchor_count = 0,
+        .sidecar_count = 0,
+    };
+    if (!appendAttentionStorePair(ops, &command, start, first, start, used)) return null;
+
+    var scan = start + 1;
+    while (scan < ops.len and command.anchor_count < max_ops) : (scan += 1) {
+        if (used) |used_ops| {
+            if (scan >= used_ops.len or used_ops[scan]) continue;
+        }
+        const next = switch (ops[scan]) {
+            .attention => |att| att,
+            else => continue,
+        };
+        if (!attentionGeometryCompatible(first, next)) continue;
+        if (!canHoistAttentionForStoreGroup(ops, start, scan, next, &command)) continue;
+        if (opConflictsSelected(ops, command.anchorIndices(), .{ .attention = next })) continue;
+        if (!appendAttentionStorePair(ops, &command, scan, next, start, used)) continue;
+    }
+
+    return if (command.anchor_count >= 2) command else null;
+}
+
+fn findRopeAttentionStoreChainCommand(
+    ops: []const backend_mod.DeviceOp,
+    start: usize,
+    used: ?[]const bool,
+) ?ProgramCommand {
+    if (start >= ops.len) return null;
+    if (used) |used_ops| {
+        if (start >= used_ops.len or used_ops[start]) return null;
+    }
+    const rr = switch (ops[start]) {
+        .rope => |rr| rr,
+        else => return null,
+    };
+
+    var scan = start + 1;
+    while (scan < ops.len) : (scan += 1) {
+        if (used) |used_ops| {
+            if (scan >= used_ops.len or used_ops[scan]) continue;
+        }
+        const att = switch (ops[scan]) {
+            .attention => |att| att,
+            else => continue,
+        };
+        if (!ropeAttentionCompatible(rr, att)) continue;
+
+        var command = ProgramCommand{
+            .kind = .rope_attention_store_chain,
+            .op_start = @intCast(start),
+            .op_count = @intCast(scan - start + 1),
+            .anchor_count = 2,
+            .sidecar_count = 0,
+        };
+        command.indices[0] = start;
+        command.indices[1] = scan;
+        if (ropeOutputHasExternalUsers(ops, start, scan, rr)) continue;
+        if (!canHoistAttentionForStoreGroup(ops, start, scan, att, &command)) continue;
+
+        const sidecar_index = findAttentionStoreSidecarIndex(ops, scan, att, used) orelse return null;
+        command.sidecar_indices[0] = sidecar_index;
+        command.sidecar_count = 1;
+        command.op_count = @intCast(sidecar_index - start + 1);
+        return command;
+    }
+    return null;
+}
+
+fn ropeOutputHasExternalUsers(
+    ops: []const backend_mod.DeviceOp,
+    rope_index: usize,
+    attention_index: usize,
+    rr: anytype,
+) bool {
+    const rope_access = opAccessSpans(.{ .rope = rr });
+    for (ops[rope_index + 1 .. attention_index], rope_index + 1..) |op, idx| {
+        if (idx == attention_index) continue;
+        for (rope_access.writeSpans()) |write| {
+            if (opTouchesSpan(op, write)) return true;
+        }
+        if (rope_access.write_overflow and opTouchesBuffer(op, rr.dst)) return true;
+    }
+    return false;
+}
+
+fn canHoistAttentionForStoreGroup(
+    ops: []const backend_mod.DeviceOp,
+    group_start: usize,
+    attention_index: usize,
+    att: anytype,
+    command: *const ProgramCommand,
+) bool {
+    const candidate_access = opAccessSpans(.{ .attention = att });
+    for (ops[group_start..attention_index], group_start..) |op, idx| {
+        if (commandContainsIndex(command, idx)) continue;
+        for (candidate_access.readSpans()) |read| {
+            if (opWritesSpan(op, read)) return false;
+        }
+        for (candidate_access.writeSpans()) |write| {
+            if (opTouchesSpan(op, write)) return false;
+        }
+        if (candidate_access.read_overflow or candidate_access.write_overflow) {
+            if (opAccessConflicts(op, .{ .attention = att })) return false;
+        }
+    }
+    return true;
+}
+
+fn commandContainsIndex(command: *const ProgramCommand, candidate: usize) bool {
+    for (command.anchorIndices()) |idx| {
+        if (idx == candidate) return true;
+    }
+    for (command.sidecarIndices()) |maybe_idx| {
+        if (maybe_idx) |idx| {
+            if (idx == candidate) return true;
+        }
+    }
+    return false;
+}
+
+fn appendAttentionStorePair(
+    ops: []const backend_mod.DeviceOp,
+    command: *ProgramCommand,
+    attention_index: usize,
+    att: anytype,
+    group_start: usize,
+    used: ?[]const bool,
+) bool {
+    const sidecar_index = findAttentionStoreSidecarIndex(ops, attention_index, att, used) orelse return false;
+    const sa = ops[sidecar_index].slice_assign;
+    if (attentionStorePairConflictsSelected(ops, command, attention_index, sa)) return false;
+
+    const slot = command.anchor_count;
+    command.indices[slot] = attention_index;
+    command.sidecar_indices[slot] = sidecar_index;
+    command.anchor_count += 1;
+    command.sidecar_count += 1;
+    command.op_count = @intCast(@max(
+        group_start + @as(usize, command.op_count),
+        sidecar_index + 1,
+    ) - group_start);
+    return true;
+}
+
+fn findAttentionStoreSidecarIndex(
+    ops: []const backend_mod.DeviceOp,
+    attention_index: usize,
+    att: anytype,
+    used: ?[]const bool,
+) ?usize {
+    var scan = attention_index + 1;
+    while (scan < ops.len) : (scan += 1) {
+        if (used) |used_ops| {
+            if (scan >= used_ops.len or used_ops[scan]) continue;
+        }
+        const sa = switch (ops[scan]) {
+            .slice_assign => |sa| sa,
+            else => continue,
+        };
+        if (!attentionSliceStoreCompatible(att, sa)) continue;
+        if (!canFuseAttentionStoreSidecar(ops, attention_index, scan, sa)) continue;
+        return scan;
+    }
+    return null;
+}
+
+fn attentionStorePairConflictsSelected(
+    ops: []const backend_mod.DeviceOp,
+    command: *const ProgramCommand,
+    attention_index: usize,
+    sa: anytype,
+) bool {
+    const attention_op = ops[attention_index];
+    const sidecar_op: backend_mod.DeviceOp = .{ .slice_assign = sa };
+    for (command.anchorIndices()) |idx| {
+        if (opAccessConflicts(ops[idx], attention_op)) return true;
+        if (opAccessConflicts(ops[idx], sidecar_op)) return true;
+    }
+    for (command.sidecarIndices()) |maybe_idx| {
+        const idx = maybe_idx orelse continue;
+        const selected_sa = switch (ops[idx]) {
+            .slice_assign => |selected| selected,
+            else => return true,
+        };
+        if (sliceAssignWritesMayOverlap(selected_sa, sa)) return true;
+    }
+    return false;
+}
+
+pub fn summarizeAttentionStoreGroupCandidates(
+    ops: []const backend_mod.DeviceOp,
+    policy: CommandStreamPolicy,
+) AttentionStoreGroupCandidateSummary {
+    var summary = AttentionStoreGroupCandidateSummary{};
+    const max_ops: usize = @intCast(@min(policy.max_attention_store_batch, max_projection_group_anchors));
+    if (max_ops < 2) return summary;
+
+    for (ops, 0..) |op, start| {
+        const first = switch (op) {
+            .attention => |att| att,
+            else => continue,
+        };
+        summary.anchors += 1;
+
+        var command = ProgramCommand{
+            .kind = .attention_store_group,
+            .op_start = @intCast(start),
+            .op_count = 1,
+            .anchor_count = 0,
+            .sidecar_count = 0,
+        };
+        if (!appendAttentionStorePair(ops, &command, start, first, start, null)) {
+            summary.first_store_missing += 1;
+            continue;
+        }
+
+        var scan = start + 1;
+        while (scan < ops.len and command.anchor_count < max_ops) : (scan += 1) {
+            const next = switch (ops[scan]) {
+                .attention => |att| att,
+                else => continue,
+            };
+            summary.candidate_attentions += 1;
+            if (!attentionGeometryCompatible(first, next)) {
+                summary.geometry_rejects += 1;
+                continue;
+            }
+            if (!canHoistAttentionForStoreGroup(ops, start, scan, next, &command)) {
+                summary.hoist_rejects += 1;
+                continue;
+            }
+            if (opConflictsSelected(ops, command.anchorIndices(), .{ .attention = next })) {
+                summary.selected_conflict_rejects += 1;
+                continue;
+            }
+            const sidecar_index = findAttentionStoreSidecarIndex(ops, scan, next, null) orelse {
+                summary.no_store_rejects += 1;
+                continue;
+            };
+            const sa = ops[sidecar_index].slice_assign;
+            if (attentionStorePairConflictsSelected(ops, &command, scan, sa)) {
+                summary.pair_conflict_rejects += 1;
+                continue;
+            }
+            _ = appendAttentionStorePair(ops, &command, scan, next, start, null);
+        }
+
+        if (command.anchor_count >= 2) {
+            summary.formed_groups += 1;
+            summary.grouped_anchors += command.anchor_count;
+            summary.max_group_anchors = @max(summary.max_group_anchors, command.anchor_count);
+        }
+    }
+
+    return summary;
 }
 
 fn findMovementGroupCommand(
@@ -1219,6 +1534,15 @@ pub fn summarizeProgramCommands(commands: []const ProgramCommand) ProgramCommand
                 summary.attention_store_chains += 1;
                 summary.attention_store_chain_sidecars += command.sidecar_count;
             },
+            .attention_store_group => {
+                summary.attention_store_groups += 1;
+                summary.attention_store_group_ops += command.anchor_count;
+                summary.attention_store_group_sidecars += command.sidecar_count;
+            },
+            .rope_attention_store_chain => {
+                summary.rope_attention_store_chains += 1;
+                summary.rope_attention_store_chain_sidecars += command.sidecar_count;
+            },
             .attention_batch => summary.attention_batches += 1,
             .attention_group => {
                 summary.attention_groups += 1;
@@ -1245,11 +1569,11 @@ pub fn summarizeProgramCommands(commands: []const ProgramCommand) ProgramCommand
 
 pub fn markProgramCommandUsed(used: []bool, command: ProgramCommand) void {
     switch (command.kind) {
-        .projection_group, .elementwise_batch, .attention_store_chain, .attention_group, .movement_group => {
+        .projection_group, .elementwise_batch, .attention_store_chain, .attention_store_group, .rope_attention_store_chain, .attention_group, .movement_group => {
             for (command.anchorIndices()) |idx| {
                 if (idx < used.len) used[idx] = true;
             }
-            if (command.kind == .projection_group or command.kind == .attention_store_chain) {
+            if (command.kind == .projection_group or command.kind == .attention_store_chain or command.kind == .attention_store_group or command.kind == .rope_attention_store_chain) {
                 for (command.sidecarIndices()) |maybe_idx| {
                     if (maybe_idx) |idx| {
                         if (idx < used.len) used[idx] = true;
@@ -1685,6 +2009,16 @@ pub fn attentionSliceStoreCompatible(att: anytype, sa: anytype) bool {
         sa.src_col_stride == att.dst_cs;
 }
 
+pub fn ropeAttentionCompatible(rr: anytype, att: anytype) bool {
+    const d = rr.half_d * 2;
+    return rr.dst == att.q and
+        rr.dst_off == att.q_off and
+        d == att.d_head and
+        rr.seq_len == att.seq_q and
+        att.q_rs == 1 and
+        att.q_cs == d;
+}
+
 fn attentionSliceMatches(
     sa: anytype,
     buf: u16,
@@ -1785,6 +2119,24 @@ pub fn attentionBatchCompatible(first: anytype, next: anytype) bool {
         first.mask == next.mask and
         first.dst == next.dst and
         first.has_mask == next.has_mask and
+        first.d_head == next.d_head and
+        first.seq_q == next.seq_q and
+        first.seq_kv == next.seq_kv and
+        first.scale == next.scale and
+        first.q_rs == next.q_rs and
+        first.q_cs == next.q_cs and
+        first.k_rs == next.k_rs and
+        first.k_cs == next.k_cs and
+        first.v_rs == next.v_rs and
+        first.v_cs == next.v_cs and
+        first.mask_rs == next.mask_rs and
+        first.mask_cs == next.mask_cs and
+        first.dst_rs == next.dst_rs and
+        first.dst_cs == next.dst_cs;
+}
+
+pub fn attentionGeometryCompatible(first: anytype, next: anytype) bool {
+    return first.has_mask == next.has_mask and
         first.d_head == next.d_head and
         first.seq_q == next.seq_q and
         first.seq_kv == next.seq_kv and
@@ -3276,6 +3628,123 @@ test "program command stream emits attention output store chains" {
     try std.testing.expectEqual(@as(u32, 1), summary.estimated_saved_dispatches);
     try std.testing.expectEqual(@as(u32, 1), summary.attention_store_chains);
     try std.testing.expectEqual(@as(u32, 1), summary.attention_store_chain_sidecars);
+}
+
+test "program command stream groups attention output stores" {
+    const att0 = testAttention(0);
+    var att1 = testAttention(8);
+    att1.attention.q = 10;
+    att1.attention.k = 11;
+    att1.attention.v = 12;
+    att1.attention.dst = 13;
+
+    const ops = [_]backend_mod.DeviceOp{
+        att0,
+        .{ .slice_assign = .{
+            .dst = 9,
+            .src = 4,
+            .rows = 4,
+            .cols = 2,
+            .dst_base_offset = 0,
+            .dst_offset = 0,
+            .dst_row_stride = 1,
+            .dst_col_stride = 8,
+            .src_offset = 0,
+            .src_row_stride = 1,
+            .src_col_stride = 4,
+            .patch_stride = 0,
+        } },
+        att1,
+        .{ .slice_assign = .{
+            .dst = 9,
+            .src = 13,
+            .rows = 4,
+            .cols = 2,
+            .dst_base_offset = 0,
+            .dst_offset = 4,
+            .dst_row_stride = 1,
+            .dst_col_stride = 8,
+            .src_offset = 8,
+            .src_row_stride = 1,
+            .src_col_stride = 4,
+            .patch_stride = 0,
+        } },
+    };
+
+    const commands = try buildProgramCommands(std.testing.allocator, &ops, CommandStreamPolicy.metal(4, 4));
+    defer std.testing.allocator.free(commands);
+
+    try std.testing.expectEqual(@as(usize, 1), commands.len);
+    try std.testing.expectEqual(ProgramCommandKind.attention_store_group, commands[0].kind);
+    try std.testing.expectEqual(@as(u32, 2), commands[0].anchor_count);
+    try std.testing.expectEqual(@as(u32, 2), commands[0].sidecar_count);
+    try std.testing.expectEqual(@as(usize, 0), commands[0].indices[0]);
+    try std.testing.expectEqual(@as(?usize, 1), commands[0].sidecar_indices[0]);
+    try std.testing.expectEqual(@as(usize, 2), commands[0].indices[1]);
+    try std.testing.expectEqual(@as(?usize, 3), commands[0].sidecar_indices[1]);
+
+    const summary = summarizeProgramCommands(commands);
+    try std.testing.expectEqual(@as(u32, 1), summary.commands);
+    try std.testing.expectEqual(@as(u32, 4), summary.covered_ops);
+    try std.testing.expectEqual(@as(u32, 1), summary.estimated_dispatches);
+    try std.testing.expectEqual(@as(u32, 3), summary.estimated_saved_dispatches);
+    try std.testing.expectEqual(@as(u32, 1), summary.attention_store_groups);
+    try std.testing.expectEqual(@as(u32, 2), summary.attention_store_group_ops);
+    try std.testing.expectEqual(@as(u32, 2), summary.attention_store_group_sidecars);
+}
+
+test "program command stream emits rope attention output store chains" {
+    var att = testAttention(0);
+    att.attention.q = 4;
+    att.attention.dst = 5;
+
+    const ops = [_]backend_mod.DeviceOp{
+        .{ .rope = .{
+            .dst = 4,
+            .src = 0,
+            .cos_sin = 1,
+            .half_d = 2,
+            .seq_len = 2,
+            .src_off = 0,
+            .cs_off = 0,
+            .dst_off = 0,
+            .src_rs = 1,
+            .src_cs = 4,
+            .cs_cs = 4,
+        } },
+        att,
+        .{ .slice_assign = .{
+            .dst = 9,
+            .src = 5,
+            .rows = 4,
+            .cols = 2,
+            .dst_base_offset = 0,
+            .dst_offset = 0,
+            .dst_row_stride = 1,
+            .dst_col_stride = 4,
+            .src_offset = 0,
+            .src_row_stride = 1,
+            .src_col_stride = 4,
+            .patch_stride = 0,
+        } },
+    };
+
+    const commands = try buildProgramCommands(std.testing.allocator, &ops, CommandStreamPolicy.metal(4, 4));
+    defer std.testing.allocator.free(commands);
+
+    try std.testing.expectEqual(@as(usize, 1), commands.len);
+    try std.testing.expectEqual(ProgramCommandKind.rope_attention_store_chain, commands[0].kind);
+    try std.testing.expectEqual(@as(u32, 2), commands[0].anchor_count);
+    try std.testing.expectEqual(@as(u32, 1), commands[0].sidecar_count);
+    try std.testing.expectEqual(@as(usize, 0), commands[0].indices[0]);
+    try std.testing.expectEqual(@as(usize, 1), commands[0].indices[1]);
+    try std.testing.expectEqual(@as(?usize, 2), commands[0].sidecar_indices[0]);
+
+    const summary = summarizeProgramCommands(commands);
+    try std.testing.expectEqual(@as(u32, 1), summary.rope_attention_store_chains);
+    try std.testing.expectEqual(@as(u32, 1), summary.rope_attention_store_chain_sidecars);
+    try std.testing.expectEqual(@as(u32, 3), summary.covered_ops);
+    try std.testing.expectEqual(@as(u32, 1), summary.estimated_dispatches);
 }
 
 test "program command stream carries delayed attention output stores" {

--- a/src/backend/program.zig
+++ b/src/backend/program.zig
@@ -298,6 +298,7 @@ pub const ProgramCommandKind = enum {
     rope_chain,
     rope_batch,
     movement_batch,
+    movement_group,
     attention_batch,
     attention_group,
     elementwise_batch,
@@ -311,6 +312,7 @@ pub const ProgramCommandKind = enum {
             .rope_chain => "rope_chain",
             .rope_batch => "rope_batch",
             .movement_batch => "movement_batch",
+            .movement_group => "movement_group",
             .attention_batch => "attention_batch",
             .attention_group => "attention_group",
             .elementwise_batch => "elementwise_batch",
@@ -431,6 +433,7 @@ pub const ProgramCommand = struct {
         return switch (self.kind) {
             .projection_group, .projection_chain => self.anchor_count + self.sidecar_count,
             .attention_group => self.anchor_count,
+            .movement_group => self.anchor_count,
             .elementwise_batch => self.anchor_count,
             else => self.op_count,
         };
@@ -438,7 +441,7 @@ pub const ProgramCommand = struct {
 
     pub fn advanceCount(self: ProgramCommand) u32 {
         return switch (self.kind) {
-            .projection_group, .elementwise_batch, .attention_group => 1,
+            .projection_group, .elementwise_batch, .attention_group, .movement_group => 1,
             else => self.op_count,
         };
     }
@@ -462,6 +465,8 @@ pub const ProgramCommandSummary = struct {
     rope_chains: u32 = 0,
     rope_batches: u32 = 0,
     movement_batches: u32 = 0,
+    movement_groups: u32 = 0,
+    movement_group_ops: u32 = 0,
     attention_batches: u32 = 0,
     attention_groups: u32 = 0,
     attention_group_ops: u32 = 0,
@@ -850,6 +855,12 @@ pub fn findProgramCommand(
         return command;
     }
 
+    if (op == .slice_assign and policy.max_movement_batch >= 2) {
+        if (findMovementGroupCommand(ops, start, policy, used)) |command| {
+            return command;
+        }
+    }
+
     if (op == .attention and policy.max_attention_batch >= 2) {
         if (findAttentionGroupCommand(ops, start, policy, used)) |command| {
             return command;
@@ -857,6 +868,52 @@ pub fn findProgramCommand(
     }
 
     return null;
+}
+
+fn findMovementGroupCommand(
+    ops: []const backend_mod.DeviceOp,
+    start: usize,
+    policy: CommandStreamPolicy,
+    used: ?[]const bool,
+) ?ProgramCommand {
+    if (start >= ops.len) return null;
+    if (used) |used_ops| {
+        if (start >= used_ops.len or used_ops[start]) return null;
+    }
+    const first = switch (ops[start]) {
+        .slice_assign => |sa| sa,
+        else => return null,
+    };
+
+    const max_ops: usize = @intCast(@min(policy.max_movement_batch, max_projection_group_anchors));
+    if (max_ops < 2) return null;
+
+    var command = ProgramCommand{
+        .kind = .movement_group,
+        .op_start = @intCast(start),
+        .op_count = 1,
+        .anchor_count = 1,
+    };
+    command.indices[0] = start;
+
+    var scan = start + 1;
+    while (scan < ops.len and command.anchor_count < max_ops) : (scan += 1) {
+        if (used) |used_ops| {
+            if (scan >= used_ops.len or used_ops[scan]) continue;
+        }
+        const next = switch (ops[scan]) {
+            .slice_assign => |sa| sa,
+            else => continue,
+        };
+        if (!sliceAssignBatchCompatible(first, next)) continue;
+        if (!canHoistOpTo(ops, start, scan, .{ .slice_assign = next })) continue;
+        if (opConflictsSelected(ops, command.anchorIndices(), .{ .slice_assign = next })) continue;
+        command.indices[command.anchor_count] = scan;
+        command.anchor_count += 1;
+        command.op_count = @intCast(scan - start + 1);
+    }
+
+    return if (command.anchor_count >= 2) command else null;
 }
 
 fn findAttentionGroupCommand(
@@ -1025,6 +1082,10 @@ pub fn summarizeProgramCommands(commands: []const ProgramCommand) ProgramCommand
             .rope_chain => summary.rope_chains += 1,
             .rope_batch => summary.rope_batches += 1,
             .movement_batch => summary.movement_batches += 1,
+            .movement_group => {
+                summary.movement_groups += 1;
+                summary.movement_group_ops += command.anchor_count;
+            },
             .attention_batch => summary.attention_batches += 1,
             .attention_group => {
                 summary.attention_groups += 1;
@@ -1051,7 +1112,7 @@ pub fn summarizeProgramCommands(commands: []const ProgramCommand) ProgramCommand
 
 pub fn markProgramCommandUsed(used: []bool, command: ProgramCommand) void {
     switch (command.kind) {
-        .projection_group, .elementwise_batch, .attention_group => {
+        .projection_group, .elementwise_batch, .attention_group, .movement_group => {
             for (command.anchorIndices()) |idx| {
                 if (idx < used.len) used[idx] = true;
             }
@@ -2850,6 +2911,33 @@ test "program command stream emits noncontiguous attention groups" {
     try std.testing.expectEqual(@as(u32, 1), summary.estimated_saved_dispatches);
     try std.testing.expectEqual(@as(u32, 1), summary.attention_groups);
     try std.testing.expectEqual(@as(u32, 2), summary.attention_group_ops);
+}
+
+test "program command stream emits noncontiguous movement groups" {
+    const ops = [_]backend_mod.DeviceOp{
+        testSliceAssign(0),
+        testQMatmulWith(9, 8, 2),
+        testSliceAssign(4),
+    };
+
+    const commands = try buildProgramCommands(std.testing.allocator, &ops, CommandStreamPolicy.metal(4, 4));
+    defer std.testing.allocator.free(commands);
+
+    try std.testing.expectEqual(@as(usize, 2), commands.len);
+    try std.testing.expectEqual(ProgramCommandKind.movement_group, commands[0].kind);
+    try std.testing.expectEqual(@as(u32, 2), commands[0].anchor_count);
+    try std.testing.expectEqual(@as(usize, 0), commands[0].indices[0]);
+    try std.testing.expectEqual(@as(usize, 2), commands[0].indices[1]);
+    try std.testing.expectEqual(ProgramCommandKind.op, commands[1].kind);
+    try std.testing.expectEqual(@as(u32, 1), commands[1].op_start);
+
+    const summary = summarizeProgramCommands(commands);
+    try std.testing.expectEqual(@as(u32, 2), summary.commands);
+    try std.testing.expectEqual(@as(u32, 3), summary.covered_ops);
+    try std.testing.expectEqual(@as(u32, 2), summary.estimated_dispatches);
+    try std.testing.expectEqual(@as(u32, 1), summary.estimated_saved_dispatches);
+    try std.testing.expectEqual(@as(u32, 1), summary.movement_groups);
+    try std.testing.expectEqual(@as(u32, 2), summary.movement_group_ops);
 }
 
 test "program command stream emits noncontiguous elementwise batch commands" {

--- a/src/backend/program.zig
+++ b/src/backend/program.zig
@@ -567,6 +567,18 @@ pub const RopeStoreGroupCandidateSummary = struct {
     max_group_pairs: u32 = 0,
 };
 
+pub const ProjectionSidecarSummary = struct {
+    anchors: u32 = 0,
+    immediate_sidecars: u32 = 0,
+    compatible_sidecars: u32 = 0,
+    primary_elidable_sidecars: u32 = 0,
+    primary_required_sidecars: u32 = 0,
+    slice_sidecars: u32 = 0,
+    elementwise_sidecars: u32 = 0,
+    fused_elementwise_sidecars: u32 = 0,
+    incompatible_sidecars: u32 = 0,
+};
+
 pub const max_projection_group_anchors = 8;
 
 pub const BufferSpan = struct {
@@ -831,19 +843,16 @@ pub fn findProjectionGroup(
         if (used) |used_ops| {
             if (idx + 1 >= used_ops.len or used_ops[idx + 1]) continue;
         }
-        const sa = switch (ops[idx + 1]) {
-            .slice_assign => |sa| sa,
-            else => continue,
-        };
         const q = ops[idx].qmatmul;
-        const compatible = switch (policy.kind) {
-            .qmatvec => qmatvecSliceSidecarCompatible(q, sa),
-            .qmatmul => qmatmulSliceSidecarCompatible(q, sa),
-        };
-        if (!compatible) continue;
-        selection.sidecar_indices[slot] = idx + 1;
-        selection.sidecar_count += 1;
-        selection.end_op = @max(selection.end_op, idx + 1);
+        const sidecar = ops[idx + 1];
+        if (!projectionSidecarMatchesPolicy(policy, q, sidecar)) continue;
+
+        var candidate = selection;
+        candidate.sidecar_indices[slot] = idx + 1;
+        candidate.sidecar_count += 1;
+        candidate.end_op = @max(candidate.end_op, idx + 1);
+        if (!canHoistProjectionSidecarToGroup(ops, selection.start_op, idx + 1, q, sidecar, &candidate)) continue;
+        selection = candidate;
     }
 
     return selection;
@@ -861,6 +870,43 @@ pub fn summarizeProjectionGroups(groups: []const ProjectionGroup) ProjectionGrou
         summary.max_span_ops = @max(summary.max_span_ops, group.op_count);
         if (covered > dispatches) {
             summary.estimated_saved_dispatches += covered - dispatches;
+        }
+    }
+    return summary;
+}
+
+pub fn summarizeProjectionSidecars(ops: []const backend_mod.DeviceOp) ProjectionSidecarSummary {
+    var summary = ProjectionSidecarSummary{};
+    for (ops, 0..) |op, i| {
+        const q = switch (op) {
+            .qmatmul => |q| q,
+            else => continue,
+        };
+        summary.anchors += 1;
+        if (i + 1 >= ops.len) continue;
+
+        const sidecar = ops[i + 1];
+        switch (sidecar) {
+            .slice_assign, .elementwise, .fused_elementwise => {},
+            else => continue,
+        }
+        summary.immediate_sidecars += 1;
+        if (!projectionSidecarCompatible(q, sidecar)) {
+            summary.incompatible_sidecars += 1;
+            continue;
+        }
+
+        summary.compatible_sidecars += 1;
+        if (projectionPrimaryOutputHasExternalUsers(ops, i, i + 1)) {
+            summary.primary_required_sidecars += 1;
+        } else {
+            summary.primary_elidable_sidecars += 1;
+        }
+        switch (sidecar) {
+            .slice_assign => summary.slice_sidecars += 1,
+            .elementwise => summary.elementwise_sidecars += 1,
+            .fused_elementwise => summary.fused_elementwise_sidecars += 1,
+            else => unreachable,
         }
     }
     return summary;
@@ -1298,6 +1344,51 @@ fn ropeStoreGroupOutputsHaveExternalUsers(
             if (!any_live and !overflow_live) break;
         }
     }
+    return false;
+}
+
+pub fn projectionPrimaryOutputHasExternalUsers(
+    ops: []const backend_mod.DeviceOp,
+    q_index: usize,
+    sidecar_index: usize,
+) bool {
+    if (q_index >= ops.len or sidecar_index >= ops.len) return true;
+    if (sidecar_index <= q_index) return true;
+    const q = switch (ops[q_index]) {
+        .qmatmul => |q| q,
+        else => return true,
+    };
+    if (!projectionSidecarCompatible(q, ops[sidecar_index])) return true;
+
+    const q_access = opAccessSpans(.{ .qmatmul = q });
+    var live_writes = [_]bool{false} ** max_access_spans;
+    for (q_access.writeSpans(), 0..) |_, slot| live_writes[slot] = true;
+    var overflow_live = q_access.write_overflow;
+
+    var scan = q_index + 1;
+    while (scan < ops.len) : (scan += 1) {
+        const op = ops[scan];
+        if (scan != sidecar_index) {
+            for (q_access.writeSpans(), 0..) |write, slot| {
+                if (!live_writes[slot]) continue;
+                if (opReadsSpan(op, write)) return true;
+            }
+            if (overflow_live and opReadsBuffer(op, q.dst)) return true;
+        }
+
+        var any_live = false;
+        for (q_access.writeSpans(), 0..) |write, slot| {
+            if (!live_writes[slot]) continue;
+            if (opWritesCoverSpan(op, write)) {
+                live_writes[slot] = false;
+            } else {
+                any_live = true;
+            }
+        }
+        if (overflow_live and opWritesBuffer(op, q.dst)) overflow_live = false;
+        if (!any_live and !overflow_live) break;
+    }
+
     return false;
 }
 
@@ -2849,6 +2940,65 @@ pub fn projectionSidecarCompatible(q: anytype, op: backend_mod.DeviceOp) bool {
     };
 }
 
+fn projectionSidecarMatchesPolicy(policy: ProjectionGroupPolicy, q: anytype, op: backend_mod.DeviceOp) bool {
+    return switch (policy.kind) {
+        .qmatvec => switch (op) {
+            .slice_assign => |sa| qmatvecSliceSidecarCompatible(q, sa),
+            else => false,
+        },
+        .qmatmul => switch (op) {
+            .slice_assign => |sa| qmatmulSliceSidecarCompatible(q, sa),
+            .elementwise => |e| qmatmulElementwiseSidecarCompatible(q, e),
+            else => false,
+        },
+    };
+}
+
+fn projectionSelectionContainsIndex(selection: *const ProjectionGroupSelection, candidate: usize) bool {
+    for (selection.anchorIndices()) |idx| {
+        if (idx == candidate) return true;
+    }
+    for (selection.sidecarIndices()) |maybe_idx| {
+        if (maybe_idx) |idx| {
+            if (idx == candidate) return true;
+        }
+    }
+    return false;
+}
+
+fn projectionWriteCoversRead(q: anytype, read: BufferSpan) bool {
+    const q_access = opAccessSpans(.{ .qmatmul = q });
+    for (q_access.writeSpans()) |write| {
+        if (write.buf == read.buf and write.start <= read.start and write.end >= read.end) return true;
+    }
+    return q_access.write_overflow and opWritesBuffer(.{ .qmatmul = q }, read.buf);
+}
+
+fn canHoistProjectionSidecarToGroup(
+    ops: []const backend_mod.DeviceOp,
+    group_start: usize,
+    sidecar_index: usize,
+    q: anytype,
+    sidecar: backend_mod.DeviceOp,
+    selection: *const ProjectionGroupSelection,
+) bool {
+    const sidecar_access = opAccessSpans(sidecar);
+    for (ops[group_start..sidecar_index], group_start..) |op, idx| {
+        if (projectionSelectionContainsIndex(selection, idx)) continue;
+        for (sidecar_access.readSpans()) |read| {
+            if (projectionWriteCoversRead(q, read)) continue;
+            if (opWritesSpan(op, read)) return false;
+        }
+        for (sidecar_access.writeSpans()) |write| {
+            if (opTouchesSpan(op, write)) return false;
+        }
+        if (sidecar_access.read_overflow or sidecar_access.write_overflow) {
+            if (opAccessConflicts(op, sidecar)) return false;
+        }
+    }
+    return true;
+}
+
 pub fn qmatmulElementwiseSidecarCompatible(q: anytype, e: anytype) bool {
     if (q.M == 1) return false;
     if (e.op != .add and e.op != .mul) return false;
@@ -4234,6 +4384,31 @@ test "projection groups carry compatible qmatmul cache-store sidecars" {
     try std.testing.expectEqual(@as(u32, 2), summary.estimated_saved_dispatches);
 }
 
+test "projection groups carry compatible qmatmul elementwise sidecars" {
+    const ops = [_]backend_mod.DeviceOp{
+        testQMatmulWith(1, 0, 2),
+        .{ .elementwise = .{ .op = .add, .dst = 10, .src0 = 1, .src1 = 20, .n = 8 } },
+        testQMatmulWith(2, 0, 2),
+        .{ .elementwise = .{ .op = .mul, .dst = 11, .src0 = 21, .src1 = 2, .n = 8 } },
+    };
+
+    const selection = findProjectionGroup(&ops, 0, ProjectionGroupPolicy.prefillQMatmul(4), null).?;
+    try std.testing.expectEqual(@as(usize, 0), selection.indices[0]);
+    try std.testing.expectEqual(@as(usize, 2), selection.indices[1]);
+    try std.testing.expectEqual(@as(?usize, 1), selection.sidecar_indices[0]);
+    try std.testing.expectEqual(@as(?usize, 3), selection.sidecar_indices[1]);
+
+    const groups = try buildProjectionGroups(std.testing.allocator, &ops, ProjectionGroupPolicy.prefillQMatmul(4));
+    defer std.testing.allocator.free(groups);
+    try std.testing.expectEqual(@as(usize, 1), groups.len);
+    try std.testing.expectEqual(@as(u32, 2), groups[0].anchor_count);
+    try std.testing.expectEqual(@as(u32, 2), groups[0].sidecar_count);
+
+    const summary = summarizeProjectionGroups(groups);
+    try std.testing.expectEqual(@as(u32, 4), summary.covered_ops);
+    try std.testing.expectEqual(@as(u32, 3), summary.estimated_saved_dispatches);
+}
+
 test "projection groups reject conflicting or nonhoistable projections" {
     const conflict_ops = [_]backend_mod.DeviceOp{
         testQMatmulWith(1, 0, 16),
@@ -4405,6 +4580,36 @@ test "projection sidecar chains reject incompatible consumers" {
     try std.testing.expectEqual(@as(usize, 2), commands.len);
     try std.testing.expectEqual(ProgramCommandKind.op, commands[0].kind);
     try std.testing.expectEqual(ProgramCommandKind.op, commands[1].kind);
+}
+
+test "projection primary output liveness ignores internal sidecar reads" {
+    const scratch_only = [_]backend_mod.DeviceOp{
+        testQMatmulWith(1, 0, 2),
+        .{ .elementwise = .{ .op = .add, .dst = 2, .src0 = 1, .src1 = 3, .n = 8 } },
+    };
+    try std.testing.expect(!projectionPrimaryOutputHasExternalUsers(&scratch_only, 0, 1));
+
+    const external_read = [_]backend_mod.DeviceOp{
+        testQMatmulWith(1, 0, 2),
+        .{ .elementwise = .{ .op = .add, .dst = 2, .src0 = 1, .src1 = 3, .n = 8 } },
+        .{ .elementwise = .{ .op = .mul, .dst = 4, .src0 = 1, .src1 = 5, .n = 8 } },
+    };
+    try std.testing.expect(projectionPrimaryOutputHasExternalUsers(&external_read, 0, 1));
+
+    const overwritten = [_]backend_mod.DeviceOp{
+        testQMatmulWith(1, 0, 2),
+        .{ .elementwise = .{ .op = .add, .dst = 2, .src0 = 1, .src1 = 3, .n = 8 } },
+        testQMatmulWith(1, 4, 2),
+        .{ .elementwise = .{ .op = .mul, .dst = 5, .src0 = 1, .src1 = 6, .n = 8 } },
+    };
+    try std.testing.expect(!projectionPrimaryOutputHasExternalUsers(&overwritten, 0, 1));
+
+    const inplace_sidecar = [_]backend_mod.DeviceOp{
+        testQMatmulWith(1, 0, 2),
+        .{ .elementwise = .{ .op = .add, .dst = 1, .src0 = 1, .src1 = 3, .n = 8 } },
+        .{ .elementwise = .{ .op = .mul, .dst = 4, .src0 = 1, .src1 = 5, .n = 8 } },
+    };
+    try std.testing.expect(!projectionPrimaryOutputHasExternalUsers(&inplace_sidecar, 0, 1));
 }
 
 test "program command stream emits contiguous batch commands" {

--- a/src/backend/program.zig
+++ b/src/backend/program.zig
@@ -299,6 +299,8 @@ pub const ProgramCommandKind = enum {
     rope_batch,
     movement_batch,
     movement_group,
+    attention_chain,
+    attention_store_chain,
     attention_batch,
     attention_group,
     elementwise_batch,
@@ -313,6 +315,8 @@ pub const ProgramCommandKind = enum {
             .rope_batch => "rope_batch",
             .movement_batch => "movement_batch",
             .movement_group => "movement_group",
+            .attention_chain => "attention_chain",
+            .attention_store_chain => "attention_store_chain",
             .attention_batch => "attention_batch",
             .attention_group => "attention_group",
             .elementwise_batch => "elementwise_batch",
@@ -432,6 +436,7 @@ pub const ProgramCommand = struct {
     pub fn coveredOpCount(self: ProgramCommand) u32 {
         return switch (self.kind) {
             .projection_group, .projection_chain => self.anchor_count + self.sidecar_count,
+            .attention_chain, .attention_store_chain => self.anchor_count + self.sidecar_count,
             .attention_group => self.anchor_count,
             .movement_group => self.anchor_count,
             .elementwise_batch => self.anchor_count,
@@ -441,7 +446,7 @@ pub const ProgramCommand = struct {
 
     pub fn advanceCount(self: ProgramCommand) u32 {
         return switch (self.kind) {
-            .projection_group, .elementwise_batch, .attention_group, .movement_group => 1,
+            .projection_group, .elementwise_batch, .attention_store_chain, .attention_group, .movement_group => 1,
             else => self.op_count,
         };
     }
@@ -467,6 +472,10 @@ pub const ProgramCommandSummary = struct {
     movement_batches: u32 = 0,
     movement_groups: u32 = 0,
     movement_group_ops: u32 = 0,
+    attention_chains: u32 = 0,
+    attention_chain_sidecars: u32 = 0,
+    attention_store_chains: u32 = 0,
+    attention_store_chain_sidecars: u32 = 0,
     attention_batches: u32 = 0,
     attention_groups: u32 = 0,
     attention_group_ops: u32 = 0,
@@ -855,6 +864,18 @@ pub fn findProgramCommand(
         return command;
     }
 
+    if (op == .slice_assign) {
+        if (findAttentionChainCommand(ops, start, used)) |command| {
+            return command;
+        }
+    }
+
+    if (op == .attention) {
+        if (findAttentionStoreChainCommand(ops, start, used)) |command| {
+            return command;
+        }
+    }
+
     if (op == .slice_assign and policy.max_movement_batch >= 2) {
         if (findMovementGroupCommand(ops, start, policy, used)) |command| {
             return command;
@@ -868,6 +889,78 @@ pub fn findProgramCommand(
     }
 
     return null;
+}
+
+fn findAttentionChainCommand(
+    ops: []const backend_mod.DeviceOp,
+    start: usize,
+    used: ?[]const bool,
+) ?ProgramCommand {
+    if (start + 1 >= ops.len) return null;
+    if (commandRangeTouchesUsed(@intCast(start), 2, used)) return null;
+    const sa = switch (ops[start]) {
+        .slice_assign => |sa| sa,
+        else => return null,
+    };
+    const att = switch (ops[start + 1]) {
+        .attention => |att| att,
+        else => return null,
+    };
+    if (attentionSliceAssignOperand(sa, att) == null) return null;
+
+    var command = ProgramCommand{
+        .kind = .attention_chain,
+        .op_start = @intCast(start),
+        .op_count = 2,
+        .anchor_count = 1,
+        .sidecar_count = 1,
+    };
+    command.indices[0] = start + 1;
+    command.sidecar_indices[0] = start;
+    return command;
+}
+
+fn findAttentionStoreChainCommand(
+    ops: []const backend_mod.DeviceOp,
+    start: usize,
+    used: ?[]const bool,
+) ?ProgramCommand {
+    if (start >= ops.len) return null;
+    if (used) |used_ops| {
+        if (start >= used_ops.len or used_ops[start]) return null;
+    }
+    const att = switch (ops[start]) {
+        .attention => |att| att,
+        else => return null,
+    };
+
+    var sidecar_idx: ?usize = null;
+    var scan = start + 1;
+    while (scan < ops.len) : (scan += 1) {
+        if (used) |used_ops| {
+            if (scan >= used_ops.len or used_ops[scan]) continue;
+        }
+        const sa = switch (ops[scan]) {
+            .slice_assign => |sa| sa,
+            else => continue,
+        };
+        if (!attentionSliceStoreCompatible(att, sa)) continue;
+        if (!canFuseAttentionStoreSidecar(ops, start, scan, sa)) continue;
+        sidecar_idx = scan;
+        break;
+    }
+    const found = sidecar_idx orelse return null;
+
+    var command = ProgramCommand{
+        .kind = .attention_store_chain,
+        .op_start = @intCast(start),
+        .op_count = @intCast(found - start + 1),
+        .anchor_count = 1,
+        .sidecar_count = 1,
+    };
+    command.indices[0] = start;
+    command.sidecar_indices[0] = found;
+    return command;
 }
 
 fn findMovementGroupCommand(
@@ -1086,6 +1179,14 @@ pub fn summarizeProgramCommands(commands: []const ProgramCommand) ProgramCommand
                 summary.movement_groups += 1;
                 summary.movement_group_ops += command.anchor_count;
             },
+            .attention_chain => {
+                summary.attention_chains += 1;
+                summary.attention_chain_sidecars += command.sidecar_count;
+            },
+            .attention_store_chain => {
+                summary.attention_store_chains += 1;
+                summary.attention_store_chain_sidecars += command.sidecar_count;
+            },
             .attention_batch => summary.attention_batches += 1,
             .attention_group => {
                 summary.attention_groups += 1;
@@ -1112,11 +1213,11 @@ pub fn summarizeProgramCommands(commands: []const ProgramCommand) ProgramCommand
 
 pub fn markProgramCommandUsed(used: []bool, command: ProgramCommand) void {
     switch (command.kind) {
-        .projection_group, .elementwise_batch, .attention_group, .movement_group => {
+        .projection_group, .elementwise_batch, .attention_store_chain, .attention_group, .movement_group => {
             for (command.anchorIndices()) |idx| {
                 if (idx < used.len) used[idx] = true;
             }
-            if (command.kind == .projection_group) {
+            if (command.kind == .projection_group or command.kind == .attention_store_chain) {
                 for (command.sidecarIndices()) |maybe_idx| {
                     if (maybe_idx) |idx| {
                         if (idx < used.len) used[idx] = true;
@@ -1358,6 +1459,76 @@ pub fn canHoistOpTo(
     return true;
 }
 
+pub fn canFuseAttentionStoreSidecar(
+    ops: []const backend_mod.DeviceOp,
+    attention_index: usize,
+    sidecar_index: usize,
+    sa: anytype,
+) bool {
+    return attentionStoreSidecarBlocker(ops, attention_index, sidecar_index, sa) == .none;
+}
+
+pub const AttentionStoreSidecarBlocker = enum {
+    none,
+    invalid_range,
+    candidate_read_written,
+    sidecar_write_read,
+    sidecar_write_written,
+    overflow_conflict,
+};
+
+pub fn attentionStoreSidecarBlocker(
+    ops: []const backend_mod.DeviceOp,
+    attention_index: usize,
+    sidecar_index: usize,
+    sa: anytype,
+) AttentionStoreSidecarBlocker {
+    if (attention_index >= sidecar_index or sidecar_index > ops.len) return .invalid_range;
+    const candidate_access = opAccessSpans(.{ .slice_assign = sa });
+    for (ops[attention_index + 1 .. sidecar_index]) |op| {
+        for (candidate_access.readSpans()) |read| {
+            if (opWritesSpan(op, read)) return .candidate_read_written;
+        }
+        for (candidate_access.writeSpans()) |write| {
+            if (opReadsSpan(op, write)) return .sidecar_write_read;
+            if (opWritesSpan(op, write)) {
+                const other_sa = switch (op) {
+                    .slice_assign => |other| other,
+                    else => return .sidecar_write_written,
+                };
+                if (sliceAssignWritesMayOverlap(other_sa, sa)) return .sidecar_write_written;
+            }
+        }
+        if (candidate_access.read_overflow or candidate_access.write_overflow) {
+            if (opAccessConflicts(op, .{ .slice_assign = sa })) return .overflow_conflict;
+        }
+    }
+    return .none;
+}
+
+fn sliceAssignWritesMayOverlap(a: anytype, b: anytype) bool {
+    if (a.dst != b.dst) return false;
+    if (a.dst_row_stride == 1 and
+        b.dst_row_stride == 1 and
+        a.dst_col_stride == b.dst_col_stride and
+        a.dst_col_stride > 0)
+    {
+        const stride: i64 = @intCast(a.dst_col_stride);
+        const diff: i64 = @as(i64, @intCast(b.dst_offset)) - @as(i64, @intCast(a.dst_offset));
+        const min_delta = -@as(i64, @intCast(a.cols)) + 1;
+        const max_delta = @as(i64, @intCast(b.cols)) - 1;
+        var delta = min_delta;
+        while (delta <= max_delta) : (delta += 1) {
+            const start_delta = diff + delta * stride;
+            if (start_delta < @as(i64, @intCast(a.rows)) and -start_delta < @as(i64, @intCast(b.rows))) return true;
+        }
+        return false;
+    }
+    const a_span = stridedSpan(a.dst, a.dst_offset, a.rows, a.cols, a.dst_row_stride, a.dst_col_stride);
+    const b_span = stridedSpan(b.dst, b.dst_offset, b.rows, b.cols, b.dst_row_stride, b.dst_col_stride);
+    return a_span.overlaps(b_span);
+}
+
 pub fn opConflictsSelected(
     ops: []const backend_mod.DeviceOp,
     indices: []const usize,
@@ -1462,6 +1633,41 @@ pub fn qmatvecSliceSidecarCompatible(q: anytype, sa: anytype) bool {
 
 pub fn qmatmulDstRowStride(q: anytype) u32 {
     return if (q.dst_row_stride != 0) q.dst_row_stride else q.N;
+}
+
+pub const AttentionOperand = enum { q, k, v };
+
+pub fn attentionSliceAssignOperand(sa: anytype, att: anytype) ?AttentionOperand {
+    if (attentionSliceMatches(sa, att.q, att.q_off, att.d_head, att.seq_q, att.q_rs, att.q_cs)) return .q;
+    if (attentionSliceMatches(sa, att.k, att.k_off, att.d_head, att.seq_kv, att.k_rs, att.k_cs)) return .k;
+    if (attentionSliceMatches(sa, att.v, att.v_off, att.d_head, att.seq_kv, att.v_rs, att.v_cs)) return .v;
+    return null;
+}
+
+pub fn attentionSliceStoreCompatible(att: anytype, sa: anytype) bool {
+    return sa.src == att.dst and
+        sa.src_offset == att.dst_off and
+        sa.rows == att.d_head and
+        sa.cols == att.seq_q and
+        sa.src_row_stride == att.dst_rs and
+        sa.src_col_stride == att.dst_cs;
+}
+
+fn attentionSliceMatches(
+    sa: anytype,
+    buf: u16,
+    offset: u32,
+    rows: u32,
+    cols: u32,
+    row_stride: u32,
+    col_stride: u32,
+) bool {
+    return sa.dst == buf and
+        sa.dst_offset == offset and
+        sa.rows == rows and
+        sa.cols == cols and
+        sa.dst_row_stride == row_stride and
+        sa.dst_col_stride == col_stride;
 }
 
 pub fn isRopeSliceAssignChain(
@@ -2911,6 +3117,123 @@ test "program command stream emits noncontiguous attention groups" {
     try std.testing.expectEqual(@as(u32, 1), summary.estimated_saved_dispatches);
     try std.testing.expectEqual(@as(u32, 1), summary.attention_groups);
     try std.testing.expectEqual(@as(u32, 2), summary.attention_group_ops);
+}
+
+test "program command stream emits attention producer chains" {
+    const ops = [_]backend_mod.DeviceOp{
+        .{ .slice_assign = .{
+            .dst = 2,
+            .src = 9,
+            .rows = 4,
+            .cols = 4,
+            .dst_base_offset = 0,
+            .dst_offset = 0,
+            .dst_row_stride = 1,
+            .dst_col_stride = 4,
+            .src_offset = 0,
+            .src_row_stride = 1,
+            .src_col_stride = 4,
+            .patch_stride = 4,
+        } },
+        testAttention(0),
+    };
+
+    const commands = try buildProgramCommands(std.testing.allocator, &ops, CommandStreamPolicy.metal(4, 4));
+    defer std.testing.allocator.free(commands);
+
+    try std.testing.expectEqual(@as(usize, 1), commands.len);
+    try std.testing.expectEqual(ProgramCommandKind.attention_chain, commands[0].kind);
+    try std.testing.expectEqual(@as(u32, 1), commands[0].anchor_count);
+    try std.testing.expectEqual(@as(u32, 1), commands[0].sidecar_count);
+    try std.testing.expectEqual(@as(usize, 1), commands[0].indices[0]);
+    try std.testing.expectEqual(@as(?usize, 0), commands[0].sidecar_indices[0]);
+
+    const summary = summarizeProgramCommands(commands);
+    try std.testing.expectEqual(@as(u32, 1), summary.commands);
+    try std.testing.expectEqual(@as(u32, 2), summary.covered_ops);
+    try std.testing.expectEqual(@as(u32, 1), summary.estimated_dispatches);
+    try std.testing.expectEqual(@as(u32, 1), summary.estimated_saved_dispatches);
+    try std.testing.expectEqual(@as(u32, 1), summary.attention_chains);
+    try std.testing.expectEqual(@as(u32, 1), summary.attention_chain_sidecars);
+}
+
+test "program command stream emits attention output store chains" {
+    const ops = [_]backend_mod.DeviceOp{
+        testAttention(0),
+        .{ .slice_assign = .{
+            .dst = 9,
+            .src = 4,
+            .rows = 4,
+            .cols = 2,
+            .dst_base_offset = 0,
+            .dst_offset = 8,
+            .dst_row_stride = 1,
+            .dst_col_stride = 4,
+            .src_offset = 0,
+            .src_row_stride = 1,
+            .src_col_stride = 4,
+            .patch_stride = 4,
+        } },
+    };
+
+    const commands = try buildProgramCommands(std.testing.allocator, &ops, CommandStreamPolicy.metal(4, 4));
+    defer std.testing.allocator.free(commands);
+
+    try std.testing.expectEqual(@as(usize, 1), commands.len);
+    try std.testing.expectEqual(ProgramCommandKind.attention_store_chain, commands[0].kind);
+    try std.testing.expectEqual(@as(u32, 1), commands[0].anchor_count);
+    try std.testing.expectEqual(@as(u32, 1), commands[0].sidecar_count);
+    try std.testing.expectEqual(@as(usize, 0), commands[0].indices[0]);
+    try std.testing.expectEqual(@as(?usize, 1), commands[0].sidecar_indices[0]);
+
+    const summary = summarizeProgramCommands(commands);
+    try std.testing.expectEqual(@as(u32, 1), summary.commands);
+    try std.testing.expectEqual(@as(u32, 2), summary.covered_ops);
+    try std.testing.expectEqual(@as(u32, 1), summary.estimated_dispatches);
+    try std.testing.expectEqual(@as(u32, 1), summary.estimated_saved_dispatches);
+    try std.testing.expectEqual(@as(u32, 1), summary.attention_store_chains);
+    try std.testing.expectEqual(@as(u32, 1), summary.attention_store_chain_sidecars);
+}
+
+test "program command stream carries delayed attention output stores" {
+    const ops = [_]backend_mod.DeviceOp{
+        testAttention(0),
+        testQMatmulWith(8, 0, 2),
+        .{ .slice_assign = .{
+            .dst = 9,
+            .src = 4,
+            .rows = 4,
+            .cols = 2,
+            .dst_base_offset = 0,
+            .dst_offset = 8,
+            .dst_row_stride = 1,
+            .dst_col_stride = 4,
+            .src_offset = 0,
+            .src_row_stride = 1,
+            .src_col_stride = 4,
+            .patch_stride = 4,
+        } },
+    };
+
+    const commands = try buildProgramCommands(std.testing.allocator, &ops, CommandStreamPolicy.metal(4, 4));
+    defer std.testing.allocator.free(commands);
+
+    try std.testing.expectEqual(@as(usize, 2), commands.len);
+    try std.testing.expectEqual(ProgramCommandKind.attention_store_chain, commands[0].kind);
+    try std.testing.expectEqual(@as(u32, 3), commands[0].op_count);
+    try std.testing.expectEqual(@as(usize, 0), commands[0].indices[0]);
+    try std.testing.expectEqual(@as(?usize, 2), commands[0].sidecar_indices[0]);
+    try std.testing.expectEqual(ProgramCommandKind.op, commands[1].kind);
+    try std.testing.expectEqual(@as(u32, 1), commands[1].op_start);
+
+    const summary = summarizeProgramCommands(commands);
+    try std.testing.expectEqual(@as(u32, 2), summary.commands);
+    try std.testing.expectEqual(@as(u32, 3), summary.covered_ops);
+    try std.testing.expectEqual(@as(u32, 2), summary.estimated_dispatches);
+    try std.testing.expectEqual(@as(u32, 1), summary.estimated_saved_dispatches);
+    try std.testing.expectEqual(@as(u32, 1), summary.op_commands);
+    try std.testing.expectEqual(@as(u32, 1), summary.attention_store_chains);
+    try std.testing.expectEqual(@as(u32, 1), summary.attention_store_chain_sidecars);
 }
 
 test "program command stream emits noncontiguous movement groups" {

--- a/src/backend/program.zig
+++ b/src/backend/program.zig
@@ -468,6 +468,55 @@ pub const ProgramCommandSummary = struct {
 
 pub const max_projection_group_anchors = 8;
 
+pub const BufferSpan = struct {
+    buf: u16,
+    start: u64,
+    end: u64,
+
+    pub fn overlaps(self: BufferSpan, other: BufferSpan) bool {
+        return self.buf == other.buf and self.start < other.end and other.start < self.end;
+    }
+};
+
+const max_access_spans = 16;
+
+const OpAccessSpans = struct {
+    reads: [max_access_spans]BufferSpan = undefined,
+    writes: [max_access_spans]BufferSpan = undefined,
+    read_count: u8 = 0,
+    write_count: u8 = 0,
+    read_overflow: bool = false,
+    write_overflow: bool = false,
+
+    fn addRead(self: *OpAccessSpans, span: BufferSpan) void {
+        if (span.start == span.end) return;
+        if (self.read_count >= max_access_spans) {
+            self.read_overflow = true;
+            return;
+        }
+        self.reads[self.read_count] = span;
+        self.read_count += 1;
+    }
+
+    fn addWrite(self: *OpAccessSpans, span: BufferSpan) void {
+        if (span.start == span.end) return;
+        if (self.write_count >= max_access_spans) {
+            self.write_overflow = true;
+            return;
+        }
+        self.writes[self.write_count] = span;
+        self.write_count += 1;
+    }
+
+    fn readSpans(self: *const OpAccessSpans) []const BufferSpan {
+        return self.reads[0..self.read_count];
+    }
+
+    fn writeSpans(self: *const OpAccessSpans) []const BufferSpan {
+        return self.writes[0..self.write_count];
+    }
+};
+
 pub const ProjectionGroup = struct {
     kind: ProjectionGroupKind,
     start_op: u32,
@@ -986,17 +1035,188 @@ pub fn opTouchesBuffer(op: backend_mod.DeviceOp, buf: u16) bool {
     return opReadsBuffer(op, buf) or opWritesBuffer(op, buf);
 }
 
+fn bufferSpan(buf: u16, offset: anytype, len: anytype) BufferSpan {
+    const start: u64 = @intCast(offset);
+    const n: u64 = @intCast(len);
+    return .{ .buf = buf, .start = start, .end = start + n };
+}
+
+fn stridedSpan(buf: u16, offset: anytype, rows: anytype, cols: anytype, row_stride: anytype, col_stride: anytype) BufferSpan {
+    const start: u64 = @intCast(offset);
+    const r: u64 = @intCast(rows);
+    const c: u64 = @intCast(cols);
+    if (r == 0 or c == 0) return .{ .buf = buf, .start = start, .end = start };
+    const rs: u64 = @intCast(row_stride);
+    const cs: u64 = @intCast(col_stride);
+    const last = start + (r - 1) * rs + (c - 1) * cs;
+    return .{ .buf = buf, .start = start, .end = last + 1 };
+}
+
+fn strided4Span(buf: u16, offset: anytype, ne: [4]u32, strides: [4]u32) BufferSpan {
+    const start: u64 = @intCast(offset);
+    var last = start;
+    for (ne, 0..) |extent, i| {
+        if (extent == 0) return .{ .buf = buf, .start = start, .end = start };
+        last += @as(u64, extent - 1) * @as(u64, strides[i]);
+    }
+    return .{ .buf = buf, .start = start, .end = last + 1 };
+}
+
+fn opAccessSpans(op: backend_mod.DeviceOp) OpAccessSpans {
+    var access = OpAccessSpans{};
+    switch (op) {
+        .elementwise => |e| {
+            access.addRead(bufferSpan(e.src0, e.src0_offset, e.n));
+            if (e.op.isBinary()) access.addRead(bufferSpan(e.src1, e.src1_offset, e.n));
+            access.addWrite(bufferSpan(e.dst, e.dst_offset, e.n));
+        },
+        .matmul => |m| {
+            const g = m.geom;
+            access.addRead(stridedSpan(m.a, g.a_offset, g.M, g.K, g.a_row_stride, g.a_col_stride));
+            access.addRead(stridedSpan(m.b, g.b_offset, g.K, g.N, g.b_row_stride, g.b_col_stride));
+            access.addWrite(stridedSpan(m.dst, g.dst_offset, g.M, g.N, g.dst_row_stride, 1));
+        },
+        .qmatmul => |q| {
+            const input_row_stride = if (q.input_row_stride != 0) q.input_row_stride else q.K;
+            access.addRead(stridedSpan(q.input, q.input_offset, q.M, q.K, input_row_stride, 1));
+            access.addWrite(stridedSpan(q.dst, q.dst_offset, q.M, q.N, qmatmulDstRowStride(q), 1));
+        },
+        .softmax => |s| {
+            access.addRead(bufferSpan(s.src, s.src_offset, s.rows * s.cols));
+            access.addWrite(bufferSpan(s.dst, s.dst_offset, s.rows * s.cols));
+        },
+        .layernorm => |l| {
+            access.addRead(bufferSpan(l.src, l.src_offset, l.rows * l.cols));
+            access.addWrite(bufferSpan(l.dst, l.dst_offset, l.rows * l.cols));
+        },
+        .rmsnorm => |r| {
+            access.addRead(bufferSpan(r.src, r.src_offset, r.rows * r.cols));
+            access.addWrite(bufferSpan(r.dst, r.dst_offset, r.rows * r.cols));
+        },
+        .reduce => |r| {
+            access.addRead(bufferSpan(r.src, r.src_offset, r.n_out * r.reduce_size));
+            access.addWrite(bufferSpan(r.dst, r.dst_offset, r.n_out));
+        },
+        .repeat => |rp| {
+            access.addRead(strided4Span(rp.src, rp.src_offset, rp.src_ne, rp.src_strides));
+            access.addWrite(strided4Span(rp.dst, rp.dst_offset, rp.dst_ne, rp.dst_strides));
+        },
+        .slice_assign => |sa| {
+            access.addRead(stridedSpan(sa.src, sa.src_offset, sa.rows, sa.cols, sa.src_row_stride, sa.src_col_stride));
+            access.addWrite(stridedSpan(sa.dst, sa.dst_offset, sa.rows, sa.cols, sa.dst_row_stride, sa.dst_col_stride));
+        },
+        .rope => |rr| {
+            const d = rr.half_d * 2;
+            access.addRead(stridedSpan(rr.src, rr.src_off, d, rr.seq_len, rr.src_rs, rr.src_cs));
+            access.addRead(stridedSpan(rr.cos_sin, rr.cs_off, d, rr.seq_len, 1, rr.cs_cs));
+            access.addWrite(stridedSpan(rr.dst, rr.dst_off, d, rr.seq_len, 1, d));
+        },
+        .attention => |att| {
+            access.addRead(stridedSpan(att.q, att.q_off, att.d_head, att.seq_q, att.q_rs, att.q_cs));
+            access.addRead(stridedSpan(att.k, att.k_off, att.d_head, att.seq_kv, att.k_rs, att.k_cs));
+            access.addRead(stridedSpan(att.v, att.v_off, att.d_head, att.seq_kv, att.v_rs, att.v_cs));
+            if (att.has_mask) access.addRead(stridedSpan(att.mask, att.mask_off, att.seq_kv, att.seq_q, att.mask_rs, att.mask_cs));
+            access.addWrite(stridedSpan(att.dst, att.dst_off, att.d_head, att.seq_q, att.dst_rs, att.dst_cs));
+        },
+        .fused_elementwise => |fe| {
+            access.addRead(bufferSpan(fe.src, fe.src_offset, fe.n));
+            for (fe.steps) |step| {
+                if (step.op.isBinary()) access.addRead(bufferSpan(step.secondary_buf, step.secondary_offset, fe.n));
+            }
+            access.addWrite(bufferSpan(fe.dst, fe.dst_offset, fe.n));
+        },
+    }
+    return access;
+}
+
+pub fn opReadsSpan(op: backend_mod.DeviceOp, target: BufferSpan) bool {
+    const access = opAccessSpans(op);
+    for (access.readSpans()) |read| {
+        if (read.overlaps(target)) return true;
+    }
+    return access.read_overflow and opReadsBuffer(op, target.buf);
+}
+
+pub fn opWritesSpan(op: backend_mod.DeviceOp, target: BufferSpan) bool {
+    const access = opAccessSpans(op);
+    for (access.writeSpans()) |write| {
+        if (write.overlaps(target)) return true;
+    }
+    return access.write_overflow and opWritesBuffer(op, target.buf);
+}
+
+pub fn opTouchesSpan(op: backend_mod.DeviceOp, target: BufferSpan) bool {
+    return opReadsSpan(op, target) or opWritesSpan(op, target);
+}
+
+pub fn opAccessConflicts(a: backend_mod.DeviceOp, b: backend_mod.DeviceOp) bool {
+    const a_access = opAccessSpans(a);
+    const b_access = opAccessSpans(b);
+    for (a_access.writeSpans()) |write| {
+        for (b_access.writeSpans()) |other_write| {
+            if (write.overlaps(other_write)) return true;
+        }
+        for (b_access.readSpans()) |read| {
+            if (write.overlaps(read)) return true;
+        }
+        if ((b_access.read_overflow and opReadsBuffer(b, write.buf)) or (b_access.write_overflow and opWritesBuffer(b, write.buf))) return true;
+    }
+    for (a_access.readSpans()) |read| {
+        for (b_access.writeSpans()) |write| {
+            if (read.overlaps(write)) return true;
+        }
+        if (b_access.write_overflow and opWritesBuffer(b, read.buf)) return true;
+    }
+    if (a_access.read_overflow or a_access.write_overflow) {
+        const b_may_touch_overflowed_buffer = for (b_access.readSpans()) |read| {
+            if (opTouchesBuffer(a, read.buf)) break true;
+        } else for (b_access.writeSpans()) |write| {
+            if (opTouchesBuffer(a, write.buf)) break true;
+        } else false;
+        if (b_may_touch_overflowed_buffer) return true;
+    }
+    return false;
+}
+
+pub fn canHoistOpTo(
+    ops: []const backend_mod.DeviceOp,
+    start: usize,
+    candidate_index: usize,
+    candidate: backend_mod.DeviceOp,
+) bool {
+    const candidate_access = opAccessSpans(candidate);
+    for (ops[start..candidate_index]) |op| {
+        for (candidate_access.readSpans()) |read| {
+            if (opWritesSpan(op, read)) return false;
+        }
+        for (candidate_access.writeSpans()) |write| {
+            if (opTouchesSpan(op, write)) return false;
+        }
+        if (candidate_access.read_overflow or candidate_access.write_overflow) {
+            if (opAccessConflicts(op, candidate)) return false;
+        }
+    }
+    return true;
+}
+
+pub fn opConflictsSelected(
+    ops: []const backend_mod.DeviceOp,
+    indices: []const usize,
+    candidate: backend_mod.DeviceOp,
+) bool {
+    for (indices) |idx| {
+        if (opAccessConflicts(ops[idx], candidate)) return true;
+    }
+    return false;
+}
+
 pub fn canHoistProjectionTo(
     ops: []const backend_mod.DeviceOp,
     start: usize,
     candidate_index: usize,
     q: anytype,
 ) bool {
-    for (ops[start..candidate_index]) |op| {
-        if (opWritesBuffer(op, q.input)) return false;
-        if (opTouchesBuffer(op, q.dst)) return false;
-    }
-    return true;
+    return canHoistOpTo(ops, start, candidate_index, .{ .qmatmul = q });
 }
 
 pub fn canBatchElementwiseOp(e: anytype) bool {
@@ -1009,12 +1229,7 @@ pub fn canHoistElementwiseTo(
     candidate_index: usize,
     e: anytype,
 ) bool {
-    for (ops[start..candidate_index]) |op| {
-        if (opWritesBuffer(op, e.src0)) return false;
-        if (e.op.isBinary() and opWritesBuffer(op, e.src1)) return false;
-        if (opTouchesBuffer(op, e.dst)) return false;
-    }
-    return true;
+    return canHoistOpTo(ops, start, candidate_index, .{ .elementwise = e });
 }
 
 pub fn elementwiseConflictsSelected(
@@ -1022,13 +1237,7 @@ pub fn elementwiseConflictsSelected(
     indices: []const usize,
     e: anytype,
 ) bool {
-    for (indices) |idx| {
-        const selected = ops[idx].elementwise;
-        if (selected.dst == e.dst) return true;
-        if (selected.dst == e.src0 or (e.op.isBinary() and selected.dst == e.src1)) return true;
-        if (e.dst == selected.src0 or (selected.op.isBinary() and e.dst == selected.src1)) return true;
-    }
-    return false;
+    return opConflictsSelected(ops, indices, .{ .elementwise = e });
 }
 
 pub fn projectionConflictsSelected(
@@ -1036,11 +1245,7 @@ pub fn projectionConflictsSelected(
     indices: []const usize,
     q: anytype,
 ) bool {
-    for (indices) |idx| {
-        const selected = ops[idx].qmatmul;
-        if (selected.dst == q.dst or selected.input == q.dst or selected.dst == q.input) return true;
-    }
-    return false;
+    return opConflictsSelected(ops, indices, .{ .qmatmul = q });
 }
 
 pub fn qmatmulSliceSrcColStart(q: anytype, sa: anytype) ?u32 {
@@ -2346,6 +2551,25 @@ test "projection groups reject conflicting or nonhoistable projections" {
     const blocked_groups = try buildProjectionGroups(std.testing.allocator, &blocked_ops, ProjectionGroupPolicy.prefillQMatmul(4));
     defer std.testing.allocator.free(blocked_groups);
     try std.testing.expectEqual(@as(usize, 0), blocked_groups.len);
+}
+
+test "projection groups use access spans instead of whole-buffer conflicts" {
+    var first = testQMatmulWith(1, 0, 2);
+    first.qmatmul.dst_offset = 0;
+    var second = testQMatmulWith(1, 0, 2);
+    second.qmatmul.dst_offset = 8;
+    const disjoint_ops = [_]backend_mod.DeviceOp{ first, second };
+
+    const groups = try buildProjectionGroups(std.testing.allocator, &disjoint_ops, ProjectionGroupPolicy.prefillQMatmul(4));
+    defer std.testing.allocator.free(groups);
+    try std.testing.expectEqual(@as(usize, 1), groups.len);
+    try std.testing.expectEqual(@as(u32, 2), groups[0].anchor_count);
+
+    second.qmatmul.dst_offset = 4;
+    const overlapping_ops = [_]backend_mod.DeviceOp{ first, second };
+    const overlapping_groups = try buildProjectionGroups(std.testing.allocator, &overlapping_ops, ProjectionGroupPolicy.prefillQMatmul(4));
+    defer std.testing.allocator.free(overlapping_groups);
+    try std.testing.expectEqual(@as(usize, 0), overlapping_groups.len);
 }
 
 test "program command stream merges stage and projection commands" {

--- a/src/backend/program.zig
+++ b/src/backend/program.zig
@@ -300,6 +300,7 @@ pub const ProgramCommandKind = enum {
     movement_batch,
     attention_batch,
     elementwise_batch,
+    projection_chain,
     projection_group,
 
     pub fn label(self: ProgramCommandKind) []const u8 {
@@ -311,6 +312,7 @@ pub const ProgramCommandKind = enum {
             .movement_batch => "movement_batch",
             .attention_batch => "attention_batch",
             .elementwise_batch => "elementwise_batch",
+            .projection_chain => "projection_chain",
             .projection_group => "projection_group",
         };
     }
@@ -425,7 +427,7 @@ pub const ProgramCommand = struct {
 
     pub fn coveredOpCount(self: ProgramCommand) u32 {
         return switch (self.kind) {
-            .projection_group => self.anchor_count + self.sidecar_count,
+            .projection_group, .projection_chain => self.anchor_count + self.sidecar_count,
             .elementwise_batch => self.anchor_count,
             else => self.op_count,
         };
@@ -460,6 +462,8 @@ pub const ProgramCommandSummary = struct {
     attention_batches: u32 = 0,
     elementwise_batches: u32 = 0,
     elementwise_ops: u32 = 0,
+    projection_chains: u32 = 0,
+    projection_chain_sidecars: u32 = 0,
     projection_groups: u32 = 0,
     projection_anchors: u32 = 0,
     projection_sidecars: u32 = 0,
@@ -818,6 +822,9 @@ pub fn findProgramCommand(
                 return ProgramCommand.fromProjectionSelection(selection);
             }
         }
+        if (findProjectionChainCommand(ops, start, used)) |command| {
+            return command;
+        }
     }
 
     if (op == .elementwise and policy.max_elementwise_batch >= 2) {
@@ -839,6 +846,32 @@ pub fn findProgramCommand(
     }
 
     return null;
+}
+
+fn findProjectionChainCommand(
+    ops: []const backend_mod.DeviceOp,
+    start: usize,
+    used: ?[]const bool,
+) ?ProgramCommand {
+    if (start + 1 >= ops.len) return null;
+    if (commandRangeTouchesUsed(@intCast(start), 2, used)) return null;
+    const q = switch (ops[start]) {
+        .qmatmul => |q| q,
+        else => return null,
+    };
+    if (!projectionSidecarCompatible(q, ops[start + 1])) return null;
+
+    var command = ProgramCommand{
+        .kind = .projection_chain,
+        .op_start = @intCast(start),
+        .op_count = 2,
+        .projection_kind = if (q.M == 1) .qmatvec else .qmatmul,
+        .anchor_count = 1,
+        .sidecar_count = 1,
+    };
+    command.indices[0] = start;
+    command.sidecar_indices[0] = start + 1;
+    return command;
 }
 
 fn findElementwiseBatchCommand(
@@ -939,6 +972,10 @@ pub fn summarizeProgramCommands(commands: []const ProgramCommand) ProgramCommand
             .elementwise_batch => {
                 summary.elementwise_batches += 1;
                 summary.elementwise_ops += command.anchor_count;
+            },
+            .projection_chain => {
+                summary.projection_chains += 1;
+                summary.projection_chain_sidecars += command.sidecar_count;
             },
             .projection_group => {
                 summary.projection_groups += 1;
@@ -1246,6 +1283,31 @@ pub fn projectionConflictsSelected(
     q: anytype,
 ) bool {
     return opConflictsSelected(ops, indices, .{ .qmatmul = q });
+}
+
+pub fn projectionSidecarCompatible(q: anytype, op: backend_mod.DeviceOp) bool {
+    return switch (op) {
+        .slice_assign => |sa| if (q.M == 1) qmatvecSliceSidecarCompatible(q, sa) else qmatmulSliceSidecarCompatible(q, sa),
+        .elementwise => |e| qmatmulElementwiseSidecarCompatible(q, e),
+        .fused_elementwise => |fe| qmatmulFusedElementwiseSidecarCompatible(q, fe),
+        else => false,
+    };
+}
+
+pub fn qmatmulElementwiseSidecarCompatible(q: anytype, e: anytype) bool {
+    if (q.M == 1) return false;
+    if (e.op != .add and e.op != .mul) return false;
+    if (e.n != q.M * q.N) return false;
+    if (qmatmulDstRowStride(q) != q.N) return false;
+    return (e.src0 == q.dst and e.src0_offset == q.dst_offset) or
+        (e.src1 == q.dst and e.src1_offset == q.dst_offset);
+}
+
+pub fn qmatmulFusedElementwiseSidecarCompatible(q: anytype, fe: anytype) bool {
+    if (q.M == 1) return false;
+    if (fe.n != q.M * q.N) return false;
+    if (qmatmulDstRowStride(q) != q.N) return false;
+    return fe.src == q.dst and fe.src_offset == q.dst_offset;
 }
 
 pub fn qmatmulSliceSrcColStart(q: anytype, sa: anytype) ?u32 {
@@ -2625,6 +2687,46 @@ test "program command stream keeps used noncontiguous ops single-owned" {
     try std.testing.expectEqual(@as(u32, 1), summary.op_commands);
     try std.testing.expectEqual(@as(u32, 1), summary.projection_groups);
     try std.testing.expectEqual(@as(u32, 1), summary.estimated_saved_dispatches);
+}
+
+test "program command stream emits projection sidecar chains" {
+    const ops = [_]backend_mod.DeviceOp{
+        testQMatmulWith(1, 0, 2),
+        .{ .elementwise = .{ .op = .add, .dst = 2, .src0 = 1, .src1 = 3, .n = 8 } },
+    };
+
+    const commands = try buildProgramCommands(std.testing.allocator, &ops, CommandStreamPolicy.metal(4, 4));
+    defer std.testing.allocator.free(commands);
+
+    try std.testing.expectEqual(@as(usize, 1), commands.len);
+    try std.testing.expectEqual(ProgramCommandKind.projection_chain, commands[0].kind);
+    try std.testing.expectEqual(ProjectionGroupKind.qmatmul, commands[0].projection_kind);
+    try std.testing.expectEqual(@as(u32, 1), commands[0].anchor_count);
+    try std.testing.expectEqual(@as(u32, 1), commands[0].sidecar_count);
+    try std.testing.expectEqual(@as(usize, 0), commands[0].indices[0]);
+    try std.testing.expectEqual(@as(?usize, 1), commands[0].sidecar_indices[0]);
+
+    const summary = summarizeProgramCommands(commands);
+    try std.testing.expectEqual(@as(u32, 1), summary.commands);
+    try std.testing.expectEqual(@as(u32, 2), summary.covered_ops);
+    try std.testing.expectEqual(@as(u32, 1), summary.estimated_dispatches);
+    try std.testing.expectEqual(@as(u32, 1), summary.estimated_saved_dispatches);
+    try std.testing.expectEqual(@as(u32, 1), summary.projection_chains);
+    try std.testing.expectEqual(@as(u32, 1), summary.projection_chain_sidecars);
+}
+
+test "projection sidecar chains reject incompatible consumers" {
+    const ops = [_]backend_mod.DeviceOp{
+        testQMatmulWith(1, 0, 2),
+        .{ .elementwise = .{ .op = .add, .dst = 2, .src0 = 1, .src1 = 3, .n = 7 } },
+    };
+
+    const commands = try buildProgramCommands(std.testing.allocator, &ops, CommandStreamPolicy.metal(4, 4));
+    defer std.testing.allocator.free(commands);
+
+    try std.testing.expectEqual(@as(usize, 2), commands.len);
+    try std.testing.expectEqual(ProgramCommandKind.op, commands[0].kind);
+    try std.testing.expectEqual(ProgramCommandKind.op, commands[1].kind);
 }
 
 test "program command stream emits contiguous batch commands" {

--- a/src/backend/program.zig
+++ b/src/backend/program.zig
@@ -2,6 +2,7 @@
 
 const std = @import("std");
 const backend_mod = @import("../backend.zig");
+const DeviceOpTag = std.meta.Tag(backend_mod.DeviceOp);
 
 pub const compute_op_softmax: u32 = 100;
 pub const compute_op_layernorm: u32 = 101;
@@ -261,11 +262,7 @@ pub const StageCommandKind = enum {
     rope_chain,
 
     pub fn label(self: StageCommandKind) []const u8 {
-        return switch (self) {
-            .op => "op",
-            .row_chain => "row_chain",
-            .rope_chain => "rope_chain",
-        };
+        return @tagName(self);
     }
 };
 
@@ -275,9 +272,8 @@ pub const StageCommand = struct {
     op_count: u32,
 
     pub fn dispatchCount(self: StageCommand) u32 {
-        return switch (self.kind) {
-            .op, .row_chain, .rope_chain => 1,
-        };
+        _ = self;
+        return 1;
     }
 };
 
@@ -308,30 +304,82 @@ pub const ProgramCommandKind = enum {
     attention_batch,
     attention_group,
     elementwise_batch,
+    repeat_fused_elementwise_chain,
+    projection_fused_elementwise_chain,
+    projection_pair_fused_elementwise_chain,
     projection_chain,
     projection_group,
+    projection_cache_group,
 
     pub fn label(self: ProgramCommandKind) []const u8 {
+        return @tagName(self);
+    }
+
+    pub fn shape(self: ProgramCommandKind) ProgramCommandShape {
         return switch (self) {
-            .op => "op",
-            .row_chain => "row_chain",
-            .rope_chain => "rope_chain",
-            .rope_batch => "rope_batch",
-            .rope_store_group => "rope_store_group",
-            .movement_batch => "movement_batch",
-            .movement_group => "movement_group",
-            .attention_chain => "attention_chain",
-            .attention_store_chain => "attention_store_chain",
-            .attention_store_group => "attention_store_group",
-            .rope_attention_store_chain => "rope_attention_store_chain",
-            .rope_attention_store_group => "rope_attention_store_group",
-            .attention_batch => "attention_batch",
-            .attention_group => "attention_group",
-            .elementwise_batch => "elementwise_batch",
-            .projection_chain => "projection_chain",
-            .projection_group => "projection_group",
+            .op,
+            .row_chain,
+            .rope_chain,
+            .rope_batch,
+            .movement_batch,
+            .attention_batch,
+            .repeat_fused_elementwise_chain,
+            .projection_fused_elementwise_chain,
+            .projection_pair_fused_elementwise_chain,
+            => .{},
+
+            .projection_chain,
+            .attention_chain,
+            => .{ .coverage = .anchor_sidecars },
+
+            .projection_group,
+            .rope_store_group,
+            .attention_store_chain,
+            .attention_store_group,
+            .rope_attention_store_chain,
+            .rope_attention_store_group,
+            => .{
+                .coverage = .anchor_sidecars,
+                .advance = .explicit_indices,
+            },
+
+            .projection_cache_group => .{
+                .coverage = .anchor_sidecars,
+                .sidecars = .flat,
+                .advance = .explicit_indices,
+            },
+
+            .movement_group,
+            .attention_group,
+            .elementwise_batch,
+            => .{
+                .coverage = .anchors_only,
+                .advance = .explicit_indices,
+            },
         };
     }
+};
+
+pub const ProgramCommandCoverage = enum {
+    contiguous,
+    anchor_sidecars,
+    anchors_only,
+};
+
+pub const ProgramCommandSidecarLayout = enum {
+    anchor_aligned,
+    flat,
+};
+
+pub const ProgramCommandAdvance = enum {
+    contiguous,
+    explicit_indices,
+};
+
+pub const ProgramCommandShape = struct {
+    coverage: ProgramCommandCoverage = .contiguous,
+    sidecars: ProgramCommandSidecarLayout = .anchor_aligned,
+    advance: ProgramCommandAdvance = .contiguous,
 };
 
 pub const ProjectionGroupKind = enum {
@@ -348,7 +396,7 @@ pub const ProjectionGroupPolicy = struct {
     carry_slice_sidecars: bool = true,
 
     pub fn decodeQMatvec(max_anchors: u32) ProjectionGroupPolicy {
-        return .{ .kind = .qmatvec, .max_anchors = max_anchors, .carry_slice_sidecars = false };
+        return .{ .kind = .qmatvec, .max_anchors = max_anchors, .carry_slice_sidecars = true };
     }
 
     pub fn prefillQMatmul(max_anchors: u32) ProjectionGroupPolicy {
@@ -361,17 +409,40 @@ pub const CommandStreamPolicy = struct {
     qmatvec_group_size: u32 = 4,
     qmatmul_group_size: u32 = 4,
     qmatmul_sidecars: bool = true,
+    qmatmul_cache_sidecars_per_anchor: u32 = 8,
+    projection_rope_cache_sidecars: bool = false,
     max_rope_batch: u32 = 16,
     max_movement_batch: u32 = 16,
     max_attention_batch: u32 = 16,
     max_attention_store_batch: u32 = 4,
+    max_rope_attention_store_batch: u32 = 16,
     max_elementwise_batch: u32 = 8,
+    fuse_repeat_fused_elementwise: bool = true,
+
+    pub fn fromCapabilities(capabilities: backend_mod.Capabilities) CommandStreamPolicy {
+        const c = capabilities.command_stream;
+        return .{
+            .stage_commands = c.stage_commands,
+            .qmatvec_group_size = c.qmatvec_group_size,
+            .qmatmul_group_size = c.qmatmul_group_size,
+            .qmatmul_sidecars = c.qmatmul_sidecars,
+            .qmatmul_cache_sidecars_per_anchor = c.qmatmul_cache_sidecars_per_anchor,
+            .projection_rope_cache_sidecars = c.projection_rope_cache_sidecars,
+            .max_rope_batch = c.max_rope_batch,
+            .max_movement_batch = c.max_movement_batch,
+            .max_attention_batch = c.max_attention_batch,
+            .max_attention_store_batch = c.max_attention_store_batch,
+            .max_rope_attention_store_batch = c.max_rope_attention_store_batch,
+            .max_elementwise_batch = c.max_elementwise_batch,
+            .fuse_repeat_fused_elementwise = c.fuse_repeat_fused_elementwise,
+        };
+    }
 
     pub fn metal(qmatvec_group_size: u32, qmatmul_group_size: u32) CommandStreamPolicy {
-        return .{
-            .qmatvec_group_size = qmatvec_group_size,
-            .qmatmul_group_size = qmatmul_group_size,
-        };
+        var policy = CommandStreamPolicy.fromCapabilities(backend_mod.Capabilities.metal);
+        policy.qmatvec_group_size = qmatvec_group_size;
+        policy.qmatmul_group_size = qmatmul_group_size;
+        return policy;
     }
 
     fn projectionPolicyFor(self: CommandStreamPolicy, q: anytype) ?ProjectionGroupPolicy {
@@ -442,22 +513,60 @@ pub const ProgramCommand = struct {
         return 1;
     }
 
+    pub fn shape(self: ProgramCommand) ProgramCommandShape {
+        return self.kind.shape();
+    }
+
     pub fn coveredOpCount(self: ProgramCommand) u32 {
-        return switch (self.kind) {
-            .projection_group, .projection_chain => self.anchor_count + self.sidecar_count,
-            .rope_store_group, .attention_chain, .attention_store_chain, .attention_store_group, .rope_attention_store_chain, .rope_attention_store_group => self.anchor_count + self.sidecar_count,
-            .attention_group => self.anchor_count,
-            .movement_group => self.anchor_count,
-            .elementwise_batch => self.anchor_count,
-            else => self.op_count,
+        return switch (self.shape().coverage) {
+            .contiguous => self.op_count,
+            .anchor_sidecars => self.anchor_count + self.sidecar_count,
+            .anchors_only => self.anchor_count,
         };
     }
 
     pub fn advanceCount(self: ProgramCommand) u32 {
-        return switch (self.kind) {
-            .projection_group, .elementwise_batch, .rope_store_group, .attention_store_chain, .attention_store_group, .rope_attention_store_chain, .rope_attention_store_group, .attention_group, .movement_group => 1,
-            else => self.op_count,
+        return switch (self.shape().advance) {
+            .contiguous => self.op_count,
+            .explicit_indices => 1,
         };
+    }
+
+    pub fn coversAnchorSidecars(self: ProgramCommand) bool {
+        return self.shape().coverage == .anchor_sidecars;
+    }
+
+    pub fn coversAnchorsOnly(self: ProgramCommand) bool {
+        return self.shape().coverage == .anchors_only;
+    }
+
+    pub fn hasExplicitCoverage(self: ProgramCommand) bool {
+        return self.shape().coverage != .contiguous;
+    }
+
+    pub fn usesExplicitIndices(self: ProgramCommand) bool {
+        return self.shape().advance == .explicit_indices;
+    }
+
+    pub fn explicitIndexSet(self: *const ProgramCommand) CommandIndexSet {
+        var set = CommandIndexSet{};
+        for (self.anchorIndices()) |idx| {
+            _ = set.append(idx);
+        }
+        for (self.carriedSidecarIndices()) |maybe_idx| {
+            if (maybe_idx) |idx| _ = set.append(idx);
+        }
+        return set;
+    }
+
+    pub fn sortedExplicitIndexSet(self: *const ProgramCommand) CommandIndexSet {
+        var set = self.explicitIndexSet();
+        set.sort();
+        return set;
+    }
+
+    pub fn coveredIndexIterator(self: *const ProgramCommand) CommandIndexIterator {
+        return CommandIndexIterator.init(self);
     }
 
     pub fn anchorIndices(self: *const ProgramCommand) []const usize {
@@ -466,6 +575,90 @@ pub const ProgramCommand = struct {
 
     pub fn sidecarIndices(self: *const ProgramCommand) []const ?usize {
         return self.sidecar_indices[0..self.anchor_count];
+    }
+
+    pub fn flatSidecarIndices(self: *const ProgramCommand) []const ?usize {
+        return self.sidecar_indices[0..self.sidecar_count];
+    }
+
+    pub fn carriedSidecarIndices(self: *const ProgramCommand) []const ?usize {
+        return switch (self.shape().sidecars) {
+            .anchor_aligned => self.sidecarIndices(),
+            .flat => self.flatSidecarIndices(),
+        };
+    }
+};
+
+pub const max_command_indices = max_projection_group_anchors * 2;
+
+pub const CommandIndexIterator = struct {
+    mode: enum { contiguous, explicit },
+    next_index: usize = 0,
+    end_index: usize = 0,
+    explicit: CommandIndexSet = .{},
+    explicit_pos: usize = 0,
+
+    pub fn init(command: *const ProgramCommand) CommandIndexIterator {
+        if (command.hasExplicitCoverage()) {
+            return .{
+                .mode = .explicit,
+                .explicit = command.sortedExplicitIndexSet(),
+            };
+        }
+
+        const start: usize = @intCast(command.op_start);
+        return .{
+            .mode = .contiguous,
+            .next_index = start,
+            .end_index = start + @as(usize, command.op_count),
+        };
+    }
+
+    pub fn next(self: *CommandIndexIterator) ?usize {
+        return switch (self.mode) {
+            .contiguous => {
+                if (self.next_index >= self.end_index) return null;
+                const idx = self.next_index;
+                self.next_index += 1;
+                return idx;
+            },
+            .explicit => {
+                if (self.explicit_pos >= self.explicit.count) return null;
+                const idx = self.explicit.indices[self.explicit_pos];
+                self.explicit_pos += 1;
+                return idx;
+            },
+        };
+    }
+
+    pub fn remainingCount(self: *const CommandIndexIterator) usize {
+        return switch (self.mode) {
+            .contiguous => self.end_index - self.next_index,
+            .explicit => self.explicit.count - self.explicit_pos,
+        };
+    }
+};
+
+pub const CommandIndexSet = struct {
+    indices: [max_command_indices]usize = undefined,
+    count: usize = 0,
+
+    pub fn append(self: *CommandIndexSet, idx: usize) bool {
+        for (self.indices[0..self.count]) |existing| {
+            if (existing == idx) return true;
+        }
+        if (self.count >= self.indices.len) return false;
+        self.indices[self.count] = idx;
+        self.count += 1;
+        return true;
+    }
+
+    pub fn sort(self: *CommandIndexSet) void {
+        std.mem.sort(usize, self.indices[0..self.count], {}, std.sort.asc(usize));
+    }
+
+    pub fn slice(self: *const CommandIndexSet) []const usize {
+        return self.indices[0..self.count];
     }
 };
 
@@ -501,12 +694,28 @@ pub const ProgramCommandSummary = struct {
     attention_group_ops: u32 = 0,
     elementwise_batches: u32 = 0,
     elementwise_ops: u32 = 0,
+    repeat_fused_elementwise_chains: u32 = 0,
+    projection_fused_elementwise_chains: u32 = 0,
+    projection_pair_fused_elementwise_chains: u32 = 0,
     projection_chains: u32 = 0,
     projection_chain_sidecars: u32 = 0,
     projection_groups: u32 = 0,
     projection_anchors: u32 = 0,
     projection_sidecars: u32 = 0,
+    projection_cache_groups: u32 = 0,
+    projection_cache_anchors: u32 = 0,
+    projection_cache_sidecars: u32 = 0,
     max_projection_span_ops: u32 = 0,
+
+    pub fn add(self: *ProgramCommandSummary, other: ProgramCommandSummary) void {
+        inline for (@typeInfo(ProgramCommandSummary).@"struct".fields) |field| {
+            if (comptime std.mem.eql(u8, field.name, "max_projection_span_ops")) {
+                @field(self.*, field.name) = @max(@field(self.*, field.name), @field(other, field.name));
+            } else {
+                @field(self.*, field.name) += @field(other, field.name);
+            }
+        }
+    }
 };
 
 pub const AttentionStoreGroupCandidateSummary = struct {
@@ -579,7 +788,16 @@ pub const ProjectionSidecarSummary = struct {
     incompatible_sidecars: u32 = 0,
 };
 
-pub const max_projection_group_anchors = 8;
+pub const ProjectionRopeCacheSummary = struct {
+    anchors: u32 = 0,
+    rope_store_pairs: u32 = 0,
+    compatible_pairs: u32 = 0,
+    tile_pair_pairs: u32 = 0,
+    rope_materializations: u32 = 0,
+    materialization_attention_fusion_skips: u32 = 0,
+};
+
+pub const max_projection_group_anchors = 32;
 
 pub const BufferSpan = struct {
     buf: u16,
@@ -858,6 +1076,412 @@ pub fn findProjectionGroup(
     return selection;
 }
 
+fn findProjectionCacheGroupCommand(
+    ops: []const backend_mod.DeviceOp,
+    start: usize,
+    policy: CommandStreamPolicy,
+    used: ?[]const bool,
+    executed: ?[]const bool,
+) ?ProgramCommand {
+    if (start >= ops.len) return null;
+    const projection_policy = policy.projectionPolicyFor(ops[start].qmatmul) orelse return null;
+    if (!projection_policy.carry_slice_sidecars) return null;
+    const selection = findProjectionGroup(ops, start, projection_policy, used) orelse return null;
+
+    var command = ProgramCommand{
+        .kind = .projection_cache_group,
+        .op_start = @intCast(selection.start_op),
+        .op_count = @intCast(selection.end_op - selection.start_op + 1),
+        .projection_kind = selection.kind,
+        .anchor_count = @intCast(selection.anchor_count),
+    };
+    var per_anchor_sidecars = [_]u32{0} ** max_projection_group_anchors;
+    for (selection.anchorIndices(), 0..) |idx, slot| command.indices[slot] = idx;
+    for (selection.sidecarIndices(), 0..) |maybe_idx, slot| {
+        const idx = maybe_idx orelse continue;
+        const sa = switch (ops[idx]) {
+            .slice_assign => |sa| sa,
+            else => return null,
+        };
+        if (!appendProjectionCacheSidecar(&command, idx, selection.start_op)) return null;
+        per_anchor_sidecars[slot] += 1;
+        if (!projectionCacheSidecarsShareSink(ops, &command, slot, sa)) return null;
+    }
+
+    const initial_sidecars = command.sidecar_count;
+    const max_sidecars_per_anchor = @max(1, policy.qmatmul_cache_sidecars_per_anchor);
+    var scan = start + 1;
+    while (scan < ops.len and command.sidecar_count < max_projection_group_anchors) : (scan += 1) {
+        if (used) |used_ops| {
+            if (scan >= used_ops.len or used_ops[scan]) continue;
+        }
+        if (commandContainsIndex(&command, scan)) continue;
+        if (scan > selection.end_op and ops[scan] == .qmatmul) break;
+        if (policy.projection_rope_cache_sidecars and ops[scan] == .rope) {
+            const rr = ops[scan].rope;
+            if (scan + 1 < ops.len) store: {
+                if (used) |used_ops| {
+                    if (scan + 1 >= used_ops.len or used_ops[scan + 1]) break :store;
+                }
+                const sa = switch (ops[scan + 1]) {
+                    .slice_assign => |sa| sa,
+                    else => break :store,
+                };
+                const slot = projectionCacheRopeStoreAnchorSlot(ops, &command, rr, sa) orelse break :store;
+                if (per_anchor_sidecars[slot] >= max_sidecars_per_anchor) break :store;
+                if (!projectionCacheSidecarsShareSink(ops, &command, slot, sa)) break :store;
+
+                var candidate = command;
+                if (!appendProjectionCacheRopeStoreSidecar(&candidate, scan, scan + 1, selection.start_op)) break;
+                if (!canHoistProjectionCacheRopeStoreToGroup(ops, selection.start_op, scan, scan + 1, ops[command.indices[slot]].qmatmul, rr, sa, &candidate, executed)) break :store;
+                if (projectionCacheSidecarConflictsSelected(ops, &command, sa)) break :store;
+                if (projectionCacheRopeOutputHasExternalUsers(ops, scan, scan + 1)) break :store;
+
+                command = candidate;
+                per_anchor_sidecars[slot] += 1;
+                scan += 1;
+                continue;
+            }
+
+            const slot = projectionCacheRopeAnchorSlot(ops, &command, rr) orelse continue;
+            if (per_anchor_sidecars[slot] >= max_sidecars_per_anchor) continue;
+            if (projectionCacheRopeWouldBlockAttentionFusion(ops, scan, used, executed)) continue;
+            var candidate = command;
+            if (!appendProjectionCacheRopeSidecar(&candidate, scan, selection.start_op)) break;
+            if (!canHoistProjectionCacheRopeToGroup(ops, selection.start_op, scan, ops[command.indices[slot]].qmatmul, rr, &candidate, executed)) continue;
+            if (projectionCacheRopeConflictsSelected(ops, &command, rr)) continue;
+
+            command = candidate;
+            per_anchor_sidecars[slot] += 1;
+            continue;
+        }
+
+        const sa = switch (ops[scan]) {
+            .slice_assign => |sa| sa,
+            else => continue,
+        };
+        const slot = projectionCacheSidecarAnchorSlot(ops, &command, sa) orelse continue;
+        if (per_anchor_sidecars[slot] >= max_sidecars_per_anchor) continue;
+        if (!projectionCacheSidecarsShareSink(ops, &command, slot, sa)) continue;
+
+        var candidate = command;
+        if (!appendProjectionCacheSidecar(&candidate, scan, selection.start_op)) break;
+        if (!canHoistProjectionCacheSidecarToGroup(ops, selection.start_op, scan, ops[command.indices[slot]].qmatmul, sa, &candidate, executed)) continue;
+        if (projectionCacheSidecarConflictsSelected(ops, &command, sa)) continue;
+
+        command = candidate;
+        per_anchor_sidecars[slot] += 1;
+    }
+
+    return if (command.sidecar_count > initial_sidecars) command else null;
+}
+
+fn appendProjectionCacheSidecar(command: *ProgramCommand, sidecar_index: usize, group_start: usize) bool {
+    if (command.sidecar_count >= max_projection_group_anchors) return false;
+    command.sidecar_indices[command.sidecar_count] = sidecar_index;
+    command.sidecar_count += 1;
+    command.op_count = @intCast(@max(
+        group_start + @as(usize, command.op_count),
+        sidecar_index + 1,
+    ) - group_start);
+    return true;
+}
+
+fn appendProjectionCacheRopeStoreSidecar(command: *ProgramCommand, rope_index: usize, sidecar_index: usize, group_start: usize) bool {
+    if (command.sidecar_count + 2 > max_projection_group_anchors) return false;
+    command.sidecar_indices[command.sidecar_count] = rope_index;
+    command.sidecar_count += 1;
+    command.sidecar_indices[command.sidecar_count] = sidecar_index;
+    command.sidecar_count += 1;
+    command.op_count = @intCast(@max(
+        group_start + @as(usize, command.op_count),
+        sidecar_index + 1,
+    ) - group_start);
+    return true;
+}
+
+fn appendProjectionCacheRopeSidecar(command: *ProgramCommand, rope_index: usize, group_start: usize) bool {
+    if (command.sidecar_count >= max_projection_group_anchors) return false;
+    command.sidecar_indices[command.sidecar_count] = rope_index;
+    command.sidecar_count += 1;
+    command.op_count = @intCast(@max(
+        group_start + @as(usize, command.op_count),
+        rope_index + 1,
+    ) - group_start);
+    return true;
+}
+
+fn projectionCacheSidecarAnchorSlot(
+    ops: []const backend_mod.DeviceOp,
+    command: *const ProgramCommand,
+    sa: anytype,
+) ?usize {
+    for (command.anchorIndices(), 0..) |idx, slot| {
+        if (idx >= ops.len) return null;
+        const q = switch (ops[idx]) {
+            .qmatmul => |q| q,
+            else => return null,
+        };
+        if (projectionSidecarCompatible(q, .{ .slice_assign = sa })) return slot;
+    }
+    return null;
+}
+
+fn projectionCacheRopeStoreAnchorSlot(
+    ops: []const backend_mod.DeviceOp,
+    command: *const ProgramCommand,
+    rr: anytype,
+    sa: anytype,
+) ?usize {
+    for (command.anchorIndices(), 0..) |idx, slot| {
+        if (idx >= ops.len) return null;
+        const q = switch (ops[idx]) {
+            .qmatmul => |q| q,
+            else => return null,
+        };
+        if (projectionRopeStoreSidecarCompatible(q, rr, sa)) return slot;
+    }
+    return null;
+}
+
+fn projectionCacheRopeAnchorSlot(
+    ops: []const backend_mod.DeviceOp,
+    command: *const ProgramCommand,
+    rr: anytype,
+) ?usize {
+    for (command.anchorIndices(), 0..) |idx, slot| {
+        if (idx >= ops.len) return null;
+        const q = switch (ops[idx]) {
+            .qmatmul => |q| q,
+            else => return null,
+        };
+        if (qmatvecRopeSidecarCompatible(q, rr)) return slot;
+    }
+    return null;
+}
+
+fn projectionCacheRopeWouldBlockAttentionFusion(
+    ops: []const backend_mod.DeviceOp,
+    rope_index: usize,
+    used: ?[]const bool,
+    executed: ?[]const bool,
+) bool {
+    return findDelayableRopeAttentionStorePair(ops, rope_index, used, executed) != null or
+        findRopeAttentionStorePair(ops, rope_index, used, executed) != null;
+}
+
+fn projectionCacheSidecarsShareSink(
+    ops: []const backend_mod.DeviceOp,
+    command: *const ProgramCommand,
+    anchor_slot: usize,
+    sa: anytype,
+) bool {
+    var i: usize = 0;
+    while (i < command.sidecar_count) : (i += 1) {
+        const idx = command.sidecar_indices[i] orelse continue;
+        switch (ops[idx]) {
+            .slice_assign => |selected| {
+                const selected_slot = projectionCacheSidecarAnchorSlot(ops, command, selected) orelse continue;
+                if (selected_slot == anchor_slot and selected.dst != sa.dst) return false;
+            },
+            .rope => |rr| {
+                if (i + 1 < command.sidecar_count) {
+                    const sidecar_idx = command.sidecar_indices[i + 1] orelse return false;
+                    const selected = switch (ops[sidecar_idx]) {
+                        .slice_assign => |selected| selected,
+                        else => continue,
+                    };
+                    const selected_slot = projectionCacheRopeStoreAnchorSlot(ops, command, rr, selected) orelse continue;
+                    if (selected_slot == anchor_slot and selected.dst != sa.dst) return false;
+                    i += 1;
+                }
+            },
+            else => return false,
+        }
+    }
+    return true;
+}
+
+fn projectionCacheSidecarConflictsSelected(
+    ops: []const backend_mod.DeviceOp,
+    command: *const ProgramCommand,
+    sa: anytype,
+) bool {
+    const sidecar_access = opAccessSpans(.{ .slice_assign = sa });
+    for (command.anchorIndices()) |idx| {
+        for (sidecar_access.writeSpans()) |write| {
+            if (opReadsSpan(ops[idx], write)) return true;
+        }
+        if (sidecar_access.write_overflow and opReadsBuffer(ops[idx], sa.dst)) return true;
+    }
+    var i: usize = 0;
+    while (i < command.sidecar_count) : (i += 1) {
+        const idx = command.sidecar_indices[i] orelse continue;
+        switch (ops[idx]) {
+            .slice_assign => |selected| {
+                if (sliceAssignWritesMayOverlap(selected, sa)) return true;
+            },
+            .rope => |rr| {
+                if (opAccessConflicts(.{ .rope = rr }, .{ .slice_assign = sa })) return true;
+                if (i + 1 < command.sidecar_count) {
+                    const sidecar_idx = command.sidecar_indices[i + 1] orelse return true;
+                    const selected = switch (ops[sidecar_idx]) {
+                        .slice_assign => |selected| selected,
+                        else => continue,
+                    };
+                    if (projectionCacheRopeStoreAnchorSlot(ops, command, rr, selected) == null) continue;
+                    if (sliceAssignWritesMayOverlap(selected, sa)) return true;
+                    i += 1;
+                }
+            },
+            else => return true,
+        }
+    }
+    return false;
+}
+
+fn projectionCacheRopeConflictsSelected(
+    ops: []const backend_mod.DeviceOp,
+    command: *const ProgramCommand,
+    rr: anytype,
+) bool {
+    const rope_op: backend_mod.DeviceOp = .{ .rope = rr };
+    for (command.anchorIndices()) |idx| {
+        if (idx >= ops.len) return true;
+        if (ops[idx] == .qmatmul and projectionRopeSidecarCompatible(ops[idx].qmatmul, rr)) continue;
+        if (opAccessConflicts(ops[idx], rope_op)) return true;
+    }
+    var i: usize = 0;
+    while (i < command.sidecar_count) : (i += 1) {
+        const idx = command.sidecar_indices[i] orelse continue;
+        if (idx >= ops.len) return true;
+        if (opAccessConflicts(ops[idx], rope_op)) return true;
+        if (ops[idx] == .rope and i + 1 < command.sidecar_count) {
+            const sidecar_idx = command.sidecar_indices[i + 1] orelse continue;
+            if (sidecar_idx >= ops.len) return true;
+            const selected = switch (ops[sidecar_idx]) {
+                .slice_assign => |selected| selected,
+                else => continue,
+            };
+            if (projectionCacheRopeStoreAnchorSlot(ops, command, ops[idx].rope, selected) != null) {
+                if (opAccessConflicts(ops[sidecar_idx], rope_op)) return true;
+                i += 1;
+            }
+        }
+    }
+    return false;
+}
+
+fn canHoistProjectionCacheSidecarToGroup(
+    ops: []const backend_mod.DeviceOp,
+    group_start: usize,
+    sidecar_index: usize,
+    q: anytype,
+    sa: anytype,
+    command: *const ProgramCommand,
+    executed: ?[]const bool,
+) bool {
+    const sidecar_access = opAccessSpans(.{ .slice_assign = sa });
+    for (ops[group_start..sidecar_index], group_start..) |op, idx| {
+        if (commandContainsIndex(command, idx)) continue;
+        if (executed) |executed_ops| {
+            if (idx < executed_ops.len and executed_ops[idx]) continue;
+        }
+        for (sidecar_access.readSpans()) |read| {
+            if (projectionWriteCoversRead(q, read)) continue;
+            if (opWritesSpan(op, read)) return false;
+        }
+        for (sidecar_access.writeSpans()) |write| {
+            if (opTouchesSpan(op, write)) return false;
+        }
+        if (sidecar_access.read_overflow or sidecar_access.write_overflow) {
+            if (opAccessConflicts(op, .{ .slice_assign = sa })) return false;
+        }
+    }
+    return true;
+}
+
+fn canHoistProjectionCacheRopeToGroup(
+    ops: []const backend_mod.DeviceOp,
+    group_start: usize,
+    rope_index: usize,
+    q: anytype,
+    rr: anytype,
+    command: *const ProgramCommand,
+    executed: ?[]const bool,
+) bool {
+    const rope_access = opAccessSpans(.{ .rope = rr });
+    for (ops[group_start..rope_index], group_start..) |op, idx| {
+        if (commandContainsIndex(command, idx)) continue;
+        if (executed) |executed_ops| {
+            if (idx < executed_ops.len and executed_ops[idx]) continue;
+        }
+        for (rope_access.readSpans()) |read| {
+            if (projectionWriteCoversRead(q, read)) continue;
+            if (opWritesSpan(op, read)) return false;
+        }
+        for (rope_access.writeSpans()) |write| {
+            if (opTouchesSpan(op, write)) return false;
+        }
+        if (rope_access.read_overflow and (opWritesBuffer(op, rr.src) or opWritesBuffer(op, rr.cos_sin))) return false;
+        if (rope_access.write_overflow and opTouchesBuffer(op, rr.dst)) return false;
+    }
+    return true;
+}
+
+fn canHoistProjectionCacheRopeStoreToGroup(
+    ops: []const backend_mod.DeviceOp,
+    group_start: usize,
+    rope_index: usize,
+    sidecar_index: usize,
+    q: anytype,
+    rr: anytype,
+    sa: anytype,
+    command: *const ProgramCommand,
+    executed: ?[]const bool,
+) bool {
+    const rope_access = opAccessSpans(.{ .rope = rr });
+    for (ops[group_start..rope_index], group_start..) |op, idx| {
+        if (commandContainsIndex(command, idx)) continue;
+        if (executed) |executed_ops| {
+            if (idx < executed_ops.len and executed_ops[idx]) continue;
+        }
+        for (rope_access.readSpans()) |read| {
+            if (projectionWriteCoversRead(q, read)) continue;
+            if (opWritesSpan(op, read)) return false;
+        }
+        if (rope_access.read_overflow and (opWritesBuffer(op, rr.src) or opWritesBuffer(op, rr.cos_sin))) return false;
+    }
+
+    const sidecar_access = opAccessSpans(.{ .slice_assign = sa });
+    for (ops[group_start..sidecar_index], group_start..) |op, idx| {
+        if (commandContainsIndex(command, idx)) continue;
+        if (executed) |executed_ops| {
+            if (idx < executed_ops.len and executed_ops[idx]) continue;
+        }
+        for (sidecar_access.writeSpans()) |write| {
+            if (opTouchesSpan(op, write)) return false;
+        }
+        if (sidecar_access.write_overflow and opTouchesBuffer(op, sa.dst)) return false;
+    }
+
+    return true;
+}
+
+fn projectionCacheRopeOutputHasExternalUsers(
+    ops: []const backend_mod.DeviceOp,
+    rope_index: usize,
+    sidecar_index: usize,
+) bool {
+    var command = ProgramCommand{
+        .kind = .rope_store_group,
+        .op_start = @intCast(rope_index),
+        .op_count = 1,
+    };
+    appendRopeStorePair(&command, rope_index, sidecar_index, rope_index);
+    return ropeStoreGroupOutputsHaveExternalUsers(ops, &command);
+}
+
 pub fn summarizeProjectionGroups(groups: []const ProjectionGroup) ProjectionGroupSummary {
     var summary = ProjectionGroupSummary{ .groups = @intCast(groups.len) };
     for (groups) |group| {
@@ -912,6 +1536,49 @@ pub fn summarizeProjectionSidecars(ops: []const backend_mod.DeviceOp) Projection
     return summary;
 }
 
+pub fn summarizeProjectionRopeCacheSidecars(ops: []const backend_mod.DeviceOp, tile_cols: u32) ProjectionRopeCacheSummary {
+    var summary = ProjectionRopeCacheSummary{};
+    for (ops) |op| {
+        const q = switch (op) {
+            .qmatmul => |q| q,
+            else => continue,
+        };
+        summary.anchors += 1;
+
+        for (ops[0..ops.len -| 1], 0..) |candidate, i| {
+            const rr = switch (candidate) {
+                .rope => |rr| rr,
+                else => continue,
+            };
+            const sa = switch (ops[i + 1]) {
+                .slice_assign => |sa| sa,
+                else => continue,
+            };
+            if (rr.src != q.dst) continue;
+            summary.rope_store_pairs += 1;
+            if (!projectionRopeStoreSidecarCompatible(q, rr, sa)) continue;
+            summary.compatible_pairs += 1;
+            if (qmatmulRopeStoreTilePairCompatible(q, rr, sa, tile_cols)) {
+                summary.tile_pair_pairs += 1;
+            }
+        }
+
+        for (ops, 0..) |candidate, i| {
+            const rr = switch (candidate) {
+                .rope => |rr| rr,
+                else => continue,
+            };
+            if (!projectionRopeSidecarCompatible(q, rr)) continue;
+            if (i + 1 < ops.len and ops[i + 1] == .slice_assign and projectionRopeStoreSidecarCompatible(q, rr, ops[i + 1].slice_assign)) continue;
+            summary.rope_materializations += 1;
+            if (projectionCacheRopeWouldBlockAttentionFusion(ops, i, null, null)) {
+                summary.materialization_attention_fusion_skips += 1;
+            }
+        }
+    }
+    return summary;
+}
+
 pub fn buildProgramCommands(
     alloc: std.mem.Allocator,
     ops: []const backend_mod.DeviceOp,
@@ -937,7 +1604,7 @@ pub fn buildProgramCommands(
             continue;
         }
 
-        if (findDelayedRopeAttentionStoreGroupCommand(ops, i, policy, used, executed)) |command| {
+        if (findDelayedProgramCommand(ops, i, policy, used, executed)) |command| {
             markProgramCommandUsed(used, command);
             try pending.append(alloc, .{ .emit_at = command.op_start, .command = command });
             i += 1;
@@ -964,6 +1631,16 @@ pub fn buildProgramCommands(
     }
 
     return commands.toOwnedSlice(alloc);
+}
+
+fn findDelayedProgramCommand(
+    ops: []const backend_mod.DeviceOp,
+    start: usize,
+    policy: CommandStreamPolicy,
+    used: ?[]const bool,
+    executed: ?[]const bool,
+) ?ProgramCommand {
+    return findProgramCommandIn(delayed_program_command_finders, ops, start, policy, used, executed);
 }
 
 const PendingProgramCommand = struct {
@@ -1013,83 +1690,275 @@ fn findProgramCommandWithExecuted(
         if (start >= used_ops.len or used_ops[start]) return null;
     }
 
-    const op = ops[start];
-    if (op == .qmatmul) {
-        if (policy.projectionPolicyFor(op.qmatmul)) |projection_policy| {
-            if (findProjectionGroup(ops, start, projection_policy, used)) |selection| {
-                return ProgramCommand.fromProjectionSelection(selection);
-            }
-        }
-        if (findProjectionChainCommand(ops, start, used)) |command| {
-            return command;
-        }
-    }
+    return findProgramCommandIn(program_command_finders, ops, start, policy, used, executed);
+}
 
-    if (op == .elementwise and policy.max_elementwise_batch >= 2) {
-        if (findElementwiseBatchCommand(ops, start, policy, used)) |command| {
-            return command;
-        }
+fn findProgramCommandIn(
+    comptime finders: anytype,
+    ops: []const backend_mod.DeviceOp,
+    start: usize,
+    policy: CommandStreamPolicy,
+    used: ?[]const bool,
+    executed: ?[]const bool,
+) ?ProgramCommand {
+    inline for (finders) |finder| {
+        if (finder.run(ops, start, policy, used, executed)) |command| return command;
     }
-
-    if (op == .rope and policy.max_rope_batch >= 2) {
-        if (findRopeStoreGroupCommand(ops, start, policy, used, executed)) |command| {
-            return command;
-        }
-    }
-
-    if (policy.stage_commands) {
-        if (findStageCommand(ops, start)) |stage_command| {
-            if (!commandRangeTouchesUsed(stage_command.op_start, stage_command.op_count, used)) {
-                return ProgramCommand.fromStageCommand(stage_command);
-            }
-        }
-    }
-
-    if (findContiguousBatchCommand(ops, start, policy, used)) |command| {
-        return command;
-    }
-
-    if (op == .rope) {
-        if (policy.max_attention_store_batch >= 2) {
-            if (findRopeAttentionStoreGroupCommand(ops, start, policy, used, executed)) |command| {
-                return command;
-            }
-        }
-        if (findRopeAttentionStoreChainCommand(ops, start, used, executed)) |command| {
-            return command;
-        }
-    }
-
-    if (op == .slice_assign) {
-        if (findAttentionChainCommand(ops, start, used)) |command| {
-            return command;
-        }
-    }
-
-    if (op == .attention) {
-        if (policy.max_attention_batch >= 2) {
-            if (findAttentionStoreGroupCommand(ops, start, policy, used, executed)) |command| {
-                return command;
-            }
-        }
-        if (findAttentionStoreChainCommand(ops, start, used)) |command| {
-            return command;
-        }
-    }
-
-    if (op == .slice_assign and policy.max_movement_batch >= 2) {
-        if (findMovementGroupCommand(ops, start, policy, used)) |command| {
-            return command;
-        }
-    }
-
-    if (op == .attention and policy.max_attention_batch >= 2) {
-        if (findAttentionGroupCommand(ops, start, policy, used)) |command| {
-            return command;
-        }
-    }
-
     return null;
+}
+
+const ProgramCommandFinderFn = *const fn ([]const backend_mod.DeviceOp, usize, CommandStreamPolicy, ?[]const bool, ?[]const bool) ?ProgramCommand;
+
+const ProgramCommandFinderFeature = enum {
+    always,
+    stage_commands,
+    elementwise_batch,
+    repeat_fused_elementwise,
+    rope_batch,
+    movement_batch,
+    attention_batch,
+    rope_attention_store_batch,
+
+    pub fn enabled(self: ProgramCommandFinderFeature, policy: CommandStreamPolicy) bool {
+        return switch (self) {
+            .always => true,
+            .stage_commands => policy.stage_commands,
+            .elementwise_batch => policy.max_elementwise_batch >= 2,
+            .repeat_fused_elementwise => policy.fuse_repeat_fused_elementwise,
+            .rope_batch => policy.max_rope_batch >= 2,
+            .movement_batch => policy.max_movement_batch >= 2,
+            .attention_batch => policy.max_attention_batch >= 2,
+            .rope_attention_store_batch => policy.max_rope_attention_store_batch >= 2,
+        };
+    }
+};
+
+const ProgramCommandFinder = struct {
+    name: []const u8,
+    start_tag: ?DeviceOpTag = null,
+    feature: ProgramCommandFinderFeature = .always,
+    find: ProgramCommandFinderFn,
+
+    fn run(
+        self: ProgramCommandFinder,
+        ops: []const backend_mod.DeviceOp,
+        start: usize,
+        policy: CommandStreamPolicy,
+        used: ?[]const bool,
+        executed: ?[]const bool,
+    ) ?ProgramCommand {
+        if (self.start_tag) |tag| {
+            if (!opIs(ops, start, tag)) return null;
+        }
+        if (!self.feature.enabled(policy)) return null;
+        return self.find(ops, start, policy, used, executed);
+    }
+};
+
+const program_command_finders = [_]ProgramCommandFinder{
+    .{ .name = "projection_pair_fused_elementwise_chain", .start_tag = .qmatmul, .find = finderUsedOnly(findProjectionPairFusedElementwiseChainCommand) },
+    .{ .name = "projection_fused_elementwise_chain", .start_tag = .qmatmul, .find = finderUsedOnly(findProjectionFusedElementwiseChainCommand) },
+    .{ .name = "projection_cache_group", .start_tag = .qmatmul, .find = findProjectionCacheGroupCommand },
+    .{ .name = "projection_group", .start_tag = .qmatmul, .find = findProjectionGroupAt },
+    .{ .name = "projection_chain", .start_tag = .qmatmul, .find = finderUsedOnly(findProjectionChainCommand) },
+    .{ .name = "elementwise_batch", .start_tag = .elementwise, .feature = .elementwise_batch, .find = finderPolicyUsed(findElementwiseBatchCommand) },
+    .{ .name = "repeat_fused_elementwise_chain", .start_tag = .repeat, .feature = .repeat_fused_elementwise, .find = finderUsedOnly(findRepeatFusedElementwiseCommand) },
+    .{ .name = "rope_store_group", .start_tag = .rope, .feature = .rope_batch, .find = findRopeStoreGroupCommand },
+    .{ .name = "stage_command", .feature = .stage_commands, .find = findStageProgramCommandAt },
+    .{ .name = "contiguous_batch", .find = finderPolicyUsed(findContiguousBatchCommand) },
+    .{ .name = "rope_attention_store_group", .start_tag = .rope, .feature = .rope_attention_store_batch, .find = findRopeAttentionStoreGroupCommand },
+    .{ .name = "rope_attention_store_chain", .start_tag = .rope, .find = finderUsedExecuted(findRopeAttentionStoreChainCommand) },
+    .{ .name = "attention_chain", .start_tag = .slice_assign, .find = finderUsedOnly(findAttentionChainCommand) },
+    .{ .name = "attention_store_group", .start_tag = .attention, .feature = .attention_batch, .find = findAttentionStoreGroupCommand },
+    .{ .name = "attention_store_chain", .start_tag = .attention, .find = finderUsedOnly(findAttentionStoreChainCommand) },
+    .{ .name = "movement_group", .start_tag = .slice_assign, .feature = .movement_batch, .find = finderPolicyUsed(findMovementGroupCommand) },
+    .{ .name = "attention_group", .start_tag = .attention, .feature = .attention_batch, .find = finderPolicyUsed(findAttentionGroupCommand) },
+};
+
+const delayed_program_command_finders = [_]ProgramCommandFinder{
+    .{ .name = "delayed_rope_attention_store_group", .start_tag = .rope, .find = findDelayedRopeAttentionStoreGroupCommand },
+};
+
+fn requireUniqueFinderNames(comptime label: []const u8, comptime finders: anytype) void {
+    inline for (finders, 0..) |finder, i| {
+        if (finder.name.len == 0) @compileError("empty " ++ label ++ " program command finder name");
+        inline for (finders[0..i]) |previous| {
+            if (std.mem.eql(u8, finder.name, previous.name)) {
+                @compileError("duplicate " ++ label ++ " program command finder name: " ++ finder.name);
+            }
+        }
+    }
+}
+
+comptime {
+    requireUniqueFinderNames("normal", program_command_finders);
+    requireUniqueFinderNames("delayed", delayed_program_command_finders);
+}
+
+fn opIs(ops: []const backend_mod.DeviceOp, start: usize, tag: DeviceOpTag) bool {
+    if (start >= ops.len) return false;
+    return std.meta.activeTag(ops[start]) == tag;
+}
+
+fn findProjectionGroupAt(
+    ops: []const backend_mod.DeviceOp,
+    start: usize,
+    policy: CommandStreamPolicy,
+    used: ?[]const bool,
+    executed: ?[]const bool,
+) ?ProgramCommand {
+    _ = executed;
+    const q = switch (ops[start]) {
+        .qmatmul => |q| q,
+        else => return null,
+    };
+    const projection_policy = policy.projectionPolicyFor(q) orelse return null;
+    const selection = findProjectionGroup(ops, start, projection_policy, used) orelse return null;
+    return ProgramCommand.fromProjectionSelection(selection);
+}
+
+fn findStageProgramCommandAt(
+    ops: []const backend_mod.DeviceOp,
+    start: usize,
+    policy: CommandStreamPolicy,
+    used: ?[]const bool,
+    executed: ?[]const bool,
+) ?ProgramCommand {
+    _ = executed;
+    _ = policy;
+    const stage_command = findStageCommand(ops, start) orelse return null;
+    if (commandRangeTouchesUsed(stage_command.op_start, stage_command.op_count, used)) return null;
+    return ProgramCommand.fromStageCommand(stage_command);
+}
+
+fn finderUsedOnly(comptime find: anytype) ProgramCommandFinderFn {
+    return struct {
+        fn run(
+            ops: []const backend_mod.DeviceOp,
+            start: usize,
+            policy: CommandStreamPolicy,
+            used: ?[]const bool,
+            executed: ?[]const bool,
+        ) ?ProgramCommand {
+            _ = policy;
+            _ = executed;
+            return find(ops, start, used);
+        }
+    }.run;
+}
+
+fn finderPolicyUsed(comptime find: anytype) ProgramCommandFinderFn {
+    return struct {
+        fn run(
+            ops: []const backend_mod.DeviceOp,
+            start: usize,
+            policy: CommandStreamPolicy,
+            used: ?[]const bool,
+            executed: ?[]const bool,
+        ) ?ProgramCommand {
+            _ = executed;
+            return find(ops, start, policy, used);
+        }
+    }.run;
+}
+
+fn finderUsedExecuted(comptime find: anytype) ProgramCommandFinderFn {
+    return struct {
+        fn run(
+            ops: []const backend_mod.DeviceOp,
+            start: usize,
+            policy: CommandStreamPolicy,
+            used: ?[]const bool,
+            executed: ?[]const bool,
+        ) ?ProgramCommand {
+            _ = policy;
+            return find(ops, start, used, executed);
+        }
+    }.run;
+}
+
+fn findProjectionPairFusedElementwiseChainCommand(
+    ops: []const backend_mod.DeviceOp,
+    start: usize,
+    used: ?[]const bool,
+) ?ProgramCommand {
+    if (start + 5 >= ops.len) return null;
+    if (commandRangeTouchesUsed(@intCast(start), 6, used)) return null;
+    const gate = switch (ops[start]) {
+        .qmatmul => |q| q,
+        else => return null,
+    };
+    const first = switch (ops[start + 1]) {
+        .fused_elementwise => |fe| fe,
+        else => return null,
+    };
+    const rp = switch (ops[start + 2]) {
+        .repeat => |rp| rp,
+        else => return null,
+    };
+    const second = switch (ops[start + 3]) {
+        .fused_elementwise => |fe| fe,
+        else => return null,
+    };
+    const up = switch (ops[start + 4]) {
+        .qmatmul => |q| q,
+        else => return null,
+    };
+    const product = switch (ops[start + 5]) {
+        .elementwise => |e| e,
+        else => return null,
+    };
+    if (!projectionPairFusedElementwiseChainCompatible(gate, first, rp, second, up, product)) return null;
+    if (projectionPairFusedElementwiseChainHasExternalUsers(ops, start)) return null;
+    return ProgramCommand.contiguous(.projection_pair_fused_elementwise_chain, start, 6);
+}
+
+fn findProjectionFusedElementwiseChainCommand(
+    ops: []const backend_mod.DeviceOp,
+    start: usize,
+    used: ?[]const bool,
+) ?ProgramCommand {
+    if (start + 3 >= ops.len) return null;
+    if (commandRangeTouchesUsed(@intCast(start), 4, used)) return null;
+    const q = switch (ops[start]) {
+        .qmatmul => |q| q,
+        else => return null,
+    };
+    const first = switch (ops[start + 1]) {
+        .fused_elementwise => |fe| fe,
+        else => return null,
+    };
+    const rp = switch (ops[start + 2]) {
+        .repeat => |rp| rp,
+        else => return null,
+    };
+    const second = switch (ops[start + 3]) {
+        .fused_elementwise => |fe| fe,
+        else => return null,
+    };
+    if (!projectionFusedElementwiseChainCompatible(q, first, rp, second)) return null;
+    if (projectionFusedElementwiseChainHasExternalUsers(ops, start)) return null;
+    return ProgramCommand.contiguous(.projection_fused_elementwise_chain, start, 4);
+}
+
+fn findRepeatFusedElementwiseCommand(
+    ops: []const backend_mod.DeviceOp,
+    start: usize,
+    used: ?[]const bool,
+) ?ProgramCommand {
+    if (start + 1 >= ops.len) return null;
+    if (commandRangeTouchesUsed(@intCast(start), 2, used)) return null;
+    const rp = switch (ops[start]) {
+        .repeat => |rp| rp,
+        else => return null,
+    };
+    const fe = switch (ops[start + 1]) {
+        .fused_elementwise => |fe| fe,
+        else => return null,
+    };
+    if (!repeatFusedElementwiseCompatible(rp, fe)) return null;
+    if (repeatOutputHasExternalUsers(ops, start, start + 1)) return null;
+    return ProgramCommand.contiguous(.repeat_fused_elementwise_chain, start, 2);
 }
 
 fn findAttentionChainCommand(
@@ -1352,13 +2221,25 @@ pub fn projectionPrimaryOutputHasExternalUsers(
     q_index: usize,
     sidecar_index: usize,
 ) bool {
-    if (q_index >= ops.len or sidecar_index >= ops.len) return true;
-    if (sidecar_index <= q_index) return true;
+    const sidecars = [_]?usize{sidecar_index};
+    return projectionPrimaryOutputHasExternalUsersExcept(ops, q_index, sidecars[0..]);
+}
+
+pub fn projectionPrimaryOutputHasExternalUsersExcept(
+    ops: []const backend_mod.DeviceOp,
+    q_index: usize,
+    sidecar_indices: []const ?usize,
+) bool {
+    if (q_index >= ops.len) return true;
     const q = switch (ops[q_index]) {
         .qmatmul => |q| q,
         else => return true,
     };
-    if (!projectionSidecarCompatible(q, ops[sidecar_index])) return true;
+    for (sidecar_indices) |maybe_idx| {
+        const idx = maybe_idx orelse continue;
+        if (idx >= ops.len or idx <= q_index) return true;
+        if (opReadsBuffer(ops[idx], q.dst) and !projectionSidecarCompatible(q, ops[idx]) and !projectionRopeSidecarOpCompatible(q, ops[idx])) return true;
+    }
 
     const q_access = opAccessSpans(.{ .qmatmul = q });
     var live_writes = [_]bool{false} ** max_access_spans;
@@ -1368,7 +2249,7 @@ pub fn projectionPrimaryOutputHasExternalUsers(
     var scan = q_index + 1;
     while (scan < ops.len) : (scan += 1) {
         const op = ops[scan];
-        if (scan != sidecar_index) {
+        if (!optionalIndexContains(sidecar_indices, scan)) {
             for (q_access.writeSpans(), 0..) |write, slot| {
                 if (!live_writes[slot]) continue;
                 if (opReadsSpan(op, write)) return true;
@@ -1387,6 +2268,207 @@ pub fn projectionPrimaryOutputHasExternalUsers(
         }
         if (overflow_live and opWritesBuffer(op, q.dst)) overflow_live = false;
         if (!any_live and !overflow_live) break;
+    }
+
+    return false;
+}
+
+fn optionalIndexContains(indices: []const ?usize, candidate: usize) bool {
+    for (indices) |maybe_idx| {
+        if (maybe_idx) |idx| {
+            if (idx == candidate) return true;
+        }
+    }
+    return false;
+}
+
+pub fn repeatFusedElementwiseCompatible(rp: anytype, fe: anytype) bool {
+    if (rp.src == rp.dst) return false;
+    if (fe.src == rp.dst) return false;
+
+    var found_secondary = false;
+    for (fe.steps) |step| {
+        if (!step.op.isBinary() or step.secondary_buf != rp.dst) continue;
+        if (step.secondary_offset < rp.dst_offset) return false;
+        const rel = step.secondary_offset - rp.dst_offset;
+        if (@as(u64, rel) + @as(u64, fe.n) > @as(u64, rp.n)) return false;
+        found_secondary = true;
+    }
+    return found_secondary;
+}
+
+pub fn projectionFusedElementwiseChainCompatible(q: anytype, first: anytype, rp: anytype, second: anytype) bool {
+    if (!qmatmulFusedElementwiseSidecarCompatible(q, first)) return false;
+    if (!repeatFusedElementwiseCompatible(rp, second)) return false;
+    if (rp.dst == q.dst) return false;
+    if (first.dst == q.dst) return false;
+    if (first.dst == rp.dst) return false;
+    if (second.src != first.dst or second.src_offset != first.dst_offset) return false;
+    if (second.n != first.n) return false;
+    if (second.dst == q.dst or second.dst == first.dst or second.dst == rp.dst) return false;
+
+    var reads_primary = false;
+    for (second.steps) |step| {
+        if (!step.op.isBinary()) continue;
+        if (step.secondary_buf == first.dst) return false;
+        if (step.secondary_buf == q.dst) {
+            if (step.secondary_offset != q.dst_offset) return false;
+            reads_primary = true;
+        }
+    }
+    return reads_primary;
+}
+
+fn qmatmulPairGeometryCompatible(a: anytype, b: anytype) bool {
+    return a.M != 1 and
+        a.M == b.M and
+        a.N == b.N and
+        a.K == b.K and
+        a.input == b.input and
+        a.input_offset == b.input_offset and
+        a.input_row_stride == b.input_row_stride and
+        qmatmulDstRowStride(a) == a.N and
+        qmatmulDstRowStride(b) == b.N;
+}
+
+pub fn projectionPairFusedElementwiseChainCompatible(
+    gate: anytype,
+    first: anytype,
+    rp: anytype,
+    second: anytype,
+    up: anytype,
+    product: anytype,
+) bool {
+    if (!projectionFusedElementwiseChainCompatible(gate, first, rp, second)) return false;
+    if (!qmatmulPairGeometryCompatible(gate, up)) return false;
+    if (product.op != .mul) return false;
+    if (product.n != gate.M * gate.N or product.n != second.n) return false;
+    const second_is_src0 = product.src0 == second.dst and product.src0_offset == second.dst_offset;
+    const second_is_src1 = product.src1 == second.dst and product.src1_offset == second.dst_offset;
+    const up_is_src0 = product.src0 == up.dst and product.src0_offset == up.dst_offset;
+    const up_is_src1 = product.src1 == up.dst and product.src1_offset == up.dst_offset;
+    if (!((second_is_src0 and up_is_src1) or (second_is_src1 and up_is_src0))) return false;
+    if (product.dst == gate.dst or product.dst == first.dst or product.dst == second.dst or product.dst == up.dst) return false;
+    return true;
+}
+
+fn spanHasExternalReadAfter(
+    ops: []const backend_mod.DeviceOp,
+    producer_index: usize,
+    included_start: usize,
+    included_end: usize,
+    span: BufferSpan,
+) bool {
+    var scan = producer_index + 1;
+    while (scan < ops.len) : (scan += 1) {
+        const included = scan >= included_start and scan < included_end;
+        if (!included and opReadsSpan(ops[scan], span)) return true;
+        if (opWritesCoverSpan(ops[scan], span)) break;
+    }
+    return false;
+}
+
+pub fn projectionPairFusedElementwiseChainHasExternalUsers(
+    ops: []const backend_mod.DeviceOp,
+    q_index: usize,
+) bool {
+    if (q_index + 5 >= ops.len) return true;
+    const gate = switch (ops[q_index]) {
+        .qmatmul => |q| q,
+        else => return true,
+    };
+    const first = switch (ops[q_index + 1]) {
+        .fused_elementwise => |fe| fe,
+        else => return true,
+    };
+    const rp = switch (ops[q_index + 2]) {
+        .repeat => |rp| rp,
+        else => return true,
+    };
+    const second = switch (ops[q_index + 3]) {
+        .fused_elementwise => |fe| fe,
+        else => return true,
+    };
+    const up = switch (ops[q_index + 4]) {
+        .qmatmul => |q| q,
+        else => return true,
+    };
+    const product = switch (ops[q_index + 5]) {
+        .elementwise => |e| e,
+        else => return true,
+    };
+    if (!projectionPairFusedElementwiseChainCompatible(gate, first, rp, second, up, product)) return true;
+
+    const included_start = q_index + 1;
+    const included_end = q_index + 6;
+    if (spanHasExternalReadAfter(ops, q_index, included_start, included_end, bufferSpan(gate.dst, gate.dst_offset, gate.M * gate.N))) return true;
+    if (spanHasExternalReadAfter(ops, q_index + 1, included_start, included_end, bufferSpan(first.dst, first.dst_offset, first.n))) return true;
+    if (spanHasExternalReadAfter(ops, q_index + 2, included_start, included_end, bufferSpan(rp.dst, rp.dst_offset, rp.n))) return true;
+    if (spanHasExternalReadAfter(ops, q_index + 3, included_start, included_end, bufferSpan(second.dst, second.dst_offset, second.n))) return true;
+    if (spanHasExternalReadAfter(ops, q_index + 4, included_start, included_end, bufferSpan(up.dst, up.dst_offset, up.M * up.N))) return true;
+    return false;
+}
+
+pub fn projectionFusedElementwiseChainHasExternalUsers(
+    ops: []const backend_mod.DeviceOp,
+    q_index: usize,
+) bool {
+    if (q_index + 3 >= ops.len) return true;
+    const q = switch (ops[q_index]) {
+        .qmatmul => |q| q,
+        else => return true,
+    };
+    const first = switch (ops[q_index + 1]) {
+        .fused_elementwise => |fe| fe,
+        else => return true,
+    };
+    const rp = switch (ops[q_index + 2]) {
+        .repeat => |rp| rp,
+        else => return true,
+    };
+    const second = switch (ops[q_index + 3]) {
+        .fused_elementwise => |fe| fe,
+        else => return true,
+    };
+    if (!projectionFusedElementwiseChainCompatible(q, first, rp, second)) return true;
+
+    const included_start = q_index + 1;
+    const included_end = q_index + 4;
+    const q_write = bufferSpan(q.dst, q.dst_offset, q.M * q.N);
+    const first_write = bufferSpan(first.dst, first.dst_offset, first.n);
+    const repeat_write = bufferSpan(rp.dst, rp.dst_offset, rp.n);
+    if (spanHasExternalReadAfter(ops, q_index, included_start, included_end, q_write)) return true;
+    if (spanHasExternalReadAfter(ops, q_index + 1, included_start, included_end, first_write)) return true;
+    if (spanHasExternalReadAfter(ops, q_index + 2, included_start, included_end, repeat_write)) return true;
+    return false;
+}
+
+pub fn repeatOutputHasExternalUsers(
+    ops: []const backend_mod.DeviceOp,
+    repeat_index: usize,
+    fused_index: usize,
+) bool {
+    if (repeat_index >= ops.len or fused_index >= ops.len) return true;
+    if (fused_index <= repeat_index) return true;
+    const rp = switch (ops[repeat_index]) {
+        .repeat => |rp| rp,
+        else => return true,
+    };
+    const fe = switch (ops[fused_index]) {
+        .fused_elementwise => |fe| fe,
+        else => return true,
+    };
+    if (!repeatFusedElementwiseCompatible(rp, fe)) return true;
+
+    const repeat_write = bufferSpan(rp.dst, rp.dst_offset, rp.n);
+
+    var scan = repeat_index + 1;
+    while (scan < ops.len) : (scan += 1) {
+        const op = ops[scan];
+        if (scan != fused_index) {
+            if (opReadsSpan(op, repeat_write)) return true;
+        }
+        if (opWritesCoverSpan(op, repeat_write)) break;
     }
 
     return false;
@@ -1612,7 +2694,7 @@ fn findRopeAttentionStoreGroupCommand(
     if (used) |used_ops| {
         if (start >= used_ops.len or used_ops[start]) return null;
     }
-    const max_pairs: usize = @intCast(@min(policy.max_attention_store_batch, max_projection_group_anchors / 2));
+    const max_pairs: usize = @intCast(@min(policy.max_rope_attention_store_batch, max_projection_group_anchors / 2));
     if (max_pairs < 2) return null;
 
     const first_pair = findRopeAttentionStorePair(ops, start, used, executed) orelse return null;
@@ -1651,7 +2733,10 @@ fn findRopeAttentionStoreGroupCommand(
         if (!canHoistAttentionForStoreGroup(ops, start, pair.attention_index, att, &candidate, executed)) continue;
         if (ropeAttentionStorePairConflictsSelected(ops, &command, scan, pair.attention_index, ops[pair.sidecar_index].slice_assign)) continue;
 
-        appendRopeAttentionStorePair(&command, scan, pair.attention_index, pair.sidecar_index, start);
+        var selected = command;
+        appendRopeAttentionStorePair(&selected, scan, pair.attention_index, pair.sidecar_index, start);
+        if (selected.sidecar_count > policy.max_attention_store_batch and !ropeAttentionStoreCompactBatchCompatible(ops, &selected)) continue;
+        command = selected;
     }
 
     return if (command.sidecar_count >= 2) command else null;
@@ -1668,11 +2753,10 @@ fn findDelayedRopeAttentionStoreGroupCommand(
     if (used) |used_ops| {
         if (start >= used_ops.len or used_ops[start]) return null;
     }
-    const max_pairs: usize = @intCast(@min(policy.max_attention_store_batch, max_projection_group_anchors / 2));
-    if (max_pairs < 2) return null;
+    const max_pairs: usize = @max(1, @as(usize, @intCast(@min(policy.max_rope_attention_store_batch, max_projection_group_anchors / 2))));
 
     const first_pair = findDelayableRopeAttentionStorePair(ops, start, used, executed) orelse return null;
-    const emit_at = first_pair.attention_index;
+    var emit_at = first_pair.attention_index;
     if (emit_at <= start) return null;
 
     var command = ProgramCommand{
@@ -1687,7 +2771,7 @@ fn findDelayedRopeAttentionStoreGroupCommand(
     const first_att = ops[first_pair.attention_index].attention;
     const first_rope = ops[start].rope;
     var scan = start + 1;
-    while (scan < emit_at and command.sidecar_count < max_pairs) : (scan += 1) {
+    while (scan < ops.len and command.sidecar_count < max_pairs) : (scan += 1) {
         if (used) |used_ops| {
             if (scan >= used_ops.len or used_ops[scan]) continue;
         }
@@ -1705,15 +2789,22 @@ fn findDelayedRopeAttentionStoreGroupCommand(
         var candidate = command;
         if (candidate.anchor_count + 2 > max_projection_group_anchors) break;
         appendRopeAttentionStorePair(&candidate, scan, pair.attention_index, pair.sidecar_index, emit_at);
-        if (!canDelayOpToCommand(ops, scan, emit_at, .{ .rope = rr }, &candidate)) continue;
-        if (!canHoistAttentionForStoreGroup(ops, emit_at, pair.attention_index, att, &candidate, executed)) continue;
-        if (!canHoistOpToRopeAttentionStoreGroup(ops, emit_at, pair.sidecar_index, .{ .slice_assign = sa }, &candidate, executed)) continue;
         if (ropeAttentionStorePairConflictsSelected(ops, &command, scan, pair.attention_index, sa)) continue;
+        const candidate_emit_at = @max(emit_at, pair.attention_index);
+        setRopeAttentionStoreCommandEmit(&candidate, candidate_emit_at);
+        if (!ropeAttentionStoreCommandLegalAt(ops, &candidate, candidate_emit_at, executed)) continue;
+        if (candidate.sidecar_count > policy.max_attention_store_batch and !ropeAttentionStoreCompactBatchCompatible(ops, &candidate)) continue;
 
         command = candidate;
+        emit_at = candidate_emit_at;
     }
 
-    return if (command.sidecar_count >= 2) command else null;
+    if (command.sidecar_count >= 2) return command;
+    if (findRopeAttentionStoreGroupCommand(ops, start, policy, used, executed) != null) return null;
+    if (findRopeAttentionStoreChainCommand(ops, start, used, executed) != null) return null;
+    command.kind = .rope_attention_store_chain;
+    command.op_count = @intCast(first_pair.sidecar_index - emit_at + 1);
+    return command;
 }
 
 const RopeAttentionStorePair = struct {
@@ -1820,6 +2911,71 @@ fn appendRopeAttentionStorePair(
     ) - group_start);
 }
 
+fn setRopeAttentionStoreCommandEmit(command: *ProgramCommand, emit_at: usize) void {
+    command.op_start = @intCast(emit_at);
+    var end = emit_at + 1;
+    for (command.sidecarIndices()[0..command.sidecar_count]) |maybe_idx| {
+        if (maybe_idx) |idx| end = @max(end, idx + 1);
+    }
+    command.op_count = @intCast(end - emit_at);
+}
+
+fn ropeAttentionStoreCommandLegalAt(
+    ops: []const backend_mod.DeviceOp,
+    command: *const ProgramCommand,
+    emit_at: usize,
+    executed: ?[]const bool,
+) bool {
+    var i: usize = 0;
+    while (i < command.sidecar_count) : (i += 1) {
+        const rope_index = command.indices[i * 2];
+        const attention_index = command.indices[i * 2 + 1];
+        const sidecar_index = command.sidecar_indices[i] orelse return false;
+        const rr = switch (ops[rope_index]) {
+            .rope => |rr| rr,
+            else => return false,
+        };
+        const att = switch (ops[attention_index]) {
+            .attention => |att| att,
+            else => return false,
+        };
+        const sa = switch (ops[sidecar_index]) {
+            .slice_assign => |sa| sa,
+            else => return false,
+        };
+        if (!canMoveOpToRopeAttentionStoreEmit(ops, rope_index, emit_at, .{ .rope = rr }, command, executed)) return false;
+        if (!canMoveAttentionToRopeAttentionStoreEmit(ops, attention_index, emit_at, att, command, executed)) return false;
+        if (!canMoveOpToRopeAttentionStoreEmit(ops, sidecar_index, emit_at, .{ .slice_assign = sa }, command, executed)) return false;
+    }
+    return true;
+}
+
+fn canMoveOpToRopeAttentionStoreEmit(
+    ops: []const backend_mod.DeviceOp,
+    candidate_index: usize,
+    emit_at: usize,
+    candidate: backend_mod.DeviceOp,
+    command: *const ProgramCommand,
+    executed: ?[]const bool,
+) bool {
+    if (candidate_index < emit_at) return canDelayOpToCommand(ops, candidate_index, emit_at, candidate, command);
+    if (candidate_index > emit_at) return canHoistOpToRopeAttentionStoreGroup(ops, emit_at, candidate_index, candidate, command, executed);
+    return true;
+}
+
+fn canMoveAttentionToRopeAttentionStoreEmit(
+    ops: []const backend_mod.DeviceOp,
+    attention_index: usize,
+    emit_at: usize,
+    att: anytype,
+    command: *const ProgramCommand,
+    executed: ?[]const bool,
+) bool {
+    if (attention_index < emit_at) return canDelayOpToCommand(ops, attention_index, emit_at, .{ .attention = att }, command);
+    if (attention_index > emit_at) return canHoistAttentionForStoreGroup(ops, emit_at, attention_index, att, command, executed);
+    return true;
+}
+
 fn canDelayOpToCommand(
     ops: []const backend_mod.DeviceOp,
     candidate_index: usize,
@@ -1835,7 +2991,7 @@ fn canDelayOpToCommand(
             if (opWritesSpan(op, read)) return false;
         }
         for (candidate_access.writeSpans()) |write| {
-            if (opTouchesSpan(op, write)) return false;
+            if (hoistWriteConflict(op, candidate, write)) return false;
         }
         if (candidate_access.read_overflow or candidate_access.write_overflow) {
             if (opAccessConflicts(op, candidate)) return false;
@@ -1862,13 +3018,26 @@ fn canHoistOpToRopeAttentionStoreGroup(
             if (opWritesSpan(op, read)) return false;
         }
         for (candidate_access.writeSpans()) |write| {
-            if (opTouchesSpan(op, write)) return false;
+            if (hoistWriteConflict(op, candidate, write)) return false;
         }
         if (candidate_access.read_overflow or candidate_access.write_overflow) {
             if (opAccessConflicts(op, candidate)) return false;
         }
     }
     return true;
+}
+
+fn hoistWriteConflict(op: backend_mod.DeviceOp, candidate: backend_mod.DeviceOp, write: BufferSpan) bool {
+    if (!opTouchesSpan(op, write)) return false;
+    const candidate_sa = switch (candidate) {
+        .slice_assign => |sa| sa,
+        else => return true,
+    };
+    const op_sa = switch (op) {
+        .slice_assign => |sa| sa,
+        else => return true,
+    };
+    return opReadsSpan(op, write) or sliceAssignWritesMayOverlap(op_sa, candidate_sa);
 }
 
 fn ropeAttentionStorePairConflictsSelected(
@@ -1970,7 +3139,7 @@ fn commandContainsIndex(command: *const ProgramCommand, candidate: usize) bool {
     for (command.anchorIndices()) |idx| {
         if (idx == candidate) return true;
     }
-    for (command.sidecarIndices()) |maybe_idx| {
+    for (command.carriedSidecarIndices()) |maybe_idx| {
         if (maybe_idx) |idx| {
             if (idx == candidate) return true;
         }
@@ -2120,85 +3289,23 @@ pub fn summarizeRopeAttentionStoreGroupCandidates(
     policy: CommandStreamPolicy,
 ) RopeAttentionStoreGroupCandidateSummary {
     var summary = RopeAttentionStoreGroupCandidateSummary{};
-    const max_pairs: usize = @intCast(@min(policy.max_attention_store_batch, max_projection_group_anchors / 2));
+    const max_pairs: usize = @intCast(@min(policy.max_rope_attention_store_batch, max_projection_group_anchors / 2));
     if (max_pairs < 2) return summary;
 
     for (ops, 0..) |op, start| {
-        const first_rope = switch (op) {
-            .rope => |rr| rr,
+        switch (op) {
+            .rope => {},
             else => continue,
-        };
+        }
         summary.anchors += 1;
 
-        const first_pair = findDelayableRopeAttentionStorePair(ops, start, null, null) orelse {
-            summary.first_pair_missing += 1;
-            continue;
-        };
-        const emit_at = first_pair.attention_index;
-        if (emit_at <= start) {
+        if (findDelayableRopeAttentionStorePair(ops, start, null, null) == null) {
             summary.first_pair_missing += 1;
             continue;
         }
 
-        var command = ProgramCommand{
-            .kind = .rope_attention_store_group,
-            .op_start = @intCast(emit_at),
-            .op_count = 1,
-            .anchor_count = 0,
-            .sidecar_count = 0,
-        };
-        appendRopeAttentionStorePair(&command, start, first_pair.attention_index, first_pair.sidecar_index, emit_at);
-        const first_att = ops[first_pair.attention_index].attention;
-
-        var scan = start + 1;
-        while (scan < emit_at and command.sidecar_count < max_pairs) : (scan += 1) {
-            const rr = switch (ops[scan]) {
-                .rope => |rr| rr,
-                else => continue,
-            };
-            summary.candidate_ropes += 1;
-            if (!ropeStoreBatchGeometryCompatible(first_rope, rr)) {
-                summary.geometry_rejects += 1;
-                continue;
-            }
-            const pair = findDelayableRopeAttentionStorePair(ops, scan, null, null) orelse {
-                summary.pair_missing_rejects += 1;
-                continue;
-            };
-            if (pair.attention_index < emit_at) {
-                summary.before_emit_rejects += 1;
-                continue;
-            }
-            const att = ops[pair.attention_index].attention;
-            if (!attentionGeometryCompatible(first_att, att)) {
-                summary.geometry_rejects += 1;
-                continue;
-            }
-            const sa = ops[pair.sidecar_index].slice_assign;
-
-            var candidate = command;
-            if (candidate.anchor_count + 2 > max_projection_group_anchors) break;
-            appendRopeAttentionStorePair(&candidate, scan, pair.attention_index, pair.sidecar_index, emit_at);
-            if (!canDelayOpToCommand(ops, scan, emit_at, .{ .rope = rr }, &candidate)) {
-                summary.delay_rejects += 1;
-                continue;
-            }
-            if (!canHoistAttentionForStoreGroup(ops, emit_at, pair.attention_index, att, &candidate, null)) {
-                summary.attention_hoist_rejects += 1;
-                continue;
-            }
-            if (!canHoistOpToRopeAttentionStoreGroup(ops, emit_at, pair.sidecar_index, .{ .slice_assign = sa }, &candidate, null)) {
-                summary.sidecar_hoist_rejects += 1;
-                continue;
-            }
-            if (ropeAttentionStorePairConflictsSelected(ops, &command, scan, pair.attention_index, sa)) {
-                summary.selected_conflict_rejects += 1;
-                continue;
-            }
-            command = candidate;
-        }
-
-        if (command.sidecar_count >= 2) {
+        const command = findDelayedRopeAttentionStoreGroupCommand(ops, start, policy, null, null) orelse continue;
+        if (command.kind == .rope_attention_store_group and command.sidecar_count >= 2) {
             summary.formed_groups += 1;
             summary.grouped_pairs += command.sidecar_count;
             summary.max_group_pairs = @max(summary.max_group_pairs, command.sidecar_count);
@@ -2213,7 +3320,7 @@ pub fn summarizeEarlyRopeAttentionStoreGroupCandidates(
     policy: CommandStreamPolicy,
 ) EarlyRopeAttentionStoreGroupCandidateSummary {
     var summary = EarlyRopeAttentionStoreGroupCandidateSummary{};
-    const max_pairs: usize = @intCast(@min(policy.max_attention_store_batch, max_projection_group_anchors / 2));
+    const max_pairs: usize = @intCast(@min(policy.max_rope_attention_store_batch, max_projection_group_anchors / 2));
     if (max_pairs < 2) return summary;
 
     for (ops, 0..) |op, start| {
@@ -2541,6 +3648,9 @@ pub fn summarizeProgramCommands(commands: []const ProgramCommand) ProgramCommand
                 summary.elementwise_batches += 1;
                 summary.elementwise_ops += command.anchor_count;
             },
+            .repeat_fused_elementwise_chain => summary.repeat_fused_elementwise_chains += 1,
+            .projection_fused_elementwise_chain => summary.projection_fused_elementwise_chains += 1,
+            .projection_pair_fused_elementwise_chain => summary.projection_pair_fused_elementwise_chains += 1,
             .projection_chain => {
                 summary.projection_chains += 1;
                 summary.projection_chain_sidecars += command.sidecar_count;
@@ -2551,30 +3661,21 @@ pub fn summarizeProgramCommands(commands: []const ProgramCommand) ProgramCommand
                 summary.projection_sidecars += command.sidecar_count;
                 summary.max_projection_span_ops = @max(summary.max_projection_span_ops, command.op_count);
             },
+            .projection_cache_group => {
+                summary.projection_cache_groups += 1;
+                summary.projection_cache_anchors += command.anchor_count;
+                summary.projection_cache_sidecars += command.sidecar_count;
+                summary.max_projection_span_ops = @max(summary.max_projection_span_ops, command.op_count);
+            },
         }
     }
     return summary;
 }
 
 pub fn markProgramCommandUsed(used: []bool, command: ProgramCommand) void {
-    switch (command.kind) {
-        .projection_group, .elementwise_batch, .rope_store_group, .attention_store_chain, .attention_store_group, .rope_attention_store_chain, .rope_attention_store_group, .attention_group, .movement_group => {
-            for (command.anchorIndices()) |idx| {
-                if (idx < used.len) used[idx] = true;
-            }
-            if (command.kind == .projection_group or command.kind == .rope_store_group or command.kind == .attention_store_chain or command.kind == .attention_store_group or command.kind == .rope_attention_store_chain or command.kind == .rope_attention_store_group) {
-                for (command.sidecarIndices()) |maybe_idx| {
-                    if (maybe_idx) |idx| {
-                        if (idx < used.len) used[idx] = true;
-                    }
-                }
-            }
-        },
-        else => {
-            const start: usize = @intCast(command.op_start);
-            const end = @min(used.len, start + @as(usize, command.op_count));
-            for (used[start..end]) |*slot| slot.* = true;
-        },
+    var indices = command.coveredIndexIterator();
+    while (indices.next()) |idx| {
+        if (idx < used.len) used[idx] = true;
     }
 }
 
@@ -2934,7 +4035,7 @@ pub fn projectionConflictsSelected(
 pub fn projectionSidecarCompatible(q: anytype, op: backend_mod.DeviceOp) bool {
     return switch (op) {
         .slice_assign => |sa| if (q.M == 1) qmatvecSliceSidecarCompatible(q, sa) else qmatmulSliceSidecarCompatible(q, sa),
-        .elementwise => |e| qmatmulElementwiseSidecarCompatible(q, e),
+        .elementwise => |e| if (q.M == 1) qmatvecElementwiseSidecarCompatible(q, e) else qmatmulElementwiseSidecarCompatible(q, e),
         .fused_elementwise => |fe| qmatmulFusedElementwiseSidecarCompatible(q, fe),
         else => false,
     };
@@ -2944,6 +4045,7 @@ fn projectionSidecarMatchesPolicy(policy: ProjectionGroupPolicy, q: anytype, op:
     return switch (policy.kind) {
         .qmatvec => switch (op) {
             .slice_assign => |sa| qmatvecSliceSidecarCompatible(q, sa),
+            .elementwise => |e| qmatvecElementwiseSidecarCompatible(q, e),
             else => false,
         },
         .qmatmul => switch (op) {
@@ -3008,6 +4110,16 @@ pub fn qmatmulElementwiseSidecarCompatible(q: anytype, e: anytype) bool {
         (e.src1 == q.dst and e.src1_offset == q.dst_offset);
 }
 
+pub fn qmatvecElementwiseSidecarCompatible(q: anytype, e: anytype) bool {
+    if (q.M != 1) return false;
+    if (e.op != .add and e.op != .mul) return false;
+    if (e.n != q.N) return false;
+    if (q.dst_row_stride != 0 and q.dst_row_stride != q.N) return false;
+    const src0_primary = e.src0 == q.dst and e.src0_offset == q.dst_offset;
+    const src1_primary = e.src1 == q.dst and e.src1_offset == q.dst_offset;
+    return src0_primary != src1_primary;
+}
+
 pub fn qmatmulFusedElementwiseSidecarCompatible(q: anytype, fe: anytype) bool {
     if (q.M == 1) return false;
     if (fe.n != q.M * q.N) return false;
@@ -3023,6 +4135,14 @@ pub fn qmatmulSliceSrcColStart(q: anytype, sa: anytype) ?u32 {
     return delta;
 }
 
+pub fn qmatmulRopeSrcColStart(q: anytype, rr: anytype) ?u32 {
+    if (rr.src_off < q.dst_offset) return null;
+    const delta = rr.src_off - q.dst_offset;
+    const dst_row_stride = qmatmulDstRowStride(q);
+    if (delta >= dst_row_stride) return null;
+    return delta;
+}
+
 pub fn qmatmulSliceSidecarCompatible(q: anytype, sa: anytype) bool {
     const slice_src_col_start = qmatmulSliceSrcColStart(q, sa) orelse return false;
     return q.M != 1 and
@@ -3031,6 +4151,50 @@ pub fn qmatmulSliceSidecarCompatible(q: anytype, sa: anytype) bool {
         q.M == sa.cols and
         sa.src_row_stride == 1 and
         sa.src_col_stride == qmatmulDstRowStride(q);
+}
+
+pub fn qmatmulRopeSidecarCompatible(q: anytype, rr: anytype) bool {
+    return q.M != 1 and projectionRopeSidecarCompatible(q, rr);
+}
+
+pub fn qmatvecRopeSidecarCompatible(q: anytype, rr: anytype) bool {
+    return q.M == 1 and projectionRopeSidecarCompatible(q, rr);
+}
+
+pub fn projectionRopeSidecarCompatible(q: anytype, rr: anytype) bool {
+    const rope_src_col_start = qmatmulRopeSrcColStart(q, rr) orelse return false;
+    const d = rr.half_d * 2;
+    return q.dst == rr.src and
+        rope_src_col_start + d <= q.N and
+        q.M == rr.seq_len and
+        rr.src_rs == 1 and
+        rr.src_cs == qmatmulDstRowStride(q);
+}
+
+pub fn qmatmulRopeStoreSidecarCompatible(q: anytype, rr: anytype, sa: anytype) bool {
+    return qmatmulRopeSidecarCompatible(q, rr) and ropeSliceAssignCompatible(rr, sa);
+}
+
+pub fn qmatvecRopeStoreSidecarCompatible(q: anytype, rr: anytype, sa: anytype) bool {
+    return qmatvecRopeSidecarCompatible(q, rr) and ropeSliceAssignCompatible(rr, sa);
+}
+
+pub fn projectionRopeStoreSidecarCompatible(q: anytype, rr: anytype, sa: anytype) bool {
+    return projectionRopeSidecarCompatible(q, rr) and ropeSliceAssignCompatible(rr, sa);
+}
+
+pub fn qmatmulRopeStoreTilePairCompatible(q: anytype, rr: anytype, sa: anytype, tile_cols: u32) bool {
+    return tile_cols != 0 and
+        qmatmulRopeStoreSidecarCompatible(q, rr, sa) and
+        rr.half_d >= tile_cols and
+        rr.half_d % tile_cols == 0;
+}
+
+fn projectionRopeSidecarOpCompatible(q: anytype, op: backend_mod.DeviceOp) bool {
+    return switch (op) {
+        .rope => |rr| projectionRopeSidecarCompatible(q, rr),
+        else => false,
+    };
 }
 
 pub fn qmatvecSliceSidecarCompatible(q: anytype, sa: anytype) bool {
@@ -3081,6 +4245,58 @@ pub fn ropeStoreBatchGeometryCompatible(first: anytype, next: anytype) bool {
         first.src_rs == next.src_rs and
         first.src_cs == next.src_cs and
         first.cs_cs == next.cs_cs;
+}
+
+pub fn ropeAttentionStoreCompactBatchCompatible(
+    ops: []const backend_mod.DeviceOp,
+    command: *const ProgramCommand,
+) bool {
+    if (command.kind != .rope_attention_store_group) return false;
+    if (command.sidecar_count < 2 or command.anchor_count != command.sidecar_count * 2) return false;
+    const first_sa_idx = command.sidecar_indices[0] orelse return false;
+    if (command.indices[0] >= ops.len or command.indices[1] >= ops.len or first_sa_idx >= ops.len) return false;
+    const first_rope = switch (ops[command.indices[0]]) {
+        .rope => |rr| rr,
+        else => return false,
+    };
+    const first_att = switch (ops[command.indices[1]]) {
+        .attention => |att| att,
+        else => return false,
+    };
+    const first_sa = switch (ops[first_sa_idx]) {
+        .slice_assign => |sa| sa,
+        else => return false,
+    };
+
+    var i: usize = 0;
+    while (i < command.sidecar_count) : (i += 1) {
+        const rope_idx = command.indices[i * 2];
+        const att_idx = command.indices[i * 2 + 1];
+        const sa_idx = command.sidecar_indices[i] orelse return false;
+        if (rope_idx >= ops.len or att_idx >= ops.len or sa_idx >= ops.len) return false;
+        const rr = switch (ops[rope_idx]) {
+            .rope => |rr| rr,
+            else => return false,
+        };
+        const att = switch (ops[att_idx]) {
+            .attention => |att| att,
+            else => return false,
+        };
+        const sa = switch (ops[sa_idx]) {
+            .slice_assign => |sa| sa,
+            else => return false,
+        };
+        if (!ropeAttentionCompatible(rr, att)) return false;
+        if (!ropeStoreBatchGeometryCompatible(first_rope, rr)) return false;
+        if (!attentionGeometryCompatible(first_att, att)) return false;
+        if (!attentionSliceStoreCompatible(att, sa)) return false;
+        if (rr.src != first_rope.src or rr.cos_sin != first_rope.cos_sin or
+            att.k != first_att.k or att.v != first_att.v or att.mask != first_att.mask or
+            sa.dst != first_sa.dst) return false;
+        if (sa.dst_row_stride != first_sa.dst_row_stride or
+            sa.dst_col_stride != first_sa.dst_col_stride) return false;
+    }
+    return true;
 }
 
 fn attentionSliceMatches(
@@ -3726,6 +4942,101 @@ pub fn buildRegionSchedule(
     return units.toOwnedSlice(alloc);
 }
 
+pub const RegionCommandPlan = struct {
+    commands: []const ProgramCommand = &.{},
+
+    pub fn deinit(self: RegionCommandPlan, alloc: std.mem.Allocator) void {
+        if (self.commands.len > 0) alloc.free(self.commands);
+    }
+};
+
+pub fn deinitRegionCommandPlans(alloc: std.mem.Allocator, plans: []const RegionCommandPlan) void {
+    for (plans) |plan| plan.deinit(alloc);
+}
+
+pub fn buildRegionCommandPlans(
+    alloc: std.mem.Allocator,
+    ops: []const backend_mod.DeviceOp,
+    units: []const ScheduleUnit,
+    policy: CommandStreamPolicy,
+) ![]RegionCommandPlan {
+    if (units.len == 0) return &.{};
+
+    const plans = try alloc.alloc(RegionCommandPlan, units.len);
+    errdefer alloc.free(plans);
+    @memset(plans, .{});
+    errdefer deinitRegionCommandPlans(alloc, plans);
+
+    for (units, 0..) |unit, i| {
+        if (unit.kind != .pattern_region or unit.op_count > 256) continue;
+        const start: usize = @intCast(unit.op_start);
+        const end = start + @as(usize, unit.op_count);
+        if (end > ops.len) continue;
+        plans[i].commands = try buildProgramCommands(alloc, ops[start..end], policy);
+    }
+
+    return plans;
+}
+
+pub const ExecutionPlan = struct {
+    schedule: []const KernelItem = &.{},
+    regions: []const ScheduleUnit = &.{},
+    region_commands: []const RegionCommandPlan = &.{},
+    region_command_policy: CommandStreamPolicy = .{},
+
+    pub fn deinit(self: ExecutionPlan, alloc: std.mem.Allocator) void {
+        if (self.schedule.len > 0) alloc.free(self.schedule);
+        if (self.regions.len > 0) alloc.free(self.regions);
+        deinitRegionCommandPlans(alloc, self.region_commands);
+        if (self.region_commands.len > 0) alloc.free(self.region_commands);
+    }
+
+    pub fn shapeMatches(
+        self: ExecutionPlan,
+        ops: []const backend_mod.DeviceOp,
+        policy: SchedulePolicy,
+    ) bool {
+        return scheduleShapeMatches(ops, self.schedule, policy);
+    }
+
+    pub fn regionCommandPlan(
+        self: ExecutionPlan,
+        unit_index: usize,
+        policy: CommandStreamPolicy,
+    ) []const ProgramCommand {
+        if (!std.meta.eql(self.region_command_policy, policy)) return &.{};
+        if (unit_index >= self.region_commands.len) return &.{};
+        return self.region_commands[unit_index].commands;
+    }
+};
+
+pub fn buildExecutionPlan(
+    alloc: std.mem.Allocator,
+    ops: []const backend_mod.DeviceOp,
+    schedule_policy: SchedulePolicy,
+    stages: []const StagePolicy,
+    command_policy: CommandStreamPolicy,
+) !ExecutionPlan {
+    const schedule = try buildKernelSchedule(alloc, ops, schedule_policy);
+    errdefer if (schedule.len > 0) alloc.free(schedule);
+
+    const regions = buildStageRegionSchedule(alloc, schedule, stages) catch &.{};
+    errdefer if (regions.len > 0) alloc.free(regions);
+
+    const region_commands = buildRegionCommandPlans(alloc, ops, regions, command_policy) catch &.{};
+    errdefer {
+        deinitRegionCommandPlans(alloc, region_commands);
+        if (region_commands.len > 0) alloc.free(region_commands);
+    }
+
+    return .{
+        .schedule = schedule,
+        .regions = regions,
+        .region_commands = region_commands,
+        .region_command_policy = command_policy,
+    };
+}
+
 pub fn summarizeRegionExecution(
     units: []const ScheduleUnit,
     items: []const KernelItem,
@@ -3979,6 +5290,76 @@ fn expectKernelItem(item: KernelItem, family: KernelFamily, execution: Execution
     try std.testing.expectEqual(execution, item.execution);
     try std.testing.expectEqual(start, item.start);
     try std.testing.expectEqual(len, item.len);
+}
+
+test "program command index set carries flat sidecars once" {
+    var command = ProgramCommand{
+        .kind = .projection_cache_group,
+        .op_start = 2,
+        .op_count = 8,
+        .anchor_count = 2,
+        .sidecar_count = 3,
+    };
+    command.indices[0] = 5;
+    command.indices[1] = 2;
+    command.sidecar_indices[0] = 6;
+    command.sidecar_indices[1] = 5;
+    command.sidecar_indices[2] = 9;
+
+    const indices = command.explicitIndexSet();
+    const expected = [_]usize{ 5, 2, 6, 9 };
+    try std.testing.expectEqualSlices(usize, &expected, indices.slice());
+
+    var sorted = command.sortedExplicitIndexSet();
+    const expected_sorted = [_]usize{ 2, 5, 6, 9 };
+    try std.testing.expectEqualSlices(usize, &expected_sorted, sorted.slice());
+
+    var iter = command.coveredIndexIterator();
+    var got: [4]usize = undefined;
+    var count: usize = 0;
+    while (iter.next()) |idx| {
+        got[count] = idx;
+        count += 1;
+    }
+    try std.testing.expectEqualSlices(usize, &expected_sorted, got[0..count]);
+}
+
+test "program command shape drives coverage and advancement" {
+    try std.testing.expectEqual(ProgramCommandCoverage.anchor_sidecars, ProgramCommandKind.projection_chain.shape().coverage);
+    try std.testing.expectEqual(ProgramCommandAdvance.contiguous, ProgramCommandKind.projection_chain.shape().advance);
+    try std.testing.expectEqual(ProgramCommandSidecarLayout.flat, ProgramCommandKind.projection_cache_group.shape().sidecars);
+
+    const chain = ProgramCommand{
+        .kind = .projection_chain,
+        .op_start = 3,
+        .op_count = 2,
+        .anchor_count = 1,
+        .sidecar_count = 1,
+    };
+    try std.testing.expect(chain.hasExplicitCoverage());
+    try std.testing.expect(!chain.usesExplicitIndices());
+    try std.testing.expectEqual(@as(u32, 2), chain.coveredOpCount());
+    try std.testing.expectEqual(@as(u32, 2), chain.advanceCount());
+
+    const group = ProgramCommand{
+        .kind = .movement_group,
+        .op_start = 3,
+        .op_count = 8,
+        .anchor_count = 4,
+    };
+    try std.testing.expect(group.hasExplicitCoverage());
+    try std.testing.expect(group.usesExplicitIndices());
+    try std.testing.expectEqual(@as(u32, 4), group.coveredOpCount());
+    try std.testing.expectEqual(@as(u32, 1), group.advanceCount());
+
+    const contiguous = ProgramCommand.contiguous(.row_chain, 4, 3);
+    var iter = contiguous.coveredIndexIterator();
+    const expected = [_]usize{ 4, 5, 6 };
+    for (expected) |idx| {
+        try std.testing.expectEqual(idx, iter.next().?);
+    }
+    try std.testing.expectEqual(@as(?usize, null), iter.next());
+    try std.testing.expectEqual(@as(usize, 0), iter.remainingCount());
 }
 
 test "kernel schedule groups contiguous fallback ops by family" {
@@ -4384,6 +5765,88 @@ test "projection groups carry compatible qmatmul cache-store sidecars" {
     try std.testing.expectEqual(@as(u32, 2), summary.estimated_saved_dispatches);
 }
 
+test "projection groups carry compatible qmatvec cache-store sidecars" {
+    const ops = [_]backend_mod.DeviceOp{
+        testQMatmulWith(1, 0, 1),
+        .{ .slice_assign = .{
+            .dst = 8,
+            .src = 1,
+            .rows = 4,
+            .cols = 1,
+            .dst_base_offset = 0,
+            .dst_offset = 0,
+            .dst_row_stride = 1,
+            .dst_col_stride = 4,
+            .src_offset = 0,
+            .src_row_stride = 1,
+            .src_col_stride = 4,
+            .patch_stride = 4,
+        } },
+        testQMatmulWith(2, 0, 1),
+    };
+
+    const selection = findProjectionGroup(&ops, 0, ProjectionGroupPolicy.decodeQMatvec(4), null).?;
+    try std.testing.expectEqual(@as(usize, 0), selection.indices[0]);
+    try std.testing.expectEqual(@as(usize, 2), selection.indices[1]);
+    try std.testing.expectEqual(@as(?usize, 1), selection.sidecar_indices[0]);
+    try std.testing.expectEqual(@as(?usize, null), selection.sidecar_indices[1]);
+    try std.testing.expect(qmatvecSliceSidecarCompatible(ops[0].qmatmul, ops[1].slice_assign));
+
+    const commands = try buildProgramCommands(std.testing.allocator, &ops, CommandStreamPolicy.metal(4, 4));
+    defer std.testing.allocator.free(commands);
+
+    try std.testing.expectEqual(@as(usize, 1), commands.len);
+    try std.testing.expectEqual(ProgramCommandKind.projection_group, commands[0].kind);
+    try std.testing.expectEqual(ProjectionGroupKind.qmatvec, commands[0].projection_kind);
+    try std.testing.expectEqual(@as(u32, 2), commands[0].anchor_count);
+    try std.testing.expectEqual(@as(u32, 1), commands[0].sidecar_count);
+
+    const summary = summarizeProgramCommands(commands);
+    try std.testing.expectEqual(@as(u32, 3), summary.covered_ops);
+    try std.testing.expectEqual(@as(u32, 1), summary.estimated_dispatches);
+    try std.testing.expectEqual(@as(u32, 2), summary.estimated_saved_dispatches);
+}
+
+test "projection groups carry compatible qmatvec elementwise sidecars" {
+    const ops = [_]backend_mod.DeviceOp{
+        testQMatmulWith(1, 0, 1),
+        .{ .elementwise = .{
+            .op = .add,
+            .dst = 8,
+            .src0 = 1,
+            .src1 = 9,
+            .n = 4,
+            .dst_offset = 0,
+            .src0_offset = 0,
+            .src1_offset = 0,
+        } },
+        testQMatmulWith(2, 0, 1),
+    };
+
+    const selection = findProjectionGroup(&ops, 0, ProjectionGroupPolicy.decodeQMatvec(4), null).?;
+    try std.testing.expectEqual(@as(usize, 0), selection.indices[0]);
+    try std.testing.expectEqual(@as(usize, 2), selection.indices[1]);
+    try std.testing.expectEqual(@as(?usize, 1), selection.sidecar_indices[0]);
+    try std.testing.expectEqual(@as(?usize, null), selection.sidecar_indices[1]);
+    try std.testing.expect(qmatvecElementwiseSidecarCompatible(ops[0].qmatmul, ops[1].elementwise));
+
+    const commands = try buildProgramCommands(std.testing.allocator, &ops, CommandStreamPolicy.metal(4, 4));
+    defer std.testing.allocator.free(commands);
+
+    try std.testing.expectEqual(@as(usize, 1), commands.len);
+    try std.testing.expectEqual(ProgramCommandKind.projection_group, commands[0].kind);
+    try std.testing.expectEqual(ProjectionGroupKind.qmatvec, commands[0].projection_kind);
+    try std.testing.expectEqual(@as(u32, 2), commands[0].anchor_count);
+    try std.testing.expectEqual(@as(u32, 1), commands[0].sidecar_count);
+
+    const summary = summarizeProgramCommands(commands);
+    try std.testing.expectEqual(@as(u32, 3), summary.covered_ops);
+    try std.testing.expectEqual(@as(u32, 1), summary.estimated_dispatches);
+    try std.testing.expectEqual(@as(u32, 2), summary.estimated_saved_dispatches);
+    try std.testing.expectEqual(@as(u32, 1), summary.projection_groups);
+    try std.testing.expectEqual(@as(u32, 1), summary.projection_sidecars);
+}
+
 test "projection groups carry compatible qmatmul elementwise sidecars" {
     const ops = [_]backend_mod.DeviceOp{
         testQMatmulWith(1, 0, 2),
@@ -4478,6 +5941,255 @@ test "program command stream merges stage and projection commands" {
     try std.testing.expectEqual(@as(u32, 3), summary.estimated_saved_dispatches);
     try std.testing.expectEqual(@as(u32, 1), summary.projection_groups);
     try std.testing.expectEqual(@as(u32, 1), summary.rope_chains);
+}
+
+test "program command stream derives defaults from backend capabilities" {
+    const policy = CommandStreamPolicy.fromCapabilities(backend_mod.Capabilities.metal);
+    try std.testing.expect(policy.stage_commands);
+    try std.testing.expectEqual(@as(u32, 4), policy.qmatvec_group_size);
+    try std.testing.expectEqual(@as(u32, 4), policy.qmatmul_group_size);
+    try std.testing.expect(policy.qmatmul_sidecars);
+    try std.testing.expectEqual(@as(u32, 8), policy.qmatmul_cache_sidecars_per_anchor);
+    try std.testing.expect(!policy.projection_rope_cache_sidecars);
+    try std.testing.expectEqual(@as(u32, 16), policy.max_rope_batch);
+    try std.testing.expectEqual(@as(u32, 16), policy.max_movement_batch);
+    try std.testing.expectEqual(@as(u32, 16), policy.max_attention_batch);
+    try std.testing.expectEqual(@as(u32, 4), policy.max_attention_store_batch);
+    try std.testing.expectEqual(@as(u32, 16), policy.max_rope_attention_store_batch);
+    try std.testing.expectEqual(@as(u32, 8), policy.max_elementwise_batch);
+    try std.testing.expect(policy.fuse_repeat_fused_elementwise);
+}
+
+test "program command stream carries multiple projection cache stores" {
+    var store0 = testQMatmulSidecar(3, 8);
+    store0.slice_assign.dst_offset = 0;
+    var store1 = testQMatmulSidecar(3, 8);
+    store1.slice_assign.dst_offset = 8;
+    var store2 = testQMatmulSidecar(3, 8);
+    store2.slice_assign.dst_offset = 16;
+
+    const ops = [_]backend_mod.DeviceOp{
+        testQMatmulWith(1, 0, 2),
+        testQMatmulWith(2, 0, 2),
+        testQMatmulWith(3, 0, 2),
+        store0,
+        .{ .elementwise = .{ .op = .add, .dst = 20, .src0 = 20, .src1 = 20, .n = 1 } },
+        store1,
+        store2,
+    };
+
+    const commands = try buildProgramCommands(std.testing.allocator, &ops, CommandStreamPolicy.metal(4, 4));
+    defer std.testing.allocator.free(commands);
+
+    try std.testing.expectEqual(@as(usize, 2), commands.len);
+    try std.testing.expectEqual(ProgramCommandKind.projection_cache_group, commands[0].kind);
+    try std.testing.expectEqual(@as(u32, 3), commands[0].anchor_count);
+    try std.testing.expectEqual(@as(u32, 3), commands[0].sidecar_count);
+    try std.testing.expectEqual(@as(?usize, 3), commands[0].sidecar_indices[0]);
+    try std.testing.expectEqual(@as(?usize, 5), commands[0].sidecar_indices[1]);
+    try std.testing.expectEqual(@as(?usize, 6), commands[0].sidecar_indices[2]);
+    try std.testing.expectEqual(ProgramCommandKind.op, commands[1].kind);
+
+    const summary = summarizeProgramCommands(commands);
+    try std.testing.expectEqual(@as(u32, 1), summary.projection_cache_groups);
+    try std.testing.expectEqual(@as(u32, 3), summary.projection_cache_anchors);
+    try std.testing.expectEqual(@as(u32, 3), summary.projection_cache_sidecars);
+    try std.testing.expectEqual(@as(u32, 7), summary.covered_ops);
+    try std.testing.expectEqual(@as(u32, 5), summary.estimated_saved_dispatches);
+}
+
+test "program command stream carries projection rope cache stores" {
+    const rope_pair = testRopeSliceAssignOps();
+    var rope = rope_pair[0];
+    rope.rope.src = 1;
+    rope.rope.src_off = 0;
+
+    const ops = [_]backend_mod.DeviceOp{
+        testQMatmulWith(1, 0, 3),
+        rope,
+        rope_pair[1],
+        testQMatmulWith(4, 0, 3),
+    };
+
+    var policy = CommandStreamPolicy.metal(4, 4);
+    policy.projection_rope_cache_sidecars = true;
+    const commands = try buildProgramCommands(std.testing.allocator, &ops, policy);
+    defer std.testing.allocator.free(commands);
+
+    try std.testing.expectEqual(@as(usize, 1), commands.len);
+    try std.testing.expectEqual(ProgramCommandKind.projection_cache_group, commands[0].kind);
+    try std.testing.expectEqual(@as(u32, 2), commands[0].anchor_count);
+    try std.testing.expectEqual(@as(u32, 2), commands[0].sidecar_count);
+    try std.testing.expectEqual(@as(?usize, 1), commands[0].sidecar_indices[0]);
+    try std.testing.expectEqual(@as(?usize, 2), commands[0].sidecar_indices[1]);
+
+    const summary = summarizeProgramCommands(commands);
+    try std.testing.expectEqual(@as(u32, 1), summary.projection_cache_groups);
+    try std.testing.expectEqual(@as(u32, 2), summary.projection_cache_anchors);
+    try std.testing.expectEqual(@as(u32, 2), summary.projection_cache_sidecars);
+    try std.testing.expectEqual(@as(u32, 4), summary.covered_ops);
+    try std.testing.expectEqual(@as(u32, 3), summary.estimated_saved_dispatches);
+}
+
+test "program command stream carries qmatvec rope cache stores" {
+    const rope_pair = testRopeSliceAssignOps();
+    var rope = rope_pair[0];
+    rope.rope.src = 1;
+    rope.rope.src_off = 0;
+    rope.rope.seq_len = 1;
+    var store = rope_pair[1];
+    store.slice_assign.cols = 1;
+
+    const ops = [_]backend_mod.DeviceOp{
+        testQMatmulWith(1, 0, 1),
+        rope,
+        store,
+        testQMatmulWith(4, 0, 1),
+    };
+
+    var policy = CommandStreamPolicy.metal(4, 4);
+    policy.projection_rope_cache_sidecars = true;
+    const commands = try buildProgramCommands(std.testing.allocator, &ops, policy);
+    defer std.testing.allocator.free(commands);
+
+    try std.testing.expectEqual(@as(usize, 1), commands.len);
+    try std.testing.expectEqual(ProgramCommandKind.projection_cache_group, commands[0].kind);
+    try std.testing.expectEqual(ProjectionGroupKind.qmatvec, commands[0].projection_kind);
+    try std.testing.expectEqual(@as(u32, 2), commands[0].anchor_count);
+    try std.testing.expectEqual(@as(u32, 2), commands[0].sidecar_count);
+    try std.testing.expectEqual(@as(?usize, 1), commands[0].sidecar_indices[0]);
+    try std.testing.expectEqual(@as(?usize, 2), commands[0].sidecar_indices[1]);
+
+    const summary = summarizeProgramCommands(commands);
+    try std.testing.expectEqual(@as(u32, 1), summary.projection_cache_groups);
+    try std.testing.expectEqual(@as(u32, 2), summary.projection_cache_anchors);
+    try std.testing.expectEqual(@as(u32, 2), summary.projection_cache_sidecars);
+    try std.testing.expectEqual(@as(u32, 4), summary.covered_ops);
+    try std.testing.expectEqual(@as(u32, 3), summary.estimated_saved_dispatches);
+}
+
+test "program command stream carries qmatvec rope materialization" {
+    const rope_pair = testRopeSliceAssignOps();
+    var rope = rope_pair[0];
+    rope.rope.src = 1;
+    rope.rope.src_off = 0;
+    rope.rope.seq_len = 1;
+
+    const ops = [_]backend_mod.DeviceOp{
+        testQMatmulWith(1, 0, 1),
+        rope,
+        testQMatmulWith(4, 0, 1),
+    };
+
+    var policy = CommandStreamPolicy.metal(4, 4);
+    policy.projection_rope_cache_sidecars = true;
+    const commands = try buildProgramCommands(std.testing.allocator, &ops, policy);
+    defer std.testing.allocator.free(commands);
+
+    try std.testing.expectEqual(@as(usize, 1), commands.len);
+    try std.testing.expectEqual(ProgramCommandKind.projection_cache_group, commands[0].kind);
+    try std.testing.expectEqual(ProjectionGroupKind.qmatvec, commands[0].projection_kind);
+    try std.testing.expectEqual(@as(u32, 2), commands[0].anchor_count);
+    try std.testing.expectEqual(@as(u32, 1), commands[0].sidecar_count);
+    try std.testing.expectEqual(@as(?usize, 1), commands[0].sidecar_indices[0]);
+
+    const summary = summarizeProgramCommands(commands);
+    try std.testing.expectEqual(@as(u32, 1), summary.projection_cache_groups);
+    try std.testing.expectEqual(@as(u32, 2), summary.projection_cache_anchors);
+    try std.testing.expectEqual(@as(u32, 1), summary.projection_cache_sidecars);
+    try std.testing.expectEqual(@as(u32, 3), summary.covered_ops);
+    try std.testing.expectEqual(@as(u32, 2), summary.estimated_saved_dispatches);
+}
+
+test "program command stream preserves q rope attention fusion" {
+    var att = testAttention(0);
+    att.attention.q = 4;
+    att.attention.k = 10;
+    att.attention.v = 11;
+    att.attention.dst = 5;
+    att.attention.seq_q = 1;
+
+    const ops = [_]backend_mod.DeviceOp{
+        testQMatmulWith(1, 0, 1),
+        .{ .rope = .{
+            .dst = 4,
+            .src = 1,
+            .cos_sin = 7,
+            .half_d = 2,
+            .seq_len = 1,
+            .src_off = 0,
+            .cs_off = 0,
+            .dst_off = 0,
+            .src_rs = 1,
+            .src_cs = 4,
+            .cs_cs = 4,
+        } },
+        testQMatmulWith(8, 0, 1),
+        att,
+        .{ .slice_assign = .{
+            .dst = 9,
+            .src = 5,
+            .rows = 4,
+            .cols = 1,
+            .dst_base_offset = 0,
+            .dst_offset = 0,
+            .dst_row_stride = 1,
+            .dst_col_stride = 4,
+            .src_offset = 0,
+            .src_row_stride = 1,
+            .src_col_stride = 4,
+            .patch_stride = 0,
+        } },
+    };
+
+    var policy = CommandStreamPolicy.metal(4, 4);
+    policy.projection_rope_cache_sidecars = true;
+    const commands = try buildProgramCommands(std.testing.allocator, &ops, policy);
+    defer std.testing.allocator.free(commands);
+
+    try std.testing.expectEqual(@as(usize, 2), commands.len);
+    try std.testing.expectEqual(ProgramCommandKind.projection_group, commands[0].kind);
+    try std.testing.expectEqual(ProjectionGroupKind.qmatvec, commands[0].projection_kind);
+    try std.testing.expectEqual(@as(u32, 2), commands[0].anchor_count);
+    try std.testing.expectEqual(@as(u32, 0), commands[0].sidecar_count);
+    try std.testing.expectEqual(ProgramCommandKind.rope_attention_store_chain, commands[1].kind);
+    try std.testing.expectEqual(@as(usize, 1), commands[1].indices[0]);
+    try std.testing.expectEqual(@as(usize, 3), commands[1].indices[1]);
+    try std.testing.expectEqual(@as(?usize, 4), commands[1].sidecar_indices[0]);
+
+    const summary = summarizeProgramCommands(commands);
+    try std.testing.expectEqual(@as(u32, 1), summary.projection_groups);
+    try std.testing.expectEqual(@as(u32, 0), summary.projection_cache_groups);
+    try std.testing.expectEqual(@as(u32, 1), summary.rope_attention_store_chains);
+    try std.testing.expectEqual(@as(u32, 5), summary.covered_ops);
+    try std.testing.expectEqual(@as(u32, 3), summary.estimated_saved_dispatches);
+
+    const rope_summary = summarizeProjectionRopeCacheSidecars(&ops, 2);
+    try std.testing.expectEqual(@as(u32, 2), rope_summary.anchors);
+    try std.testing.expectEqual(@as(u32, 1), rope_summary.rope_materializations);
+    try std.testing.expectEqual(@as(u32, 1), rope_summary.materialization_attention_fusion_skips);
+}
+
+test "projection rope cache summary counts tile-pair opportunities" {
+    const rope_pair = testRopeSliceAssignOps();
+    var rope = rope_pair[0];
+    rope.rope.src = 1;
+    rope.rope.src_off = 0;
+
+    const ops = [_]backend_mod.DeviceOp{
+        testQMatmulWith(1, 0, 3),
+        rope,
+        rope_pair[1],
+        testQMatmulWith(4, 0, 3),
+    };
+
+    const summary = summarizeProjectionRopeCacheSidecars(&ops, 2);
+    try std.testing.expectEqual(@as(u32, 2), summary.anchors);
+    try std.testing.expectEqual(@as(u32, 1), summary.rope_store_pairs);
+    try std.testing.expectEqual(@as(u32, 1), summary.compatible_pairs);
+    try std.testing.expectEqual(@as(u32, 1), summary.tile_pair_pairs);
+    try std.testing.expectEqual(@as(u32, 0), summary.rope_materializations);
+    try std.testing.expectEqual(@as(u32, 0), summary.materialization_attention_fusion_skips);
 }
 
 test "program command stream groups rope slice stores" {
@@ -4867,6 +6579,7 @@ test "program command stream groups attention output stores" {
 test "program command stream emits rope attention output store chains" {
     var att = testAttention(0);
     att.attention.q = 4;
+    att.attention.k = 10;
     att.attention.dst = 5;
 
     const ops = [_]backend_mod.DeviceOp{
@@ -5007,6 +6720,62 @@ test "program command stream groups rope attention output stores" {
     try std.testing.expectEqual(@as(u32, 1), summary.estimated_dispatches);
 }
 
+test "program command stream groups wide shared-offset rope attention stores" {
+    var ops: [15]backend_mod.DeviceOp = undefined;
+    for (0..5) |h| {
+        const off: u32 = @intCast(h * 8);
+        ops[h * 3] = .{ .rope = .{
+            .dst = 4,
+            .src = 0,
+            .cos_sin = 1,
+            .half_d = 2,
+            .seq_len = 2,
+            .src_off = off,
+            .cs_off = off,
+            .dst_off = off,
+            .src_rs = 1,
+            .src_cs = 4,
+            .cs_cs = 4,
+        } };
+        ops[h * 3 + 1] = testAttention(off);
+        ops[h * 3 + 1].attention.q = 4;
+        ops[h * 3 + 1].attention.dst = 5;
+        ops[h * 3 + 1].attention.k_off = off;
+        ops[h * 3 + 1].attention.v_off = off;
+        ops[h * 3 + 1].attention.mask_off = off;
+        ops[h * 3 + 2] = .{ .slice_assign = .{
+            .dst = 9,
+            .src = 5,
+            .rows = 4,
+            .cols = 2,
+            .dst_base_offset = 0,
+            .dst_offset = off,
+            .dst_row_stride = 1,
+            .dst_col_stride = 20,
+            .src_offset = off,
+            .src_row_stride = 1,
+            .src_col_stride = 4,
+            .patch_stride = 0,
+        } };
+    }
+
+    const commands = try buildProgramCommands(std.testing.allocator, &ops, CommandStreamPolicy.metal(4, 4));
+    defer std.testing.allocator.free(commands);
+
+    try std.testing.expectEqual(@as(usize, 1), commands.len);
+    try std.testing.expectEqual(ProgramCommandKind.rope_attention_store_group, commands[0].kind);
+    try std.testing.expectEqual(@as(u32, 10), commands[0].anchor_count);
+    try std.testing.expectEqual(@as(u32, 5), commands[0].sidecar_count);
+    try std.testing.expect(ropeAttentionStoreCompactBatchCompatible(&ops, &commands[0]));
+
+    const summary = summarizeProgramCommands(commands);
+    try std.testing.expectEqual(@as(u32, 1), summary.rope_attention_store_groups);
+    try std.testing.expectEqual(@as(u32, 10), summary.rope_attention_store_group_ops);
+    try std.testing.expectEqual(@as(u32, 5), summary.rope_attention_store_group_sidecars);
+    try std.testing.expectEqual(@as(u32, 15), summary.covered_ops);
+    try std.testing.expectEqual(@as(u32, 1), summary.estimated_dispatches);
+}
+
 test "program command stream delays rope attention groups until inputs are ready" {
     var att0 = testAttention(0);
     var att1 = testAttention(8);
@@ -5082,7 +6851,7 @@ test "program command stream delays rope attention groups until inputs are ready
     try std.testing.expectEqual(ProgramCommandKind.op, commands[0].kind);
     try std.testing.expectEqual(@as(u32, 1), commands[0].op_start);
     try std.testing.expectEqual(ProgramCommandKind.rope_attention_store_group, commands[1].kind);
-    try std.testing.expectEqual(@as(u32, 3), commands[1].op_start);
+    try std.testing.expectEqual(@as(u32, 5), commands[1].op_start);
     try std.testing.expectEqual(@as(u32, 4), commands[1].anchor_count);
     try std.testing.expectEqual(@as(u32, 2), commands[1].sidecar_count);
     try std.testing.expectEqual(@as(usize, 0), commands[1].indices[0]);
@@ -5101,6 +6870,74 @@ test "program command stream delays rope attention groups until inputs are ready
     try std.testing.expectEqual(@as(u32, 1), summary.rope_attention_store_groups);
     try std.testing.expectEqual(@as(u32, 4), summary.rope_attention_store_group_ops);
     try std.testing.expectEqual(@as(u32, 2), summary.rope_attention_store_group_sidecars);
+}
+
+test "program command stream delays single rope attention store chains" {
+    var att = testAttention(0);
+    att.attention.q = 4;
+    att.attention.k = 10;
+    att.attention.dst = 5;
+
+    const ops = [_]backend_mod.DeviceOp{
+        .{ .rope = .{
+            .dst = 4,
+            .src = 0,
+            .cos_sin = 1,
+            .half_d = 2,
+            .seq_len = 2,
+            .src_off = 0,
+            .cs_off = 0,
+            .dst_off = 0,
+            .src_rs = 1,
+            .src_cs = 4,
+            .cs_cs = 4,
+        } },
+        .{ .elementwise = .{
+            .op = .add,
+            .dst = 10,
+            .src0 = 8,
+            .src1 = 8,
+            .n = 16,
+        } },
+        att,
+        .{ .slice_assign = .{
+            .dst = 9,
+            .src = 5,
+            .rows = 4,
+            .cols = 2,
+            .dst_base_offset = 0,
+            .dst_offset = 0,
+            .dst_row_stride = 1,
+            .dst_col_stride = 8,
+            .src_offset = 0,
+            .src_row_stride = 1,
+            .src_col_stride = 4,
+            .patch_stride = 0,
+        } },
+    };
+
+    const commands = try buildProgramCommands(std.testing.allocator, &ops, CommandStreamPolicy.metal(4, 4));
+    defer std.testing.allocator.free(commands);
+
+    try std.testing.expectEqual(@as(usize, 2), commands.len);
+    try std.testing.expectEqual(ProgramCommandKind.op, commands[0].kind);
+    try std.testing.expectEqual(@as(u32, 1), commands[0].op_start);
+    try std.testing.expectEqual(ProgramCommandKind.rope_attention_store_chain, commands[1].kind);
+    try std.testing.expectEqual(@as(u32, 2), commands[1].op_start);
+    try std.testing.expectEqual(@as(u32, 2), commands[1].anchor_count);
+    try std.testing.expectEqual(@as(u32, 1), commands[1].sidecar_count);
+    try std.testing.expectEqual(@as(usize, 0), commands[1].indices[0]);
+    try std.testing.expectEqual(@as(usize, 2), commands[1].indices[1]);
+    try std.testing.expectEqual(@as(?usize, 3), commands[1].sidecar_indices[0]);
+
+    const summary = summarizeProgramCommands(commands);
+    try std.testing.expectEqual(@as(u32, 2), summary.commands);
+    try std.testing.expectEqual(@as(u32, 4), summary.covered_ops);
+    try std.testing.expectEqual(@as(u32, 2), summary.estimated_dispatches);
+    try std.testing.expectEqual(@as(u32, 2), summary.estimated_saved_dispatches);
+    try std.testing.expectEqual(@as(u32, 1), summary.op_commands);
+    try std.testing.expectEqual(@as(u32, 1), summary.rope_attention_store_chains);
+    try std.testing.expectEqual(@as(u32, 1), summary.rope_attention_store_chain_sidecars);
 }
 
 test "program command stream carries delayed attention output stores" {
@@ -5197,6 +7034,193 @@ test "program command stream emits noncontiguous elementwise batch commands" {
     try std.testing.expectEqual(@as(u32, 1), summary.op_commands);
     try std.testing.expectEqual(@as(u32, 1), summary.elementwise_batches);
     try std.testing.expectEqual(@as(u32, 2), summary.elementwise_ops);
+}
+
+test "program command stream fuses repeat feeding fused elementwise secondary" {
+    const steps = [_]backend_mod.FusedEwStep{
+        .{ .op = .add, .is_swapped = false, .secondary_buf = 2, .secondary_offset = 0 },
+        .{ .op = .recip, .is_swapped = false, .secondary_buf = 0, .secondary_offset = 0 },
+        .{ .op = .mul, .is_swapped = true, .secondary_buf = 3, .secondary_offset = 0 },
+    };
+    const ops = [_]backend_mod.DeviceOp{
+        .{ .repeat = .{
+            .dst = 2,
+            .src = 1,
+            .n = 8,
+            .src_ne = .{ 1, 1, 1, 1 },
+            .dst_ne = .{ 4, 2, 1, 1 },
+            .src_strides = .{ 1, 1, 1, 1 },
+            .dst_strides = .{ 1, 4, 8, 8 },
+        } },
+        .{ .fused_elementwise = .{
+            .steps = &steps,
+            .n = 8,
+            .dst = 4,
+            .src = 5,
+            .dst_offset = 0,
+            .src_offset = 0,
+        } },
+    };
+
+    const commands = try buildProgramCommands(std.testing.allocator, &ops, CommandStreamPolicy.metal(4, 4));
+    defer std.testing.allocator.free(commands);
+
+    try std.testing.expectEqual(@as(usize, 1), commands.len);
+    try std.testing.expectEqual(ProgramCommandKind.repeat_fused_elementwise_chain, commands[0].kind);
+    try std.testing.expectEqual(@as(u32, 2), commands[0].op_count);
+
+    const summary = summarizeProgramCommands(commands);
+    try std.testing.expectEqual(@as(u32, 1), summary.commands);
+    try std.testing.expectEqual(@as(u32, 2), summary.covered_ops);
+    try std.testing.expectEqual(@as(u32, 1), summary.estimated_dispatches);
+    try std.testing.expectEqual(@as(u32, 1), summary.estimated_saved_dispatches);
+    try std.testing.expectEqual(@as(u32, 1), summary.repeat_fused_elementwise_chains);
+}
+
+test "program command stream fuses projection activation expression chain" {
+    const exp_steps = [_]backend_mod.FusedEwStep{
+        .{ .op = .neg, .is_swapped = false, .secondary_buf = 0, .secondary_offset = 0 },
+        .{ .op = .exp, .is_swapped = false, .secondary_buf = 0, .secondary_offset = 0 },
+    };
+    const silu_steps = [_]backend_mod.FusedEwStep{
+        .{ .op = .add, .is_swapped = false, .secondary_buf = 4, .secondary_offset = 0 },
+        .{ .op = .recip, .is_swapped = false, .secondary_buf = 0, .secondary_offset = 0 },
+        .{ .op = .mul, .is_swapped = true, .secondary_buf = 2, .secondary_offset = 0 },
+    };
+    const ops = [_]backend_mod.DeviceOp{
+        testQMatmulWith(2, 8, 2),
+        .{ .fused_elementwise = .{
+            .steps = &exp_steps,
+            .n = 8,
+            .dst = 3,
+            .src = 2,
+            .dst_offset = 0,
+            .src_offset = 0,
+        } },
+        .{ .repeat = .{
+            .dst = 4,
+            .src = 5,
+            .n = 8,
+            .src_ne = .{ 1, 1, 1, 1 },
+            .dst_ne = .{ 4, 2, 1, 1 },
+            .src_strides = .{ 1, 1, 1, 1 },
+            .dst_strides = .{ 1, 4, 8, 8 },
+        } },
+        .{ .fused_elementwise = .{
+            .steps = &silu_steps,
+            .n = 8,
+            .dst = 6,
+            .src = 3,
+            .dst_offset = 0,
+            .src_offset = 0,
+        } },
+        testQMatmulWith(2, 8, 2),
+    };
+
+    const commands = try buildProgramCommands(std.testing.allocator, &ops, CommandStreamPolicy.metal(4, 4));
+    defer std.testing.allocator.free(commands);
+
+    try std.testing.expectEqual(@as(usize, 2), commands.len);
+    try std.testing.expectEqual(ProgramCommandKind.projection_fused_elementwise_chain, commands[0].kind);
+    try std.testing.expectEqual(@as(u32, 4), commands[0].op_count);
+    try std.testing.expectEqual(ProgramCommandKind.op, commands[1].kind);
+
+    const summary = summarizeProgramCommands(commands);
+    try std.testing.expectEqual(@as(u32, 2), summary.commands);
+    try std.testing.expectEqual(@as(u32, 5), summary.covered_ops);
+    try std.testing.expectEqual(@as(u32, 2), summary.estimated_dispatches);
+    try std.testing.expectEqual(@as(u32, 3), summary.estimated_saved_dispatches);
+    try std.testing.expectEqual(@as(u32, 1), summary.projection_fused_elementwise_chains);
+}
+
+test "program command stream fuses paired projection activation product chain" {
+    const exp_steps = [_]backend_mod.FusedEwStep{
+        .{ .op = .neg, .is_swapped = false, .secondary_buf = 0, .secondary_offset = 0 },
+        .{ .op = .exp, .is_swapped = false, .secondary_buf = 0, .secondary_offset = 0 },
+    };
+    const silu_steps = [_]backend_mod.FusedEwStep{
+        .{ .op = .add, .is_swapped = false, .secondary_buf = 4, .secondary_offset = 0 },
+        .{ .op = .recip, .is_swapped = false, .secondary_buf = 0, .secondary_offset = 0 },
+        .{ .op = .mul, .is_swapped = true, .secondary_buf = 2, .secondary_offset = 0 },
+    };
+    const ops = [_]backend_mod.DeviceOp{
+        testQMatmulWith(2, 8, 2),
+        .{ .fused_elementwise = .{
+            .steps = &exp_steps,
+            .n = 8,
+            .dst = 3,
+            .src = 2,
+            .dst_offset = 0,
+            .src_offset = 0,
+        } },
+        .{ .repeat = .{
+            .dst = 4,
+            .src = 5,
+            .n = 8,
+            .src_ne = .{ 1, 1, 1, 1 },
+            .dst_ne = .{ 4, 2, 1, 1 },
+            .src_strides = .{ 1, 1, 1, 1 },
+            .dst_strides = .{ 1, 4, 8, 8 },
+        } },
+        .{ .fused_elementwise = .{
+            .steps = &silu_steps,
+            .n = 8,
+            .dst = 6,
+            .src = 3,
+            .dst_offset = 0,
+            .src_offset = 0,
+        } },
+        testQMatmulWith(2, 8, 2),
+        .{ .elementwise = .{ .op = .mul, .dst = 4, .src0 = 6, .src1 = 2, .n = 8 } },
+        testQMatmulWith(7, 8, 2),
+    };
+
+    const commands = try buildProgramCommands(std.testing.allocator, &ops, CommandStreamPolicy.metal(4, 4));
+    defer std.testing.allocator.free(commands);
+
+    try std.testing.expectEqual(@as(usize, 2), commands.len);
+    try std.testing.expectEqual(ProgramCommandKind.projection_pair_fused_elementwise_chain, commands[0].kind);
+    try std.testing.expectEqual(@as(u32, 6), commands[0].op_count);
+    try std.testing.expectEqual(ProgramCommandKind.op, commands[1].kind);
+
+    const summary = summarizeProgramCommands(commands);
+    try std.testing.expectEqual(@as(u32, 2), summary.commands);
+    try std.testing.expectEqual(@as(u32, 7), summary.covered_ops);
+    try std.testing.expectEqual(@as(u32, 2), summary.estimated_dispatches);
+    try std.testing.expectEqual(@as(u32, 5), summary.estimated_saved_dispatches);
+    try std.testing.expectEqual(@as(u32, 1), summary.projection_pair_fused_elementwise_chains);
+}
+
+test "program command stream keeps live repeat outputs materialized" {
+    const steps = [_]backend_mod.FusedEwStep{.{ .op = .add, .is_swapped = false, .secondary_buf = 2, .secondary_offset = 0 }};
+    const ops = [_]backend_mod.DeviceOp{
+        .{ .repeat = .{
+            .dst = 2,
+            .src = 1,
+            .n = 4,
+            .src_ne = .{ 1, 1, 1, 1 },
+            .dst_ne = .{ 4, 1, 1, 1 },
+            .src_strides = .{ 1, 1, 1, 1 },
+            .dst_strides = .{ 1, 4, 4, 4 },
+        } },
+        .{ .fused_elementwise = .{
+            .steps = &steps,
+            .n = 4,
+            .dst = 4,
+            .src = 5,
+            .dst_offset = 0,
+            .src_offset = 0,
+        } },
+        .{ .elementwise = .{ .op = .add, .dst = 6, .src0 = 2, .src1 = 5, .n = 4 } },
+    };
+
+    const commands = try buildProgramCommands(std.testing.allocator, &ops, CommandStreamPolicy.metal(4, 4));
+    defer std.testing.allocator.free(commands);
+
+    try std.testing.expectEqual(@as(usize, 3), commands.len);
+    try std.testing.expectEqual(ProgramCommandKind.op, commands[0].kind);
+    try std.testing.expectEqual(ProgramCommandKind.op, commands[1].kind);
+    try std.testing.expectEqual(ProgramCommandKind.op, commands[2].kind);
 }
 
 test "program command stream keeps conflicting elementwise ops separate" {
@@ -5316,6 +7340,82 @@ test "region schedule covers items once and replaces selected patterns" {
     try std.testing.expectEqual(@as(u32, 3), units[1].op_count);
     try std.testing.expectEqual(ScheduleUnitKind.item, units[2].kind);
     try std.testing.expectEqual(@as(u32, 5), units[2].op_start);
+}
+
+test "region command plans compile commands only for pattern regions" {
+    const ops = [_]backend_mod.DeviceOp{
+        testElementwise(.add),
+        testElementwise(.mul),
+        testMatmul(1),
+        testElementwise(.relu),
+    };
+    const units = [_]ScheduleUnit{
+        .{
+            .kind = .pattern_region,
+            .pattern_index = 0,
+            .start_item = 0,
+            .item_count = 1,
+            .op_start = 0,
+            .op_count = 3,
+        },
+        .{
+            .kind = .item,
+            .start_item = 1,
+            .item_count = 1,
+            .op_start = 3,
+            .op_count = 1,
+        },
+    };
+
+    const plans = try buildRegionCommandPlans(std.testing.allocator, &ops, &units, .{});
+    defer {
+        deinitRegionCommandPlans(std.testing.allocator, plans);
+        std.testing.allocator.free(plans);
+    }
+
+    try std.testing.expectEqual(@as(usize, units.len), plans.len);
+    try std.testing.expect(plans[0].commands.len > 0);
+    try std.testing.expectEqual(@as(usize, 0), plans[1].commands.len);
+
+    const summary = summarizeProgramCommands(plans[0].commands);
+    try std.testing.expectEqual(@as(u32, 3), summary.covered_ops);
+}
+
+test "execution plan bundles schedule regions and cached command plans" {
+    const ops = [_]backend_mod.DeviceOp{
+        testQMatmul(16),
+        testElementwise(.add),
+        testQMatmul(16),
+    };
+    const schedule_policy = SchedulePolicy{
+        .capabilities = backend_mod.Capabilities.metal,
+        .native_kernels = .{ .qmatmul = true, .elementwise = true },
+        .fine_grained = true,
+        .min_backend_qmatmul_m = 0,
+    };
+    const stages = [_]StagePolicy{
+        StagePolicy.anchored("qmatmul-stage", 0, RegionPolicy.qmatmulCluster(), 1),
+    };
+    const command_policy = CommandStreamPolicy.metal(4, 4);
+
+    const plan = try buildExecutionPlan(
+        std.testing.allocator,
+        &ops,
+        schedule_policy,
+        &stages,
+        command_policy,
+    );
+    defer plan.deinit(std.testing.allocator);
+
+    try std.testing.expect(plan.schedule.len > 0);
+    try std.testing.expect(plan.regions.len > 0);
+    try std.testing.expectEqual(plan.regions.len, plan.region_commands.len);
+    try std.testing.expect(plan.shapeMatches(&ops, schedule_policy));
+    try std.testing.expect(plan.regionCommandPlan(0, command_policy).len > 0);
+
+    var different_command_policy = command_policy;
+    different_command_policy.max_elementwise_batch = 1;
+    try std.testing.expectEqual(@as(usize, 0), plan.regionCommandPlan(0, different_command_policy).len);
 }
 
 test "region execution summary counts backend islands and transitions" {

--- a/src/backend/program.zig
+++ b/src/backend/program.zig
@@ -907,6 +907,7 @@ fn findAttentionChainCommand(
         else => return null,
     };
     if (attentionSliceAssignOperand(sa, att) == null) return null;
+    if (attentionHasFusableStoreSidecar(ops, start + 1, used)) return null;
 
     var command = ProgramCommand{
         .kind = .attention_chain,
@@ -918,6 +919,37 @@ fn findAttentionChainCommand(
     command.indices[0] = start + 1;
     command.sidecar_indices[0] = start;
     return command;
+}
+
+fn attentionHasFusableStoreSidecar(
+    ops: []const backend_mod.DeviceOp,
+    attention_index: usize,
+    used: ?[]const bool,
+) bool {
+    if (attention_index >= ops.len) return false;
+    if (used) |used_ops| {
+        if (attention_index >= used_ops.len or used_ops[attention_index]) return false;
+    }
+    const att = switch (ops[attention_index]) {
+        .attention => |att| att,
+        else => return false,
+    };
+
+    var scan = attention_index + 1;
+    while (scan < ops.len) : (scan += 1) {
+        if (used) |used_ops| {
+            if (scan >= used_ops.len or used_ops[scan]) continue;
+        }
+        const sa = switch (ops[scan]) {
+            .slice_assign => |sa| sa,
+            else => continue,
+        };
+        if (sa.src != att.dst) continue;
+        if (!attentionSliceStoreCompatible(att, sa)) continue;
+        if (!canFuseAttentionStoreSidecar(ops, attention_index, scan, sa)) continue;
+        return true;
+    }
+    return false;
 }
 
 fn findAttentionStoreChainCommand(
@@ -3155,6 +3187,57 @@ test "program command stream emits attention producer chains" {
     try std.testing.expectEqual(@as(u32, 1), summary.estimated_saved_dispatches);
     try std.testing.expectEqual(@as(u32, 1), summary.attention_chains);
     try std.testing.expectEqual(@as(u32, 1), summary.attention_chain_sidecars);
+}
+
+test "program command stream preserves attention output store over input sidecar" {
+    const ops = [_]backend_mod.DeviceOp{
+        .{ .slice_assign = .{
+            .dst = 2,
+            .src = 9,
+            .rows = 4,
+            .cols = 4,
+            .dst_base_offset = 0,
+            .dst_offset = 0,
+            .dst_row_stride = 1,
+            .dst_col_stride = 4,
+            .src_offset = 0,
+            .src_row_stride = 1,
+            .src_col_stride = 4,
+            .patch_stride = 4,
+        } },
+        testAttention(0),
+        .{ .slice_assign = .{
+            .dst = 9,
+            .src = 4,
+            .rows = 4,
+            .cols = 2,
+            .dst_base_offset = 0,
+            .dst_offset = 8,
+            .dst_row_stride = 1,
+            .dst_col_stride = 4,
+            .src_offset = 0,
+            .src_row_stride = 1,
+            .src_col_stride = 4,
+            .patch_stride = 4,
+        } },
+    };
+
+    const commands = try buildProgramCommands(std.testing.allocator, &ops, CommandStreamPolicy.metal(4, 4));
+    defer std.testing.allocator.free(commands);
+
+    try std.testing.expectEqual(@as(usize, 2), commands.len);
+    try std.testing.expectEqual(ProgramCommandKind.op, commands[0].kind);
+    try std.testing.expectEqual(@as(u32, 0), commands[0].op_start);
+    try std.testing.expectEqual(ProgramCommandKind.attention_store_chain, commands[1].kind);
+    try std.testing.expectEqual(@as(usize, 1), commands[1].indices[0]);
+    try std.testing.expectEqual(@as(?usize, 2), commands[1].sidecar_indices[0]);
+
+    const summary = summarizeProgramCommands(commands);
+    try std.testing.expectEqual(@as(u32, 2), summary.commands);
+    try std.testing.expectEqual(@as(u32, 3), summary.covered_ops);
+    try std.testing.expectEqual(@as(u32, 1), summary.op_commands);
+    try std.testing.expectEqual(@as(u32, 0), summary.attention_chains);
+    try std.testing.expectEqual(@as(u32, 1), summary.attention_store_chains);
 }
 
 test "program command stream emits attention output store chains" {

--- a/src/backend/program.zig
+++ b/src/backend/program.zig
@@ -292,6 +292,22 @@ pub const StageCommandSummary = struct {
     rope_chain_ops: u32 = 0,
 };
 
+pub const ProgramCommandKind = enum {
+    op,
+    row_chain,
+    rope_chain,
+    projection_group,
+
+    pub fn label(self: ProgramCommandKind) []const u8 {
+        return switch (self) {
+            .op => "op",
+            .row_chain => "row_chain",
+            .rope_chain => "rope_chain",
+            .projection_group => "projection_group",
+        };
+    }
+};
+
 pub const ProjectionGroupKind = enum {
     qmatvec,
     qmatmul,
@@ -312,6 +328,116 @@ pub const ProjectionGroupPolicy = struct {
     pub fn prefillQMatmul(max_anchors: u32) ProjectionGroupPolicy {
         return .{ .kind = .qmatmul, .max_anchors = max_anchors };
     }
+};
+
+pub const CommandStreamPolicy = struct {
+    stage_commands: bool = true,
+    qmatvec_group_size: u32 = 4,
+    qmatmul_group_size: u32 = 4,
+    qmatmul_sidecars: bool = true,
+
+    pub fn metal(qmatvec_group_size: u32, qmatmul_group_size: u32) CommandStreamPolicy {
+        return .{
+            .qmatvec_group_size = qmatvec_group_size,
+            .qmatmul_group_size = qmatmul_group_size,
+        };
+    }
+
+    fn projectionPolicyFor(self: CommandStreamPolicy, q: anytype) ?ProjectionGroupPolicy {
+        if (q.M == 1) {
+            if (self.qmatvec_group_size < 2) return null;
+            return ProjectionGroupPolicy.decodeQMatvec(self.qmatvec_group_size);
+        }
+        if (self.qmatmul_group_size < 2) return null;
+        var policy = ProjectionGroupPolicy.prefillQMatmul(self.qmatmul_group_size);
+        policy.carry_slice_sidecars = self.qmatmul_sidecars;
+        return policy;
+    }
+};
+
+pub const ProgramCommand = struct {
+    kind: ProgramCommandKind,
+    op_start: u32,
+    op_count: u32,
+    projection_kind: ProjectionGroupKind = .qmatmul,
+    anchor_count: u32 = 0,
+    sidecar_count: u32 = 0,
+    indices: [max_projection_group_anchors]usize = [_]usize{0} ** max_projection_group_anchors,
+    sidecar_indices: [max_projection_group_anchors]?usize = [_]?usize{null} ** max_projection_group_anchors,
+
+    pub fn op(start: usize) ProgramCommand {
+        return .{
+            .kind = .op,
+            .op_start = @intCast(start),
+            .op_count = 1,
+        };
+    }
+
+    pub fn fromStageCommand(command: StageCommand) ProgramCommand {
+        return .{
+            .kind = switch (command.kind) {
+                .op => .op,
+                .row_chain => .row_chain,
+                .rope_chain => .rope_chain,
+            },
+            .op_start = command.op_start,
+            .op_count = command.op_count,
+        };
+    }
+
+    pub fn fromProjectionSelection(selection: ProjectionGroupSelection) ProgramCommand {
+        var command = ProgramCommand{
+            .kind = .projection_group,
+            .op_start = @intCast(selection.start_op),
+            .op_count = @intCast(selection.end_op - selection.start_op + 1),
+            .projection_kind = selection.kind,
+            .anchor_count = @intCast(selection.anchor_count),
+            .sidecar_count = @intCast(selection.sidecar_count),
+        };
+        for (selection.anchorIndices(), 0..) |idx, slot| command.indices[slot] = idx;
+        for (selection.sidecarIndices(), 0..) |idx, slot| command.sidecar_indices[slot] = idx;
+        return command;
+    }
+
+    pub fn dispatchCount(_: ProgramCommand) u32 {
+        return 1;
+    }
+
+    pub fn coveredOpCount(self: ProgramCommand) u32 {
+        return switch (self.kind) {
+            .projection_group => self.anchor_count + self.sidecar_count,
+            else => self.op_count,
+        };
+    }
+
+    pub fn advanceCount(self: ProgramCommand) u32 {
+        return switch (self.kind) {
+            .projection_group => 1,
+            else => self.op_count,
+        };
+    }
+
+    pub fn anchorIndices(self: *const ProgramCommand) []const usize {
+        return self.indices[0..self.anchor_count];
+    }
+
+    pub fn sidecarIndices(self: *const ProgramCommand) []const ?usize {
+        return self.sidecar_indices[0..self.anchor_count];
+    }
+};
+
+pub const ProgramCommandSummary = struct {
+    commands: u32 = 0,
+    covered_ops: u32 = 0,
+    estimated_dispatches: u32 = 0,
+    estimated_saved_dispatches: u32 = 0,
+    op_commands: u32 = 0,
+    row_chains: u32 = 0,
+    rope_chains: u32 = 0,
+    projection_groups: u32 = 0,
+    projection_anchors: u32 = 0,
+    projection_sidecars: u32 = 0,
+    max_projection_span_ops: u32 = 0,
 };
 
 pub const max_projection_group_anchors = 8;
@@ -562,6 +688,129 @@ pub fn summarizeProjectionGroups(groups: []const ProjectionGroup) ProjectionGrou
         }
     }
     return summary;
+}
+
+pub fn buildProgramCommands(
+    alloc: std.mem.Allocator,
+    ops: []const backend_mod.DeviceOp,
+    policy: CommandStreamPolicy,
+) ![]ProgramCommand {
+    var commands: std.ArrayListUnmanaged(ProgramCommand) = .empty;
+    errdefer commands.deinit(alloc);
+
+    const used = try alloc.alloc(bool, ops.len);
+    defer alloc.free(used);
+    @memset(used, false);
+
+    var i: usize = 0;
+    while (i < ops.len) {
+        if (used[i]) {
+            i += 1;
+            continue;
+        }
+
+        if (findProgramCommand(ops, i, policy, used)) |command| {
+            markProgramCommandUsed(used, command);
+            try commands.append(alloc, command);
+            i += command.advanceCount();
+            continue;
+        }
+
+        const command = ProgramCommand.op(i);
+        markProgramCommandUsed(used, command);
+        try commands.append(alloc, command);
+        i += 1;
+    }
+
+    return commands.toOwnedSlice(alloc);
+}
+
+pub fn findProgramCommand(
+    ops: []const backend_mod.DeviceOp,
+    start: usize,
+    policy: CommandStreamPolicy,
+    used: ?[]const bool,
+) ?ProgramCommand {
+    if (start >= ops.len) return null;
+    if (used) |used_ops| {
+        if (start >= used_ops.len or used_ops[start]) return null;
+    }
+
+    const op = ops[start];
+    if (op == .qmatmul) {
+        if (policy.projectionPolicyFor(op.qmatmul)) |projection_policy| {
+            if (findProjectionGroup(ops, start, projection_policy, used)) |selection| {
+                return ProgramCommand.fromProjectionSelection(selection);
+            }
+        }
+    }
+
+    if (policy.stage_commands) {
+        if (findStageCommand(ops, start)) |stage_command| {
+            if (!commandRangeTouchesUsed(stage_command.op_start, stage_command.op_count, used)) {
+                return ProgramCommand.fromStageCommand(stage_command);
+            }
+        }
+    }
+
+    return null;
+}
+
+pub fn summarizeProgramCommands(commands: []const ProgramCommand) ProgramCommandSummary {
+    var summary = ProgramCommandSummary{ .commands = @intCast(commands.len) };
+    for (commands) |command| {
+        const covered = command.coveredOpCount();
+        const dispatches = command.dispatchCount();
+        summary.covered_ops += covered;
+        summary.estimated_dispatches += dispatches;
+        if (covered > dispatches) {
+            summary.estimated_saved_dispatches += covered - dispatches;
+        }
+
+        switch (command.kind) {
+            .op => summary.op_commands += 1,
+            .row_chain => summary.row_chains += 1,
+            .rope_chain => summary.rope_chains += 1,
+            .projection_group => {
+                summary.projection_groups += 1;
+                summary.projection_anchors += command.anchor_count;
+                summary.projection_sidecars += command.sidecar_count;
+                summary.max_projection_span_ops = @max(summary.max_projection_span_ops, command.op_count);
+            },
+        }
+    }
+    return summary;
+}
+
+pub fn markProgramCommandUsed(used: []bool, command: ProgramCommand) void {
+    switch (command.kind) {
+        .projection_group => {
+            for (command.anchorIndices()) |idx| {
+                if (idx < used.len) used[idx] = true;
+            }
+            for (command.sidecarIndices()) |maybe_idx| {
+                if (maybe_idx) |idx| {
+                    if (idx < used.len) used[idx] = true;
+                }
+            }
+        },
+        else => {
+            const start: usize = @intCast(command.op_start);
+            const end = @min(used.len, start + @as(usize, command.op_count));
+            for (used[start..end]) |*slot| slot.* = true;
+        },
+    }
+}
+
+fn commandRangeTouchesUsed(op_start: u32, op_count: u32, used: ?[]const bool) bool {
+    const used_ops = used orelse return false;
+    const start: usize = @intCast(op_start);
+    if (start >= used_ops.len) return true;
+    const end = @min(used_ops.len, start + @as(usize, op_count));
+    for (used_ops[start..end]) |slot| {
+        if (slot) return true;
+    }
+    return false;
 }
 
 fn projectionMatchesPolicy(q: anytype, policy: ProjectionGroupPolicy) bool {
@@ -1821,6 +2070,61 @@ test "projection groups reject conflicting or nonhoistable projections" {
     const blocked_groups = try buildProjectionGroups(std.testing.allocator, &blocked_ops, ProjectionGroupPolicy.prefillQMatmul(4));
     defer std.testing.allocator.free(blocked_groups);
     try std.testing.expectEqual(@as(usize, 0), blocked_groups.len);
+}
+
+test "program command stream merges stage and projection commands" {
+    const rope_chain = testRopeSliceAssignOps();
+    const ops = [_]backend_mod.DeviceOp{
+        testQMatmulWith(1, 0, 2),
+        testQMatmulSidecar(1, 8),
+        rope_chain[0],
+        rope_chain[1],
+        testQMatmulWith(4, 0, 2),
+    };
+
+    const commands = try buildProgramCommands(std.testing.allocator, &ops, CommandStreamPolicy.metal(4, 4));
+    defer std.testing.allocator.free(commands);
+
+    try std.testing.expectEqual(@as(usize, 2), commands.len);
+    try std.testing.expectEqual(ProgramCommandKind.projection_group, commands[0].kind);
+    try std.testing.expectEqual(ProjectionGroupKind.qmatmul, commands[0].projection_kind);
+    try std.testing.expectEqual(@as(u32, 2), commands[0].anchor_count);
+    try std.testing.expectEqual(@as(u32, 1), commands[0].sidecar_count);
+    try std.testing.expectEqual(@as(usize, 0), commands[0].indices[0]);
+    try std.testing.expectEqual(@as(usize, 4), commands[0].indices[1]);
+    try std.testing.expectEqual(@as(?usize, 1), commands[0].sidecar_indices[0]);
+    try std.testing.expectEqual(ProgramCommandKind.rope_chain, commands[1].kind);
+    try std.testing.expectEqual(@as(u32, 2), commands[1].op_start);
+
+    const summary = summarizeProgramCommands(commands);
+    try std.testing.expectEqual(@as(u32, 2), summary.commands);
+    try std.testing.expectEqual(@as(u32, 5), summary.covered_ops);
+    try std.testing.expectEqual(@as(u32, 2), summary.estimated_dispatches);
+    try std.testing.expectEqual(@as(u32, 3), summary.estimated_saved_dispatches);
+    try std.testing.expectEqual(@as(u32, 1), summary.projection_groups);
+    try std.testing.expectEqual(@as(u32, 1), summary.rope_chains);
+}
+
+test "program command stream keeps used noncontiguous ops single-owned" {
+    const ops = [_]backend_mod.DeviceOp{
+        testQMatmulWith(1, 0, 2),
+        .{ .elementwise = .{ .op = .add, .dst = 9, .src0 = 9, .src1 = 9, .n = 1 } },
+        testQMatmulWith(4, 0, 2),
+    };
+
+    const commands = try buildProgramCommands(std.testing.allocator, &ops, CommandStreamPolicy.metal(4, 4));
+    defer std.testing.allocator.free(commands);
+
+    try std.testing.expectEqual(@as(usize, 2), commands.len);
+    try std.testing.expectEqual(ProgramCommandKind.projection_group, commands[0].kind);
+    try std.testing.expectEqual(ProgramCommandKind.op, commands[1].kind);
+    try std.testing.expectEqual(@as(u32, 1), commands[1].op_start);
+
+    const summary = summarizeProgramCommands(commands);
+    try std.testing.expectEqual(@as(u32, 3), summary.covered_ops);
+    try std.testing.expectEqual(@as(u32, 1), summary.op_commands);
+    try std.testing.expectEqual(@as(u32, 1), summary.projection_groups);
+    try std.testing.expectEqual(@as(u32, 1), summary.estimated_saved_dispatches);
 }
 
 test "family pattern regions match exact contiguous family sequences" {

--- a/src/backend/program.zig
+++ b/src/backend/program.zig
@@ -296,6 +296,9 @@ pub const ProgramCommandKind = enum {
     op,
     row_chain,
     rope_chain,
+    rope_batch,
+    movement_batch,
+    attention_batch,
     projection_group,
 
     pub fn label(self: ProgramCommandKind) []const u8 {
@@ -303,6 +306,9 @@ pub const ProgramCommandKind = enum {
             .op => "op",
             .row_chain => "row_chain",
             .rope_chain => "rope_chain",
+            .rope_batch => "rope_batch",
+            .movement_batch => "movement_batch",
+            .attention_batch => "attention_batch",
             .projection_group => "projection_group",
         };
     }
@@ -335,6 +341,9 @@ pub const CommandStreamPolicy = struct {
     qmatvec_group_size: u32 = 4,
     qmatmul_group_size: u32 = 4,
     qmatmul_sidecars: bool = true,
+    max_rope_batch: u32 = 16,
+    max_movement_batch: u32 = 16,
+    max_attention_batch: u32 = 16,
 
     pub fn metal(qmatvec_group_size: u32, qmatmul_group_size: u32) CommandStreamPolicy {
         return .{
@@ -399,6 +408,14 @@ pub const ProgramCommand = struct {
         return command;
     }
 
+    pub fn contiguous(kind: ProgramCommandKind, start: usize, count: usize) ProgramCommand {
+        return .{
+            .kind = kind,
+            .op_start = @intCast(start),
+            .op_count = @intCast(count),
+        };
+    }
+
     pub fn dispatchCount(_: ProgramCommand) u32 {
         return 1;
     }
@@ -434,6 +451,9 @@ pub const ProgramCommandSummary = struct {
     op_commands: u32 = 0,
     row_chains: u32 = 0,
     rope_chains: u32 = 0,
+    rope_batches: u32 = 0,
+    movement_batches: u32 = 0,
+    attention_batches: u32 = 0,
     projection_groups: u32 = 0,
     projection_anchors: u32 = 0,
     projection_sidecars: u32 = 0,
@@ -753,6 +773,40 @@ pub fn findProgramCommand(
         }
     }
 
+    if (findContiguousBatchCommand(ops, start, policy, used)) |command| {
+        return command;
+    }
+
+    return null;
+}
+
+fn findContiguousBatchCommand(
+    ops: []const backend_mod.DeviceOp,
+    start: usize,
+    policy: CommandStreamPolicy,
+    used: ?[]const bool,
+) ?ProgramCommand {
+    if (policy.max_attention_batch >= 2) {
+        const n = attentionBatchRunLen(ops[start..], policy.max_attention_batch);
+        if (n >= 2 and !commandRangeTouchesUsed(@intCast(start), @intCast(n), used)) {
+            return ProgramCommand.contiguous(.attention_batch, start, n);
+        }
+    }
+
+    if (policy.max_rope_batch >= 2) {
+        const n = ropeBatchRunLen(ops[start..], policy.max_rope_batch);
+        if (n >= 2 and !commandRangeTouchesUsed(@intCast(start), @intCast(n), used)) {
+            return ProgramCommand.contiguous(.rope_batch, start, n);
+        }
+    }
+
+    if (policy.max_movement_batch >= 2) {
+        const n = sliceAssignBatchRunLen(ops[start..], policy.max_movement_batch);
+        if (n >= 2 and !commandRangeTouchesUsed(@intCast(start), @intCast(n), used)) {
+            return ProgramCommand.contiguous(.movement_batch, start, n);
+        }
+    }
+
     return null;
 }
 
@@ -771,6 +825,9 @@ pub fn summarizeProgramCommands(commands: []const ProgramCommand) ProgramCommand
             .op => summary.op_commands += 1,
             .row_chain => summary.row_chains += 1,
             .rope_chain => summary.rope_chains += 1,
+            .rope_batch => summary.rope_batches += 1,
+            .movement_batch => summary.movement_batches += 1,
+            .attention_batch => summary.attention_batches += 1,
             .projection_group => {
                 summary.projection_groups += 1;
                 summary.projection_anchors += command.anchor_count;
@@ -944,6 +1001,98 @@ pub fn ropeSliceAssignCompatible(rr: anytype, sa: anytype) bool {
         sa.cols == rr.seq_len and
         sa.src_row_stride == 1 and
         sa.src_col_stride == d;
+}
+
+pub fn ropeBatchCompatible(first: anytype, next: anytype) bool {
+    return first.src == next.src and
+        first.cos_sin == next.cos_sin and
+        first.dst == next.dst and
+        first.half_d == next.half_d and
+        first.seq_len == next.seq_len and
+        first.src_rs == next.src_rs and
+        first.src_cs == next.src_cs and
+        first.cs_cs == next.cs_cs;
+}
+
+pub fn ropeBatchRunLen(ops: []const backend_mod.DeviceOp, max_ops: u32) usize {
+    if (ops.len < 2 or max_ops < 2) return 0;
+    const first = switch (ops[0]) {
+        .rope => |rr| rr,
+        else => return 0,
+    };
+    var n: usize = 1;
+    const limit = @min(ops.len, @as(usize, @intCast(max_ops)));
+    while (n < limit) : (n += 1) {
+        const next = switch (ops[n]) {
+            .rope => |rr| rr,
+            else => break,
+        };
+        if (!ropeBatchCompatible(first, next)) break;
+    }
+    return if (n >= 2) n else 0;
+}
+
+pub fn sliceAssignBatchCompatible(first: anytype, next: anytype) bool {
+    return first.src == next.src and first.dst == next.dst;
+}
+
+pub fn sliceAssignBatchRunLen(ops: []const backend_mod.DeviceOp, max_ops: u32) usize {
+    if (ops.len < 2 or max_ops < 2) return 0;
+    const first = switch (ops[0]) {
+        .slice_assign => |sa| sa,
+        else => return 0,
+    };
+    var n: usize = 1;
+    const limit = @min(ops.len, @as(usize, @intCast(max_ops)));
+    while (n < limit) : (n += 1) {
+        const next = switch (ops[n]) {
+            .slice_assign => |sa| sa,
+            else => break,
+        };
+        if (!sliceAssignBatchCompatible(first, next)) break;
+    }
+    return if (n >= 2) n else 0;
+}
+
+pub fn attentionBatchCompatible(first: anytype, next: anytype) bool {
+    return first.q == next.q and
+        first.k == next.k and
+        first.v == next.v and
+        first.mask == next.mask and
+        first.dst == next.dst and
+        first.has_mask == next.has_mask and
+        first.d_head == next.d_head and
+        first.seq_q == next.seq_q and
+        first.seq_kv == next.seq_kv and
+        first.scale == next.scale and
+        first.q_rs == next.q_rs and
+        first.q_cs == next.q_cs and
+        first.k_rs == next.k_rs and
+        first.k_cs == next.k_cs and
+        first.v_rs == next.v_rs and
+        first.v_cs == next.v_cs and
+        first.mask_rs == next.mask_rs and
+        first.mask_cs == next.mask_cs and
+        first.dst_rs == next.dst_rs and
+        first.dst_cs == next.dst_cs;
+}
+
+pub fn attentionBatchRunLen(ops: []const backend_mod.DeviceOp, max_ops: u32) usize {
+    if (ops.len < 2 or max_ops < 2) return 0;
+    const first = switch (ops[0]) {
+        .attention => |att| att,
+        else => return 0,
+    };
+    var n: usize = 1;
+    const limit = @min(ops.len, @as(usize, @intCast(max_ops)));
+    while (n < limit) : (n += 1) {
+        const next = switch (ops[n]) {
+            .attention => |att| att,
+            else => break,
+        };
+        if (!attentionBatchCompatible(first, next)) break;
+    }
+    return if (n >= 2) n else 0;
 }
 
 pub fn isRmsnormScaleChain(
@@ -1615,6 +1764,36 @@ fn testRopeSliceAssignOps() [2]backend_mod.DeviceOp {
     };
 }
 
+fn testAttention(offset: u32) backend_mod.DeviceOp {
+    return .{ .attention = .{
+        .dst = 4,
+        .q = 0,
+        .k = 1,
+        .v = 2,
+        .mask = 3,
+        .has_mask = true,
+        .d_head = 4,
+        .seq_q = 2,
+        .seq_kv = 4,
+        .scale = 0.5,
+        .q_off = offset,
+        .k_off = 0,
+        .v_off = 0,
+        .mask_off = 0,
+        .dst_off = offset,
+        .q_rs = 1,
+        .q_cs = 4,
+        .k_rs = 1,
+        .k_cs = 4,
+        .v_rs = 1,
+        .v_cs = 4,
+        .mask_rs = 1,
+        .mask_cs = 4,
+        .dst_rs = 1,
+        .dst_cs = 4,
+    } };
+}
+
 fn testRmsnormScaleOps() [3]backend_mod.DeviceOp {
     return .{
         .{ .rmsnorm = .{
@@ -2125,6 +2304,41 @@ test "program command stream keeps used noncontiguous ops single-owned" {
     try std.testing.expectEqual(@as(u32, 1), summary.op_commands);
     try std.testing.expectEqual(@as(u32, 1), summary.projection_groups);
     try std.testing.expectEqual(@as(u32, 1), summary.estimated_saved_dispatches);
+}
+
+test "program command stream emits contiguous batch commands" {
+    var rope_pair = testRopeSliceAssignOps();
+    rope_pair[1] = rope_pair[0];
+    rope_pair[1].rope.src_off = 4;
+    rope_pair[1].rope.dst_off = 12;
+
+    const ops = [_]backend_mod.DeviceOp{
+        rope_pair[0],
+        rope_pair[1],
+        testQMatmulSidecar(1, 8),
+        testQMatmulSidecar(1, 8),
+        testAttention(0),
+        testAttention(8),
+    };
+
+    const commands = try buildProgramCommands(std.testing.allocator, &ops, CommandStreamPolicy.metal(4, 4));
+    defer std.testing.allocator.free(commands);
+
+    try std.testing.expectEqual(@as(usize, 3), commands.len);
+    try std.testing.expectEqual(ProgramCommandKind.rope_batch, commands[0].kind);
+    try std.testing.expectEqual(@as(u32, 2), commands[0].op_count);
+    try std.testing.expectEqual(ProgramCommandKind.movement_batch, commands[1].kind);
+    try std.testing.expectEqual(@as(u32, 2), commands[1].op_count);
+    try std.testing.expectEqual(ProgramCommandKind.attention_batch, commands[2].kind);
+    try std.testing.expectEqual(@as(u32, 2), commands[2].op_count);
+
+    const summary = summarizeProgramCommands(commands);
+    try std.testing.expectEqual(@as(u32, 3), summary.commands);
+    try std.testing.expectEqual(@as(u32, 6), summary.covered_ops);
+    try std.testing.expectEqual(@as(u32, 3), summary.estimated_saved_dispatches);
+    try std.testing.expectEqual(@as(u32, 1), summary.rope_batches);
+    try std.testing.expectEqual(@as(u32, 1), summary.movement_batches);
+    try std.testing.expectEqual(@as(u32, 1), summary.attention_batches);
 }
 
 test "family pattern regions match exact contiguous family sequences" {

--- a/src/backend/program.zig
+++ b/src/backend/program.zig
@@ -299,6 +299,7 @@ pub const ProgramCommandKind = enum {
     rope_batch,
     movement_batch,
     attention_batch,
+    elementwise_batch,
     projection_group,
 
     pub fn label(self: ProgramCommandKind) []const u8 {
@@ -309,6 +310,7 @@ pub const ProgramCommandKind = enum {
             .rope_batch => "rope_batch",
             .movement_batch => "movement_batch",
             .attention_batch => "attention_batch",
+            .elementwise_batch => "elementwise_batch",
             .projection_group => "projection_group",
         };
     }
@@ -344,6 +346,7 @@ pub const CommandStreamPolicy = struct {
     max_rope_batch: u32 = 16,
     max_movement_batch: u32 = 16,
     max_attention_batch: u32 = 16,
+    max_elementwise_batch: u32 = 8,
 
     pub fn metal(qmatvec_group_size: u32, qmatmul_group_size: u32) CommandStreamPolicy {
         return .{
@@ -423,13 +426,14 @@ pub const ProgramCommand = struct {
     pub fn coveredOpCount(self: ProgramCommand) u32 {
         return switch (self.kind) {
             .projection_group => self.anchor_count + self.sidecar_count,
+            .elementwise_batch => self.anchor_count,
             else => self.op_count,
         };
     }
 
     pub fn advanceCount(self: ProgramCommand) u32 {
         return switch (self.kind) {
-            .projection_group => 1,
+            .projection_group, .elementwise_batch => 1,
             else => self.op_count,
         };
     }
@@ -454,6 +458,8 @@ pub const ProgramCommandSummary = struct {
     rope_batches: u32 = 0,
     movement_batches: u32 = 0,
     attention_batches: u32 = 0,
+    elementwise_batches: u32 = 0,
+    elementwise_ops: u32 = 0,
     projection_groups: u32 = 0,
     projection_anchors: u32 = 0,
     projection_sidecars: u32 = 0,
@@ -765,6 +771,12 @@ pub fn findProgramCommand(
         }
     }
 
+    if (op == .elementwise and policy.max_elementwise_batch >= 2) {
+        if (findElementwiseBatchCommand(ops, start, policy, used)) |command| {
+            return command;
+        }
+    }
+
     if (policy.stage_commands) {
         if (findStageCommand(ops, start)) |stage_command| {
             if (!commandRangeTouchesUsed(stage_command.op_start, stage_command.op_count, used)) {
@@ -778,6 +790,53 @@ pub fn findProgramCommand(
     }
 
     return null;
+}
+
+fn findElementwiseBatchCommand(
+    ops: []const backend_mod.DeviceOp,
+    start: usize,
+    policy: CommandStreamPolicy,
+    used: ?[]const bool,
+) ?ProgramCommand {
+    if (start >= ops.len) return null;
+    if (used) |used_ops| {
+        if (start >= used_ops.len or used_ops[start]) return null;
+    }
+    const first = switch (ops[start]) {
+        .elementwise => |e| e,
+        else => return null,
+    };
+    if (!canBatchElementwiseOp(first)) return null;
+
+    const max_ops: usize = @intCast(@min(policy.max_elementwise_batch, max_projection_group_anchors));
+    if (max_ops < 2) return null;
+
+    var command = ProgramCommand{
+        .kind = .elementwise_batch,
+        .op_start = @intCast(start),
+        .op_count = 1,
+        .anchor_count = 1,
+    };
+    command.indices[0] = start;
+
+    var scan = start + 1;
+    while (scan < ops.len and command.anchor_count < max_ops) : (scan += 1) {
+        if (used) |used_ops| {
+            if (scan >= used_ops.len or used_ops[scan]) continue;
+        }
+        const e = switch (ops[scan]) {
+            .elementwise => |e| e,
+            else => continue,
+        };
+        if (!canBatchElementwiseOp(e)) continue;
+        if (!canHoistElementwiseTo(ops, start, scan, e)) continue;
+        if (elementwiseConflictsSelected(ops, command.anchorIndices(), e)) continue;
+        command.indices[command.anchor_count] = scan;
+        command.anchor_count += 1;
+        command.op_count = @intCast(scan - start + 1);
+    }
+
+    return if (command.anchor_count >= 2) command else null;
 }
 
 fn findContiguousBatchCommand(
@@ -828,6 +887,10 @@ pub fn summarizeProgramCommands(commands: []const ProgramCommand) ProgramCommand
             .rope_batch => summary.rope_batches += 1,
             .movement_batch => summary.movement_batches += 1,
             .attention_batch => summary.attention_batches += 1,
+            .elementwise_batch => {
+                summary.elementwise_batches += 1;
+                summary.elementwise_ops += command.anchor_count;
+            },
             .projection_group => {
                 summary.projection_groups += 1;
                 summary.projection_anchors += command.anchor_count;
@@ -841,13 +904,15 @@ pub fn summarizeProgramCommands(commands: []const ProgramCommand) ProgramCommand
 
 pub fn markProgramCommandUsed(used: []bool, command: ProgramCommand) void {
     switch (command.kind) {
-        .projection_group => {
+        .projection_group, .elementwise_batch => {
             for (command.anchorIndices()) |idx| {
                 if (idx < used.len) used[idx] = true;
             }
-            for (command.sidecarIndices()) |maybe_idx| {
-                if (maybe_idx) |idx| {
-                    if (idx < used.len) used[idx] = true;
+            if (command.kind == .projection_group) {
+                for (command.sidecarIndices()) |maybe_idx| {
+                    if (maybe_idx) |idx| {
+                        if (idx < used.len) used[idx] = true;
+                    }
                 }
             }
         },
@@ -932,6 +997,38 @@ pub fn canHoistProjectionTo(
         if (opTouchesBuffer(op, q.dst)) return false;
     }
     return true;
+}
+
+pub fn canBatchElementwiseOp(e: anytype) bool {
+    return e.op.isFusible();
+}
+
+pub fn canHoistElementwiseTo(
+    ops: []const backend_mod.DeviceOp,
+    start: usize,
+    candidate_index: usize,
+    e: anytype,
+) bool {
+    for (ops[start..candidate_index]) |op| {
+        if (opWritesBuffer(op, e.src0)) return false;
+        if (e.op.isBinary() and opWritesBuffer(op, e.src1)) return false;
+        if (opTouchesBuffer(op, e.dst)) return false;
+    }
+    return true;
+}
+
+pub fn elementwiseConflictsSelected(
+    ops: []const backend_mod.DeviceOp,
+    indices: []const usize,
+    e: anytype,
+) bool {
+    for (indices) |idx| {
+        const selected = ops[idx].elementwise;
+        if (selected.dst == e.dst) return true;
+        if (selected.dst == e.src0 or (e.op.isBinary() and selected.dst == e.src1)) return true;
+        if (e.dst == selected.src0 or (selected.op.isBinary() and e.dst == selected.src1)) return true;
+    }
+    return false;
 }
 
 pub fn projectionConflictsSelected(
@@ -2339,6 +2436,54 @@ test "program command stream emits contiguous batch commands" {
     try std.testing.expectEqual(@as(u32, 1), summary.rope_batches);
     try std.testing.expectEqual(@as(u32, 1), summary.movement_batches);
     try std.testing.expectEqual(@as(u32, 1), summary.attention_batches);
+}
+
+test "program command stream emits noncontiguous elementwise batch commands" {
+    const ops = [_]backend_mod.DeviceOp{
+        .{ .elementwise = .{ .op = .add, .dst = 1, .src0 = 0, .src1 = 0, .n = 4 } },
+        testQMatmulWith(9, 8, 2),
+        .{ .elementwise = .{ .op = .mul, .dst = 2, .src0 = 0, .src1 = 0, .n = 4 } },
+    };
+
+    const commands = try buildProgramCommands(std.testing.allocator, &ops, CommandStreamPolicy.metal(4, 4));
+    defer std.testing.allocator.free(commands);
+
+    try std.testing.expectEqual(@as(usize, 2), commands.len);
+    try std.testing.expectEqual(ProgramCommandKind.elementwise_batch, commands[0].kind);
+    try std.testing.expectEqual(@as(u32, 2), commands[0].anchor_count);
+    try std.testing.expectEqual(@as(usize, 0), commands[0].indices[0]);
+    try std.testing.expectEqual(@as(usize, 2), commands[0].indices[1]);
+    try std.testing.expectEqual(ProgramCommandKind.op, commands[1].kind);
+    try std.testing.expectEqual(@as(u32, 1), commands[1].op_start);
+
+    const summary = summarizeProgramCommands(commands);
+    try std.testing.expectEqual(@as(u32, 2), summary.commands);
+    try std.testing.expectEqual(@as(u32, 3), summary.covered_ops);
+    try std.testing.expectEqual(@as(u32, 2), summary.estimated_dispatches);
+    try std.testing.expectEqual(@as(u32, 1), summary.estimated_saved_dispatches);
+    try std.testing.expectEqual(@as(u32, 1), summary.op_commands);
+    try std.testing.expectEqual(@as(u32, 1), summary.elementwise_batches);
+    try std.testing.expectEqual(@as(u32, 2), summary.elementwise_ops);
+}
+
+test "program command stream keeps conflicting elementwise ops separate" {
+    const ops = [_]backend_mod.DeviceOp{
+        .{ .elementwise = .{ .op = .add, .dst = 1, .src0 = 0, .src1 = 0, .n = 4 } },
+        .{ .elementwise = .{ .op = .mul, .dst = 1, .src0 = 0, .src1 = 0, .n = 4 } },
+    };
+
+    const commands = try buildProgramCommands(std.testing.allocator, &ops, CommandStreamPolicy.metal(4, 4));
+    defer std.testing.allocator.free(commands);
+
+    try std.testing.expectEqual(@as(usize, 2), commands.len);
+    try std.testing.expectEqual(ProgramCommandKind.op, commands[0].kind);
+    try std.testing.expectEqual(ProgramCommandKind.op, commands[1].kind);
+
+    const summary = summarizeProgramCommands(commands);
+    try std.testing.expectEqual(@as(u32, 2), summary.commands);
+    try std.testing.expectEqual(@as(u32, 2), summary.covered_ops);
+    try std.testing.expectEqual(@as(u32, 0), summary.elementwise_batches);
+    try std.testing.expectEqual(@as(u32, 2), summary.op_commands);
 }
 
 test "family pattern regions match exact contiguous family sequences" {

--- a/src/backend/program.zig
+++ b/src/backend/program.zig
@@ -297,6 +297,7 @@ pub const ProgramCommandKind = enum {
     row_chain,
     rope_chain,
     rope_batch,
+    rope_store_group,
     movement_batch,
     movement_group,
     attention_chain,
@@ -316,6 +317,7 @@ pub const ProgramCommandKind = enum {
             .row_chain => "row_chain",
             .rope_chain => "rope_chain",
             .rope_batch => "rope_batch",
+            .rope_store_group => "rope_store_group",
             .movement_batch => "movement_batch",
             .movement_group => "movement_group",
             .attention_chain => "attention_chain",
@@ -443,7 +445,7 @@ pub const ProgramCommand = struct {
     pub fn coveredOpCount(self: ProgramCommand) u32 {
         return switch (self.kind) {
             .projection_group, .projection_chain => self.anchor_count + self.sidecar_count,
-            .attention_chain, .attention_store_chain, .attention_store_group, .rope_attention_store_chain, .rope_attention_store_group => self.anchor_count + self.sidecar_count,
+            .rope_store_group, .attention_chain, .attention_store_chain, .attention_store_group, .rope_attention_store_chain, .rope_attention_store_group => self.anchor_count + self.sidecar_count,
             .attention_group => self.anchor_count,
             .movement_group => self.anchor_count,
             .elementwise_batch => self.anchor_count,
@@ -453,7 +455,7 @@ pub const ProgramCommand = struct {
 
     pub fn advanceCount(self: ProgramCommand) u32 {
         return switch (self.kind) {
-            .projection_group, .elementwise_batch, .attention_store_chain, .attention_store_group, .rope_attention_store_chain, .rope_attention_store_group, .attention_group, .movement_group => 1,
+            .projection_group, .elementwise_batch, .rope_store_group, .attention_store_chain, .attention_store_group, .rope_attention_store_chain, .rope_attention_store_group, .attention_group, .movement_group => 1,
             else => self.op_count,
         };
     }
@@ -476,6 +478,9 @@ pub const ProgramCommandSummary = struct {
     row_chains: u32 = 0,
     rope_chains: u32 = 0,
     rope_batches: u32 = 0,
+    rope_store_groups: u32 = 0,
+    rope_store_group_ops: u32 = 0,
+    rope_store_group_sidecars: u32 = 0,
     movement_batches: u32 = 0,
     movement_groups: u32 = 0,
     movement_group_ops: u32 = 0,
@@ -543,6 +548,20 @@ pub const EarlyRopeAttentionStoreGroupCandidateSummary = struct {
     rope_hoist_rejects: u32 = 0,
     attention_hoist_rejects: u32 = 0,
     selected_conflict_rejects: u32 = 0,
+    formed_groups: u32 = 0,
+    grouped_pairs: u32 = 0,
+    max_group_pairs: u32 = 0,
+};
+
+pub const RopeStoreGroupCandidateSummary = struct {
+    anchors: u32 = 0,
+    first_pair_missing: u32 = 0,
+    candidate_ropes: u32 = 0,
+    geometry_rejects: u32 = 0,
+    pair_missing_rejects: u32 = 0,
+    hoist_rejects: u32 = 0,
+    selected_conflict_rejects: u32 = 0,
+    external_user_rejects: u32 = 0,
     formed_groups: u32 = 0,
     grouped_pairs: u32 = 0,
     max_group_pairs: u32 = 0,
@@ -966,6 +985,12 @@ fn findProgramCommandWithExecuted(
         }
     }
 
+    if (op == .rope and policy.max_rope_batch >= 2) {
+        if (findRopeStoreGroupCommand(ops, start, policy, used, executed)) |command| {
+            return command;
+        }
+    }
+
     if (policy.stage_commands) {
         if (findStageCommand(ops, start)) |stage_command| {
             if (!commandRangeTouchesUsed(stage_command.op_start, stage_command.op_count, used)) {
@@ -1080,6 +1105,273 @@ fn attentionHasFusableStoreSidecar(
         return true;
     }
     return false;
+}
+
+const RopeStorePair = struct {
+    sidecar_index: usize,
+};
+
+fn findRopeStoreGroupCommand(
+    ops: []const backend_mod.DeviceOp,
+    start: usize,
+    policy: CommandStreamPolicy,
+    used: ?[]const bool,
+    executed: ?[]const bool,
+) ?ProgramCommand {
+    if (start >= ops.len) return null;
+    if (used) |used_ops| {
+        if (start >= used_ops.len or used_ops[start]) return null;
+    }
+    const max_pairs: usize = @intCast(@min(policy.max_rope_batch, max_projection_group_anchors));
+    if (max_pairs < 2) return null;
+
+    const first_pair = findRopeStorePair(ops, start, used) orelse return null;
+    const first_rope = ops[start].rope;
+    const first_sa = ops[first_pair.sidecar_index].slice_assign;
+
+    var command = ProgramCommand{
+        .kind = .rope_store_group,
+        .op_start = @intCast(start),
+        .op_count = 1,
+        .anchor_count = 0,
+        .sidecar_count = 0,
+    };
+    appendRopeStorePair(&command, start, first_pair.sidecar_index, start);
+
+    var scan = start + 1;
+    while (scan < ops.len and command.anchor_count < max_pairs) : (scan += 1) {
+        if (used) |used_ops| {
+            if (scan >= used_ops.len or used_ops[scan]) continue;
+        }
+        const rr = switch (ops[scan]) {
+            .rope => |rr| rr,
+            else => continue,
+        };
+        const pair = findRopeStorePair(ops, scan, used) orelse continue;
+        const sa = ops[pair.sidecar_index].slice_assign;
+        if (!ropeStoreGroupCompatible(first_rope, first_sa, rr, sa)) continue;
+
+        var candidate = command;
+        if (candidate.anchor_count + 1 > max_projection_group_anchors) break;
+        appendRopeStorePair(&candidate, scan, pair.sidecar_index, start);
+        if (!canHoistRopeStorePairToGroup(ops, start, scan, pair.sidecar_index, rr, sa, &candidate, executed)) continue;
+        if (ropeStorePairConflictsSelected(ops, &command, scan, sa)) continue;
+
+        command = candidate;
+    }
+
+    if (ropeStoreGroupOutputsHaveExternalUsers(ops, &command)) return null;
+    return if (command.anchor_count >= 2) command else null;
+}
+
+fn findRopeStorePair(
+    ops: []const backend_mod.DeviceOp,
+    rope_index: usize,
+    used: ?[]const bool,
+) ?RopeStorePair {
+    if (rope_index + 1 >= ops.len) return null;
+    if (used) |used_ops| {
+        if (rope_index >= used_ops.len or used_ops[rope_index]) return null;
+        if (rope_index + 1 >= used_ops.len or used_ops[rope_index + 1]) return null;
+    }
+    if (!isRopeSliceAssignChain(ops[rope_index], ops[rope_index + 1])) return null;
+    return .{ .sidecar_index = rope_index + 1 };
+}
+
+fn appendRopeStorePair(
+    command: *ProgramCommand,
+    rope_index: usize,
+    sidecar_index: usize,
+    group_start: usize,
+) void {
+    const slot = command.anchor_count;
+    command.indices[slot] = rope_index;
+    command.sidecar_indices[slot] = sidecar_index;
+    command.anchor_count += 1;
+    command.sidecar_count += 1;
+    command.op_count = @intCast(@max(
+        group_start + @as(usize, command.op_count),
+        sidecar_index + 1,
+    ) - group_start);
+}
+
+fn canHoistRopeStorePairToGroup(
+    ops: []const backend_mod.DeviceOp,
+    group_start: usize,
+    rope_index: usize,
+    sidecar_index: usize,
+    rr: anytype,
+    sa: anytype,
+    command: *const ProgramCommand,
+    executed: ?[]const bool,
+) bool {
+    const rope_access = opAccessSpans(.{ .rope = rr });
+    for (ops[group_start..rope_index], group_start..) |op, idx| {
+        if (commandContainsIndex(command, idx)) continue;
+        if (executed) |executed_ops| {
+            if (idx < executed_ops.len and executed_ops[idx]) continue;
+        }
+        for (rope_access.readSpans()) |read| {
+            if (opWritesSpan(op, read)) return false;
+        }
+        if (rope_access.read_overflow and (opWritesBuffer(op, rr.src) or opWritesBuffer(op, rr.cos_sin))) return false;
+    }
+
+    const sidecar_access = opAccessSpans(.{ .slice_assign = sa });
+    for (ops[group_start..sidecar_index], group_start..) |op, idx| {
+        if (commandContainsIndex(command, idx)) continue;
+        if (executed) |executed_ops| {
+            if (idx < executed_ops.len and executed_ops[idx]) continue;
+        }
+        for (sidecar_access.writeSpans()) |write| {
+            if (opTouchesSpan(op, write)) return false;
+        }
+        if (sidecar_access.write_overflow and opTouchesBuffer(op, sa.dst)) return false;
+    }
+
+    return true;
+}
+
+fn ropeStorePairConflictsSelected(
+    ops: []const backend_mod.DeviceOp,
+    command: *const ProgramCommand,
+    rope_index: usize,
+    sa: anytype,
+) bool {
+    const rope_op = ops[rope_index];
+    const sidecar_op: backend_mod.DeviceOp = .{ .slice_assign = sa };
+    const sidecar_access = opAccessSpans(sidecar_op);
+    for (command.anchorIndices()) |idx| {
+        for (sidecar_access.writeSpans()) |write| {
+            if (opReadsSpan(ops[idx], write)) return true;
+        }
+        if (sidecar_access.write_overflow and opReadsBuffer(ops[idx], sa.dst)) return true;
+    }
+    for (command.sidecarIndices()) |maybe_idx| {
+        const idx = maybe_idx orelse continue;
+        const selected_sa = switch (ops[idx]) {
+            .slice_assign => |selected| selected,
+            else => return true,
+        };
+        if (sliceAssignWritesMayOverlap(selected_sa, sa)) return true;
+        const selected_access = opAccessSpans(ops[idx]);
+        for (selected_access.writeSpans()) |write| {
+            if (opReadsSpan(rope_op, write)) return true;
+        }
+        if (selected_access.write_overflow and opReadsBuffer(rope_op, selected_sa.dst)) return true;
+    }
+    return false;
+}
+
+fn ropeStoreGroupOutputsHaveExternalUsers(
+    ops: []const backend_mod.DeviceOp,
+    command: *const ProgramCommand,
+) bool {
+    for (command.anchorIndices()) |rope_index| {
+        const rr = switch (ops[rope_index]) {
+            .rope => |rr| rr,
+            else => return true,
+        };
+        const rope_access = opAccessSpans(.{ .rope = rr });
+        var live_writes = [_]bool{false} ** max_access_spans;
+        for (rope_access.writeSpans(), 0..) |_, slot| live_writes[slot] = true;
+        var overflow_live = rope_access.write_overflow;
+
+        for (ops[rope_index + 1 ..], rope_index + 1..) |op, idx| {
+            if (commandContainsIndex(command, idx)) continue;
+            for (rope_access.writeSpans(), 0..) |write, slot| {
+                if (!live_writes[slot]) continue;
+                if (opReadsSpan(op, write)) return true;
+            }
+            if (overflow_live and opReadsBuffer(op, rr.dst)) return true;
+
+            var any_live = false;
+            for (rope_access.writeSpans(), 0..) |write, slot| {
+                if (!live_writes[slot]) continue;
+                if (opWritesCoverSpan(op, write)) {
+                    live_writes[slot] = false;
+                } else {
+                    any_live = true;
+                }
+            }
+            if (overflow_live and opWritesBuffer(op, rr.dst)) overflow_live = false;
+            if (!any_live and !overflow_live) break;
+        }
+    }
+    return false;
+}
+
+pub fn summarizeRopeStoreGroupCandidates(
+    ops: []const backend_mod.DeviceOp,
+    policy: CommandStreamPolicy,
+) RopeStoreGroupCandidateSummary {
+    var summary = RopeStoreGroupCandidateSummary{};
+    const max_pairs: usize = @intCast(@min(policy.max_rope_batch, max_projection_group_anchors));
+    if (max_pairs < 2) return summary;
+
+    for (ops, 0..) |op, start| {
+        const first_rope = switch (op) {
+            .rope => |rr| rr,
+            else => continue,
+        };
+        summary.anchors += 1;
+
+        const first_pair = findRopeStorePair(ops, start, null) orelse {
+            summary.first_pair_missing += 1;
+            continue;
+        };
+        const first_sa = ops[first_pair.sidecar_index].slice_assign;
+        var command = ProgramCommand{
+            .kind = .rope_store_group,
+            .op_start = @intCast(start),
+            .op_count = 1,
+            .anchor_count = 0,
+            .sidecar_count = 0,
+        };
+        appendRopeStorePair(&command, start, first_pair.sidecar_index, start);
+
+        var scan = start + 1;
+        while (scan < ops.len and command.anchor_count < max_pairs) : (scan += 1) {
+            const rr = switch (ops[scan]) {
+                .rope => |rr| rr,
+                else => continue,
+            };
+            summary.candidate_ropes += 1;
+            const pair = findRopeStorePair(ops, scan, null) orelse {
+                summary.pair_missing_rejects += 1;
+                continue;
+            };
+            const sa = ops[pair.sidecar_index].slice_assign;
+            if (!ropeStoreGroupCompatible(first_rope, first_sa, rr, sa)) {
+                summary.geometry_rejects += 1;
+                continue;
+            }
+
+            var candidate = command;
+            if (candidate.anchor_count + 1 > max_projection_group_anchors) break;
+            appendRopeStorePair(&candidate, scan, pair.sidecar_index, start);
+            if (!canHoistRopeStorePairToGroup(ops, start, scan, pair.sidecar_index, rr, sa, &candidate, null)) {
+                summary.hoist_rejects += 1;
+                continue;
+            }
+            if (ropeStorePairConflictsSelected(ops, &command, scan, sa)) {
+                summary.selected_conflict_rejects += 1;
+                continue;
+            }
+            command = candidate;
+        }
+
+        if (command.anchor_count < 2) continue;
+        if (ropeStoreGroupOutputsHaveExternalUsers(ops, &command)) {
+            summary.external_user_rejects += 1;
+            continue;
+        }
+        summary.formed_groups += 1;
+        summary.grouped_pairs += command.anchor_count;
+        summary.max_group_pairs = @max(summary.max_group_pairs, command.anchor_count);
+    }
+
+    return summary;
 }
 
 fn findAttentionStoreChainCommand(
@@ -2117,6 +2409,11 @@ pub fn summarizeProgramCommands(commands: []const ProgramCommand) ProgramCommand
             .row_chain => summary.row_chains += 1,
             .rope_chain => summary.rope_chains += 1,
             .rope_batch => summary.rope_batches += 1,
+            .rope_store_group => {
+                summary.rope_store_groups += 1;
+                summary.rope_store_group_ops += command.anchor_count;
+                summary.rope_store_group_sidecars += command.sidecar_count;
+            },
             .movement_batch => summary.movement_batches += 1,
             .movement_group => {
                 summary.movement_groups += 1;
@@ -2170,11 +2467,11 @@ pub fn summarizeProgramCommands(commands: []const ProgramCommand) ProgramCommand
 
 pub fn markProgramCommandUsed(used: []bool, command: ProgramCommand) void {
     switch (command.kind) {
-        .projection_group, .elementwise_batch, .attention_store_chain, .attention_store_group, .rope_attention_store_chain, .rope_attention_store_group, .attention_group, .movement_group => {
+        .projection_group, .elementwise_batch, .rope_store_group, .attention_store_chain, .attention_store_group, .rope_attention_store_chain, .rope_attention_store_group, .attention_group, .movement_group => {
             for (command.anchorIndices()) |idx| {
                 if (idx < used.len) used[idx] = true;
             }
-            if (command.kind == .projection_group or command.kind == .attention_store_chain or command.kind == .attention_store_group or command.kind == .rope_attention_store_chain or command.kind == .rope_attention_store_group) {
+            if (command.kind == .projection_group or command.kind == .rope_store_group or command.kind == .attention_store_chain or command.kind == .attention_store_group or command.kind == .rope_attention_store_chain or command.kind == .rope_attention_store_group) {
                 for (command.sidecarIndices()) |maybe_idx| {
                     if (maybe_idx) |idx| {
                         if (idx < used.len) used[idx] = true;
@@ -2358,6 +2655,14 @@ pub fn opWritesSpan(op: backend_mod.DeviceOp, target: BufferSpan) bool {
     const access = opAccessSpans(op);
     for (access.writeSpans()) |write| {
         if (write.overlaps(target)) return true;
+    }
+    return access.write_overflow and opWritesBuffer(op, target.buf);
+}
+
+pub fn opWritesCoverSpan(op: backend_mod.DeviceOp, target: BufferSpan) bool {
+    const access = opAccessSpans(op);
+    for (access.writeSpans()) |write| {
+        if (write.buf == target.buf and write.start <= target.start and write.end >= target.end) return true;
     }
     return access.write_overflow and opWritesBuffer(op, target.buf);
 }
@@ -2668,6 +2973,18 @@ pub fn ropeSliceAssignCompatible(rr: anytype, sa: anytype) bool {
         sa.cols == rr.seq_len and
         sa.src_row_stride == 1 and
         sa.src_col_stride == d;
+}
+
+pub fn ropeStoreGroupCompatible(first_rope: anytype, first_sa: anytype, next_rope: anytype, next_sa: anytype) bool {
+    return first_rope.cos_sin == next_rope.cos_sin and
+        first_sa.dst == next_sa.dst and
+        first_rope.half_d == next_rope.half_d and
+        first_rope.seq_len == next_rope.seq_len and
+        first_rope.src_rs == next_rope.src_rs and
+        first_rope.src_cs == next_rope.src_cs and
+        first_rope.cs_cs == next_rope.cs_cs and
+        first_sa.dst_row_stride == next_sa.dst_row_stride and
+        first_sa.dst_col_stride == next_sa.dst_col_stride;
 }
 
 pub fn ropeBatchCompatible(first: anytype, next: anytype) bool {
@@ -3986,6 +4303,46 @@ test "program command stream merges stage and projection commands" {
     try std.testing.expectEqual(@as(u32, 3), summary.estimated_saved_dispatches);
     try std.testing.expectEqual(@as(u32, 1), summary.projection_groups);
     try std.testing.expectEqual(@as(u32, 1), summary.rope_chains);
+}
+
+test "program command stream groups rope slice stores" {
+    const first = testRopeSliceAssignOps();
+    var second = testRopeSliceAssignOps();
+    second[0].rope.src = 11;
+    second[0].rope.src_off = 8;
+    second[1].slice_assign.dst_offset = 16;
+
+    const ops = [_]backend_mod.DeviceOp{
+        first[0],
+        first[1],
+        testQMatmulWith(8, 9, 2),
+        second[0],
+        second[1],
+    };
+
+    const commands = try buildProgramCommands(std.testing.allocator, &ops, CommandStreamPolicy.metal(4, 4));
+    defer std.testing.allocator.free(commands);
+
+    try std.testing.expectEqual(@as(usize, 2), commands.len);
+    try std.testing.expectEqual(ProgramCommandKind.rope_store_group, commands[0].kind);
+    try std.testing.expectEqual(@as(u32, 2), commands[0].anchor_count);
+    try std.testing.expectEqual(@as(u32, 2), commands[0].sidecar_count);
+    try std.testing.expectEqual(@as(usize, 0), commands[0].indices[0]);
+    try std.testing.expectEqual(@as(?usize, 1), commands[0].sidecar_indices[0]);
+    try std.testing.expectEqual(@as(usize, 3), commands[0].indices[1]);
+    try std.testing.expectEqual(@as(?usize, 4), commands[0].sidecar_indices[1]);
+    try std.testing.expectEqual(ProgramCommandKind.op, commands[1].kind);
+    try std.testing.expectEqual(@as(u32, 2), commands[1].op_start);
+
+    const summary = summarizeProgramCommands(commands);
+    try std.testing.expectEqual(@as(u32, 2), summary.commands);
+    try std.testing.expectEqual(@as(u32, 5), summary.covered_ops);
+    try std.testing.expectEqual(@as(u32, 2), summary.estimated_dispatches);
+    try std.testing.expectEqual(@as(u32, 3), summary.estimated_saved_dispatches);
+    try std.testing.expectEqual(@as(u32, 1), summary.op_commands);
+    try std.testing.expectEqual(@as(u32, 1), summary.rope_store_groups);
+    try std.testing.expectEqual(@as(u32, 2), summary.rope_store_group_ops);
+    try std.testing.expectEqual(@as(u32, 2), summary.rope_store_group_sidecars);
 }
 
 test "program command stream keeps used noncontiguous ops single-owned" {

--- a/src/device_inference.zig
+++ b/src/device_inference.zig
@@ -238,10 +238,11 @@ pub fn DeviceInference(comptime T: type) type {
             };
         }
 
-        /// Patch all slice_assign destination offsets (KV-cache write positions).
+        /// Patch dynamic slice_assign destination offsets (KV-cache write positions).
         pub fn patchSliceAssignOffset(self: *Self, pos: u32) void {
             for (self.slice_assign_op_indices) |idx| {
                 const sa = &self.program_ops[idx].slice_assign;
+                if (sa.patch_stride == 0) continue;
                 sa.dst_offset = sa.dst_base_offset + pos * sa.patch_stride;
             }
         }
@@ -715,7 +716,7 @@ pub fn DeviceInference(comptime T: type) type {
                     const dst = node.src1 orelse node;
                     const base = buffers.offset(dst);
                     const dst_offset = base + node.storage_offset * dst.strides[0];
-                    try ops.append(alloc, sliceAssignDeviceOp(buffers, src, dst, src0_idx, src.ne[0], src.ne[1], base, dst_offset, dst.strides[0]));
+                    try ops.append(alloc, sliceAssignDeviceOp(buffers, src, dst, src0_idx, src.ne[0], src.ne[1], base, dst_offset, 0));
                 },
                 .rope => {
                     const src = node.src0.?;
@@ -899,6 +900,36 @@ test "DeviceInference lowers prefill slice_assign with 2D strides" {
     try testing.expectEqual(@as(u32, 20), dev.program_ops[0].slice_assign.dst_offset);
     dev.execute();
     try testing.expectEqual(@as(usize, 1), state.refresh_calls);
+}
+
+test "DeviceInference keeps slice_assign_rows static during position patch" {
+    var graph = ComputeGraphF32.init(testing.allocator);
+    defer graph.deinit();
+    const a = graph.allocator();
+
+    const dst = try TensorF32.init(a, &.{ 8, 2 });
+    const src_full = try TensorF32.init(a, &.{ 8, 2 });
+    const src = src_full.sliceRows(2, 6);
+    const y = dst.sliceAssignRows(src, 2);
+    try graph.infer(y);
+
+    var out = [_]f32{0} ** 16;
+    var state = TestBackendState{};
+    var dev = try DeviceInference(f32).init(.{
+        .graph = &graph,
+        .be = testBackend(&state),
+        .alloc = testing.allocator,
+        .input_tensors = &.{src_full},
+        .output_tensor = y,
+        .output_host_buf = &out,
+        .output_len = out.len,
+    });
+    defer dev.deinit();
+
+    const before = dev.program_ops[0].slice_assign.dst_offset;
+    try testing.expectEqual(@as(u32, 0), dev.program_ops[0].slice_assign.patch_stride);
+    dev.patchSliceAssignOffset(5);
+    try testing.expectEqual(before, dev.program_ops[0].slice_assign.dst_offset);
 }
 
 test "DeviceInference lowers batched attention geometry" {

--- a/src/llm/stage_plan.zig
+++ b/src/llm/stage_plan.zig
@@ -19,6 +19,7 @@ pub const StageCapabilities = struct {
     decode_attention: bool = false,
     quantized_kv: bool = false,
     command_buffer_execution: bool = false,
+    projection_rope_cache_sidecars: bool = false,
 
     pub fn fromBackendCapabilities(caps: backend_mod.Capabilities) StageCapabilities {
         return .{
@@ -29,6 +30,7 @@ pub const StageCapabilities = struct {
             .decode_attention = caps.decode_attention or caps.attention.supported,
             .quantized_kv = caps.quantized_kv,
             .command_buffer_execution = caps.command_buffer_execution,
+            .projection_rope_cache_sidecars = caps.command_stream.projection_rope_cache_sidecars,
         };
     }
 };
@@ -278,7 +280,7 @@ pub fn LlamaDecodePlan(comptime config: LlamaConfig) type {
             try writer.print("  logical stages/token={d}\n", .{self.logicalStageCount()});
             if (caps) |c| {
                 try writer.print(
-                    "  target command buffers/token={d} (fused_ew={} f16_matmul={} qmatmul={} decode_attention={} quantized_kv={})\n",
+                    "  target command buffers/token={d} (fused_ew={} f16_matmul={} qmatmul={} decode_attention={} quantized_kv={} projection_rope_cache={})\n",
                     .{
                         self.targetCommandBuffers(c),
                         c.fused_elementwise,
@@ -286,6 +288,7 @@ pub fn LlamaDecodePlan(comptime config: LlamaConfig) type {
                         c.qmatmul,
                         c.decode_attention,
                         c.quantized_kv,
+                        c.projection_rope_cache_sidecars,
                     },
                 );
             }
@@ -378,7 +381,7 @@ pub fn LlamaPrefillPlan(comptime config: LlamaConfig) type {
             try writer.print("  logical stages/window={d}\n", .{self.logicalStageCount()});
             if (caps) |c| {
                 try writer.print(
-                    "  target command buffers/window={d} (fused_ew={} f16_matmul={} qmatmul={} prefill_attention={} quantized_kv={})\n",
+                    "  target command buffers/window={d} (fused_ew={} f16_matmul={} qmatmul={} prefill_attention={} quantized_kv={} projection_rope_cache={})\n",
                     .{
                         self.targetCommandBuffers(c),
                         c.fused_elementwise,
@@ -386,6 +389,7 @@ pub fn LlamaPrefillPlan(comptime config: LlamaConfig) type {
                         c.qmatmul,
                         c.prefill_attention,
                         c.quantized_kv,
+                        c.projection_rope_cache_sidecars,
                     },
                 );
             }
@@ -522,4 +526,5 @@ test "stage capabilities mirror backend capability metadata" {
     try testing.expect(metal_caps.prefill_attention);
     try testing.expect(metal_caps.decode_attention);
     try testing.expect(metal_caps.command_buffer_execution);
+    try testing.expect(!metal_caps.projection_rope_cache_sidecars);
 }

--- a/src/models/llama_transformer.zig
+++ b/src/models/llama_transformer.zig
@@ -223,7 +223,8 @@ pub fn LlamaBlock(comptime T: type, comptime cfg: LlamaBlockConfig) type {
             const attn_scale: T = 1.0 / @sqrt(dk);
             // Build the concatenated attention output directly, then apply a
             // single output projection instead of one tiny matmul per head.
-            var attn_buf = x.scaleByVal(0).sliceRows(0, cfg.d_model);
+            // This scratch buffer is fully populated by the per-head stores below.
+            var attn_buf = Tensor(T).init(alloc, &.{ cfg.d_model, x.ne[1] }) catch unreachable;
 
             var attention_nodes: [cfg.n_heads]*Tensor(T) = undefined;
             for (0..cfg.n_heads) |h| {

--- a/src/profile.zig
+++ b/src/profile.zig
@@ -16,6 +16,31 @@ pub const DeviceProgram = backend.DeviceProgram;
 /// Number of distinct DeviceOp tags.
 const n_op_tags = 12;
 const n_program_command_kinds = @typeInfo(program_mod.ProgramCommandKind).@"enum".fields.len;
+const max_schedule_region_patterns = 16;
+
+pub const ScheduleRegionStats = struct {
+    attempted: u64 = 0,
+    lowered: u64 = 0,
+    failed: u64 = 0,
+    attempted_ops: u64 = 0,
+    lowered_ops: u64 = 0,
+    failed_ops: u64 = 0,
+
+    pub fn recordAttempt(self: *ScheduleRegionStats, op_count: u32) void {
+        self.attempted +%= 1;
+        self.attempted_ops +%= op_count;
+    }
+
+    pub fn recordLowered(self: *ScheduleRegionStats, op_count: u32) void {
+        self.lowered +%= 1;
+        self.lowered_ops +%= op_count;
+    }
+
+    pub fn recordFailed(self: *ScheduleRegionStats, op_count: u32) void {
+        self.failed +%= 1;
+        self.failed_ops +%= op_count;
+    }
+};
 
 /// Tag names in canonical order matching the DeviceOp union(enum) declaration.
 const tag_names = [n_op_tags][]const u8{
@@ -356,13 +381,30 @@ pub fn printProjectionSidecarSummary(label: []const u8, ops: []const DeviceOp) v
     );
 }
 
+pub fn printProjectionRopeCacheSummary(label: []const u8, ops: []const DeviceOp, tile_cols: u32) void {
+    const summary = program_mod.summarizeProjectionRopeCacheSidecars(ops, tile_cols);
+    std.debug.print(
+        "Projection RoPE sidecars ({s}): {d} projection anchors, {d} projection->rope->slice pairs ({d} compatible, {d} qmatmul tile-pair compatible at tile={d}), {d} rope materializations ({d} left for attention fusion)\n\n",
+        .{
+            label,
+            summary.anchors,
+            summary.rope_store_pairs,
+            summary.compatible_pairs,
+            summary.tile_pair_pairs,
+            tile_cols,
+            summary.rope_materializations,
+            summary.materialization_attention_fusion_skips,
+        },
+    );
+}
+
 pub fn printProgramCommandSummary(label: []const u8, summary: program_mod.ProgramCommandSummary) void {
     const saved_pct: f64 = if (summary.covered_ops > 0)
         @as(f64, @floatFromInt(summary.estimated_saved_dispatches)) / @as(f64, @floatFromInt(summary.covered_ops)) * 100.0
     else
         0.0;
     std.debug.print(
-        "Program commands ({s}): {d} commands cover {d} ops, estimated {d} dispatches ({d} saved, {d:.1}% of ops); ops={d}, row={d}, rope={d}, rope_batch={d}, movement_batch={d}, movement_group={d} ({d} ops), attention_chain={d} ({d} sidecars), attention_store_chain={d} ({d} sidecars), attention_store_group={d} ({d} ops, {d} sidecars), attention_batch={d}, attention_group={d} ({d} ops), elementwise_batch={d} ({d} ops), projection_chains={d} ({d} sidecars), projection_groups={d} ({d} anchors, {d} sidecars, max span {d})\n",
+        "Program commands ({s}): {d} commands cover {d} ops, estimated {d} dispatches ({d} saved, {d:.1}% of ops); ops={d}, row={d}, rope={d}, rope_batch={d}, movement_batch={d}, movement_group={d} ({d} ops), attention_chain={d} ({d} sidecars), attention_store_chain={d} ({d} sidecars), attention_store_group={d} ({d} ops, {d} sidecars), attention_batch={d}, attention_group={d} ({d} ops)\n",
         .{
             label,
             summary.commands,
@@ -387,13 +429,24 @@ pub fn printProgramCommandSummary(label: []const u8, summary: program_mod.Progra
             summary.attention_batches,
             summary.attention_groups,
             summary.attention_group_ops,
+        },
+    );
+    std.debug.print(
+        "  elementwise_batch={d} ({d} ops), repeat_fused_ew={d}, projection_fused_ew={d}, projection_pair_fused_ew={d}, projection_chains={d} ({d} sidecars), projection_groups={d} ({d} anchors, {d} sidecars), projection_cache_groups={d} ({d} anchors, {d} sidecars, max span {d})\n",
+        .{
             summary.elementwise_batches,
             summary.elementwise_ops,
+            summary.repeat_fused_elementwise_chains,
+            summary.projection_fused_elementwise_chains,
+            summary.projection_pair_fused_elementwise_chains,
             summary.projection_chains,
             summary.projection_chain_sidecars,
             summary.projection_groups,
             summary.projection_anchors,
             summary.projection_sidecars,
+            summary.projection_cache_groups,
+            summary.projection_cache_anchors,
+            summary.projection_cache_sidecars,
             summary.max_projection_span_ops,
         },
     );
@@ -719,43 +772,7 @@ pub fn printRegionProgramCommandSummary(
         const summary = program_mod.summarizeProgramCommands(commands);
         alloc.free(commands);
         regions += 1;
-        total.commands += summary.commands;
-        total.covered_ops += summary.covered_ops;
-        total.estimated_dispatches += summary.estimated_dispatches;
-        total.estimated_saved_dispatches += summary.estimated_saved_dispatches;
-        total.op_commands += summary.op_commands;
-        total.row_chains += summary.row_chains;
-        total.rope_chains += summary.rope_chains;
-        total.rope_batches += summary.rope_batches;
-        total.rope_store_groups += summary.rope_store_groups;
-        total.rope_store_group_ops += summary.rope_store_group_ops;
-        total.rope_store_group_sidecars += summary.rope_store_group_sidecars;
-        total.movement_batches += summary.movement_batches;
-        total.movement_groups += summary.movement_groups;
-        total.movement_group_ops += summary.movement_group_ops;
-        total.attention_chains += summary.attention_chains;
-        total.attention_chain_sidecars += summary.attention_chain_sidecars;
-        total.attention_store_chains += summary.attention_store_chains;
-        total.attention_store_chain_sidecars += summary.attention_store_chain_sidecars;
-        total.attention_store_groups += summary.attention_store_groups;
-        total.attention_store_group_ops += summary.attention_store_group_ops;
-        total.attention_store_group_sidecars += summary.attention_store_group_sidecars;
-        total.rope_attention_store_chains += summary.rope_attention_store_chains;
-        total.rope_attention_store_chain_sidecars += summary.rope_attention_store_chain_sidecars;
-        total.rope_attention_store_groups += summary.rope_attention_store_groups;
-        total.rope_attention_store_group_ops += summary.rope_attention_store_group_ops;
-        total.rope_attention_store_group_sidecars += summary.rope_attention_store_group_sidecars;
-        total.attention_batches += summary.attention_batches;
-        total.attention_groups += summary.attention_groups;
-        total.attention_group_ops += summary.attention_group_ops;
-        total.elementwise_batches += summary.elementwise_batches;
-        total.elementwise_ops += summary.elementwise_ops;
-        total.projection_chains += summary.projection_chains;
-        total.projection_chain_sidecars += summary.projection_chain_sidecars;
-        total.projection_groups += summary.projection_groups;
-        total.projection_anchors += summary.projection_anchors;
-        total.projection_sidecars += summary.projection_sidecars;
-        total.max_projection_span_ops = @max(total.max_projection_span_ops, summary.max_projection_span_ops);
+        total.add(summary);
     }
     std.debug.print("Region-local command rollup ({s}): {d} regions\n", .{ label, regions });
     printProgramCommandSummary(label, total);
@@ -806,6 +823,11 @@ pub const RuntimeProfile = struct {
     program_command_planned_counts: [n_program_command_kinds]u64 = [_]u64{0} ** n_program_command_kinds,
     program_command_attempt_counts: [n_program_command_kinds]u64 = [_]u64{0} ** n_program_command_kinds,
     program_command_failed_counts: [n_program_command_kinds]u64 = [_]u64{0} ** n_program_command_kinds,
+    schedule_regions: ScheduleRegionStats = .{},
+    schedule_region_patterns: [max_schedule_region_patterns]ScheduleRegionStats = [_]ScheduleRegionStats{.{}} ** max_schedule_region_patterns,
+    region_command_plan_cached_count: u64 = 0,
+    region_command_plan_dynamic_count: u64 = 0,
+    region_command_plan_cached_command_count: u64 = 0,
     backend_op_count: u64 = 0,
     fallback_op_count: u64 = 0,
     backend_dispatch_count: u64 = 0,
@@ -834,7 +856,36 @@ pub const RuntimeProfile = struct {
     pub fn recordProgramCommandFailed(self: *RuntimeProfile, kind: program_mod.ProgramCommandKind) void {
         self.program_command_failed_counts[@intFromEnum(kind)] +%= 1;
     }
+
+    pub fn recordScheduleRegionAttempt(self: *RuntimeProfile, unit: program_mod.ScheduleUnit) void {
+        self.schedule_regions.recordAttempt(unit.op_count);
+        if (scheduleRegionPatternSlot(unit)) |slot| self.schedule_region_patterns[slot].recordAttempt(unit.op_count);
+    }
+
+    pub fn recordScheduleRegionLowered(self: *RuntimeProfile, unit: program_mod.ScheduleUnit) void {
+        self.schedule_regions.recordLowered(unit.op_count);
+        if (scheduleRegionPatternSlot(unit)) |slot| self.schedule_region_patterns[slot].recordLowered(unit.op_count);
+    }
+
+    pub fn recordScheduleRegionFailed(self: *RuntimeProfile, unit: program_mod.ScheduleUnit) void {
+        self.schedule_regions.recordFailed(unit.op_count);
+        if (scheduleRegionPatternSlot(unit)) |slot| self.schedule_region_patterns[slot].recordFailed(unit.op_count);
+    }
+
+    pub fn recordCachedRegionCommandPlan(self: *RuntimeProfile, command_count: usize) void {
+        self.region_command_plan_cached_count +%= 1;
+        self.region_command_plan_cached_command_count +%= command_count;
+    }
+
+    pub fn recordDynamicRegionCommandPlan(self: *RuntimeProfile) void {
+        self.region_command_plan_dynamic_count +%= 1;
+    }
 };
+
+fn scheduleRegionPatternSlot(unit: program_mod.ScheduleUnit) ?usize {
+    const idx: usize = @intCast(unit.pattern_index);
+    return if (idx < max_schedule_region_patterns) idx else null;
+}
 
 /// Estimate FLOPs for a single DeviceOp based on its geometry.
 pub fn estimateFlops(op: DeviceOp) u64 {
@@ -950,6 +1001,54 @@ pub fn printRuntimeProfile(rt: RuntimeProfile, est: ProgramEstimates) void {
             "Backend dispatches: {d} total ({d:.1}/call)\n",
             .{ rt.backend_dispatch_count, dispatches_per_call },
         );
+    }
+    if (rt.schedule_regions.attempted > 0) {
+        const regions = rt.schedule_regions;
+        const attempt_f: f64 = @floatFromInt(regions.attempted);
+        const lowered_pct = @as(f64, @floatFromInt(regions.lowered)) / attempt_f * 100.0;
+        const lowered_per_call = @as(f64, @floatFromInt(regions.lowered)) / calls_f;
+        const lowered_ops_per_call = @as(f64, @floatFromInt(regions.lowered_ops)) / calls_f;
+        std.debug.print(
+            "Schedule regions: {d}/{d} lowered ({d:.1}%, {d:.1}/call), {d:.1} ops/call covered, {d} ops refused\n",
+            .{
+                regions.lowered,
+                regions.attempted,
+                lowered_pct,
+                lowered_per_call,
+                lowered_ops_per_call,
+                regions.failed_ops,
+            },
+        );
+        for (rt.schedule_region_patterns, 0..) |pattern_stats, pattern| {
+            if (pattern_stats.attempted == 0) continue;
+            const pattern_lowered_ops_per_call = @as(f64, @floatFromInt(pattern_stats.lowered_ops)) / calls_f;
+            std.debug.print(
+                "  pattern#{d}: {d}/{d} lowered, {d} failed, {d:.1} ops/call covered, {d} ops refused\n",
+                .{
+                    pattern,
+                    pattern_stats.lowered,
+                    pattern_stats.attempted,
+                    pattern_stats.failed,
+                    pattern_lowered_ops_per_call,
+                    pattern_stats.failed_ops,
+                },
+            );
+        }
+        if (rt.region_command_plan_cached_count > 0 or rt.region_command_plan_dynamic_count > 0) {
+            const cached_per_call = @as(f64, @floatFromInt(rt.region_command_plan_cached_count)) / calls_f;
+            const dynamic_per_call = @as(f64, @floatFromInt(rt.region_command_plan_dynamic_count)) / calls_f;
+            const cached_commands_per_call = @as(f64, @floatFromInt(rt.region_command_plan_cached_command_count)) / calls_f;
+            std.debug.print(
+                "Region command plans: {d} cached ({d:.1}/call, {d:.1} commands/call), {d} dynamic ({d:.1}/call)\n",
+                .{
+                    rt.region_command_plan_cached_count,
+                    cached_per_call,
+                    cached_commands_per_call,
+                    rt.region_command_plan_dynamic_count,
+                    dynamic_per_call,
+                },
+            );
+        }
     }
     if (rt.sync_count > 0) {
         const sync_ms: f64 = @as(f64, @floatFromInt(rt.sync_time_ns)) / 1_000_000.0;
@@ -1173,6 +1272,25 @@ test "estimateProgram aggregates per tag" {
 test "RuntimeProfile reset" {
     var rt = RuntimeProfile{};
     rt.time_ns[0] = 42;
+    rt.schedule_regions = .{
+        .attempted = 2,
+        .lowered = 1,
+        .failed = 1,
+        .attempted_ops = 14,
+        .lowered_ops = 7,
+        .failed_ops = 7,
+    };
+    rt.schedule_region_patterns[3] = .{
+        .attempted = 2,
+        .lowered = 1,
+        .failed = 1,
+        .attempted_ops = 14,
+        .lowered_ops = 7,
+        .failed_ops = 7,
+    };
+    rt.region_command_plan_cached_count = 2;
+    rt.region_command_plan_dynamic_count = 3;
+    rt.region_command_plan_cached_command_count = 11;
     rt.backend_op_count = 7;
     rt.fallback_op_count = 11;
     rt.backend_dispatch_count = 3;
@@ -1181,10 +1299,74 @@ test "RuntimeProfile reset" {
     rt.call_count = 5;
     rt.reset();
     try std.testing.expectEqual(@as(u64, 0), rt.time_ns[0]);
+    try std.testing.expectEqual(ScheduleRegionStats{}, rt.schedule_regions);
+    try std.testing.expectEqual(ScheduleRegionStats{}, rt.schedule_region_patterns[3]);
     try std.testing.expectEqual(@as(u64, 0), rt.backend_op_count);
+    try std.testing.expectEqual(@as(u64, 0), rt.region_command_plan_cached_count);
+    try std.testing.expectEqual(@as(u64, 0), rt.region_command_plan_dynamic_count);
+    try std.testing.expectEqual(@as(u64, 0), rt.region_command_plan_cached_command_count);
     try std.testing.expectEqual(@as(u64, 0), rt.fallback_op_count);
     try std.testing.expectEqual(@as(u64, 0), rt.backend_dispatch_count);
     try std.testing.expectEqual(@as(u64, 0), rt.sync_time_ns);
     try std.testing.expectEqual(@as(u64, 0), rt.sync_count);
     try std.testing.expectEqual(@as(u32, 0), rt.call_count);
+}
+
+test "RuntimeProfile records schedule region lowerings" {
+    var rt = RuntimeProfile{};
+    const unit = program_mod.ScheduleUnit{
+        .kind = .pattern_region,
+        .pattern_index = 3,
+        .start_item = 2,
+        .item_count = 4,
+        .op_start = 10,
+        .op_count = 7,
+    };
+
+    rt.recordScheduleRegionAttempt(unit);
+    rt.recordScheduleRegionLowered(unit);
+    rt.recordScheduleRegionFailed(unit);
+
+    const expected = ScheduleRegionStats{
+        .attempted = 1,
+        .lowered = 1,
+        .failed = 1,
+        .attempted_ops = 7,
+        .lowered_ops = 7,
+        .failed_ops = 7,
+    };
+    try std.testing.expectEqual(expected, rt.schedule_regions);
+    try std.testing.expectEqual(expected, rt.schedule_region_patterns[3]);
+}
+
+test "RuntimeProfile records region command plan source" {
+    var rt = RuntimeProfile{};
+    rt.recordCachedRegionCommandPlan(9);
+    rt.recordCachedRegionCommandPlan(4);
+    rt.recordDynamicRegionCommandPlan();
+
+    try std.testing.expectEqual(@as(u64, 2), rt.region_command_plan_cached_count);
+    try std.testing.expectEqual(@as(u64, 1), rt.region_command_plan_dynamic_count);
+    try std.testing.expectEqual(@as(u64, 13), rt.region_command_plan_cached_command_count);
+}
+
+test "RuntimeProfile ignores out-of-range schedule region pattern counters" {
+    var rt = RuntimeProfile{};
+    const unit = program_mod.ScheduleUnit{
+        .kind = .pattern_region,
+        .pattern_index = 999,
+        .start_item = 0,
+        .item_count = 1,
+        .op_start = 0,
+        .op_count = 4,
+    };
+
+    rt.recordScheduleRegionAttempt(unit);
+    rt.recordScheduleRegionLowered(unit);
+
+    try std.testing.expectEqual(@as(u64, 1), rt.schedule_regions.attempted);
+    try std.testing.expectEqual(@as(u64, 1), rt.schedule_regions.lowered);
+    for (rt.schedule_region_patterns) |stats| {
+        try std.testing.expectEqual(ScheduleRegionStats{}, stats);
+    }
 }

--- a/src/profile.zig
+++ b/src/profile.zig
@@ -342,7 +342,7 @@ pub fn printProgramCommandSummary(label: []const u8, summary: program_mod.Progra
     else
         0.0;
     std.debug.print(
-        "Program commands ({s}): {d} commands cover {d} ops, estimated {d} dispatches ({d} saved, {d:.1}% of ops); ops={d}, row={d}, rope={d}, rope_batch={d}, movement_batch={d}, attention_batch={d}, elementwise_batch={d} ({d} ops), projection_groups={d} ({d} anchors, {d} sidecars, max span {d})\n\n",
+        "Program commands ({s}): {d} commands cover {d} ops, estimated {d} dispatches ({d} saved, {d:.1}% of ops); ops={d}, row={d}, rope={d}, rope_batch={d}, movement_batch={d}, attention_batch={d}, elementwise_batch={d} ({d} ops), projection_chains={d} ({d} sidecars), projection_groups={d} ({d} anchors, {d} sidecars, max span {d})\n\n",
         .{
             label,
             summary.commands,
@@ -358,6 +358,8 @@ pub fn printProgramCommandSummary(label: []const u8, summary: program_mod.Progra
             summary.attention_batches,
             summary.elementwise_batches,
             summary.elementwise_ops,
+            summary.projection_chains,
+            summary.projection_chain_sidecars,
             summary.projection_groups,
             summary.projection_anchors,
             summary.projection_sidecars,

--- a/src/profile.zig
+++ b/src/profile.zig
@@ -337,6 +337,25 @@ pub fn printProjectionGroupSummary(label: []const u8, summary: program_mod.Proje
     );
 }
 
+pub fn printProjectionSidecarSummary(label: []const u8, ops: []const DeviceOp) void {
+    const summary = program_mod.summarizeProjectionSidecars(ops);
+    std.debug.print(
+        "Projection sidecars ({s}): {d} qmatmul anchors, immediate={d}, compatible={d}; primary_elidable={d}, primary_required={d}; slice={d}, elementwise={d}, fused_elementwise={d}, incompatible={d}\n\n",
+        .{
+            label,
+            summary.anchors,
+            summary.immediate_sidecars,
+            summary.compatible_sidecars,
+            summary.primary_elidable_sidecars,
+            summary.primary_required_sidecars,
+            summary.slice_sidecars,
+            summary.elementwise_sidecars,
+            summary.fused_elementwise_sidecars,
+            summary.incompatible_sidecars,
+        },
+    );
+}
+
 pub fn printProgramCommandSummary(label: []const u8, summary: program_mod.ProgramCommandSummary) void {
     const saved_pct: f64 = if (summary.covered_ops > 0)
         @as(f64, @floatFromInt(summary.estimated_saved_dispatches)) / @as(f64, @floatFromInt(summary.covered_ops)) * 100.0

--- a/src/profile.zig
+++ b/src/profile.zig
@@ -343,7 +343,7 @@ pub fn printProgramCommandSummary(label: []const u8, summary: program_mod.Progra
     else
         0.0;
     std.debug.print(
-        "Program commands ({s}): {d} commands cover {d} ops, estimated {d} dispatches ({d} saved, {d:.1}% of ops); ops={d}, row={d}, rope={d}, rope_batch={d}, movement_batch={d}, movement_group={d} ({d} ops), attention_chain={d} ({d} sidecars), attention_store_chain={d} ({d} sidecars), attention_batch={d}, attention_group={d} ({d} ops), elementwise_batch={d} ({d} ops), projection_chains={d} ({d} sidecars), projection_groups={d} ({d} anchors, {d} sidecars, max span {d})\n\n",
+        "Program commands ({s}): {d} commands cover {d} ops, estimated {d} dispatches ({d} saved, {d:.1}% of ops); ops={d}, row={d}, rope={d}, rope_batch={d}, movement_batch={d}, movement_group={d} ({d} ops), attention_chain={d} ({d} sidecars), attention_store_chain={d} ({d} sidecars), attention_store_group={d} ({d} ops, {d} sidecars), attention_batch={d}, attention_group={d} ({d} ops), elementwise_batch={d} ({d} ops), projection_chains={d} ({d} sidecars), projection_groups={d} ({d} anchors, {d} sidecars, max span {d})\n",
         .{
             label,
             summary.commands,
@@ -362,6 +362,9 @@ pub fn printProgramCommandSummary(label: []const u8, summary: program_mod.Progra
             summary.attention_chain_sidecars,
             summary.attention_store_chains,
             summary.attention_store_chain_sidecars,
+            summary.attention_store_groups,
+            summary.attention_store_group_ops,
+            summary.attention_store_group_sidecars,
             summary.attention_batches,
             summary.attention_groups,
             summary.attention_group_ops,
@@ -374,6 +377,10 @@ pub fn printProgramCommandSummary(label: []const u8, summary: program_mod.Progra
             summary.projection_sidecars,
             summary.max_projection_span_ops,
         },
+    );
+    std.debug.print(
+        "  fused producer chains: rope_attention_store_chain={d} ({d} sidecars)\n\n",
+        .{ summary.rope_attention_store_chains, summary.rope_attention_store_chain_sidecars },
     );
 }
 
@@ -548,6 +555,27 @@ pub fn printAttentionStoreSidecarSummary(label: []const u8, ops: []const DeviceO
     );
 }
 
+pub fn printAttentionStoreGroupCandidateSummary(label: []const u8, ops: []const DeviceOp, policy: program_mod.CommandStreamPolicy) void {
+    const summary = program_mod.summarizeAttentionStoreGroupCandidates(ops, policy);
+    std.debug.print(
+        "Attention store group candidates ({s}): {d} anchors, formed={d} groups ({d} anchors, max {d}); first-store missing={d}, candidates={d}, rejects geometry={d}, hoist={d}, selected-conflict={d}, no-store={d}, pair-conflict={d}\n\n",
+        .{
+            label,
+            summary.anchors,
+            summary.formed_groups,
+            summary.grouped_anchors,
+            summary.max_group_anchors,
+            summary.first_store_missing,
+            summary.candidate_attentions,
+            summary.geometry_rejects,
+            summary.hoist_rejects,
+            summary.selected_conflict_rejects,
+            summary.no_store_rejects,
+            summary.pair_conflict_rejects,
+        },
+    );
+}
+
 pub fn printAttentionStoreRegionSummary(label: []const u8, ops: []const DeviceOp, units: []const program_mod.ScheduleUnit) void {
     var fusable: u32 = 0;
     var same_unit: u32 = 0;
@@ -613,6 +641,11 @@ pub fn printRegionProgramCommandSummary(
         total.attention_chain_sidecars += summary.attention_chain_sidecars;
         total.attention_store_chains += summary.attention_store_chains;
         total.attention_store_chain_sidecars += summary.attention_store_chain_sidecars;
+        total.attention_store_groups += summary.attention_store_groups;
+        total.attention_store_group_ops += summary.attention_store_group_ops;
+        total.attention_store_group_sidecars += summary.attention_store_group_sidecars;
+        total.rope_attention_store_chains += summary.rope_attention_store_chains;
+        total.rope_attention_store_chain_sidecars += summary.rope_attention_store_chain_sidecars;
         total.attention_batches += summary.attention_batches;
         total.attention_groups += summary.attention_groups;
         total.attention_group_ops += summary.attention_group_ops;

--- a/src/profile.zig
+++ b/src/profile.zig
@@ -336,6 +336,31 @@ pub fn printProjectionGroupSummary(label: []const u8, summary: program_mod.Proje
     );
 }
 
+pub fn printProgramCommandSummary(label: []const u8, summary: program_mod.ProgramCommandSummary) void {
+    const saved_pct: f64 = if (summary.covered_ops > 0)
+        @as(f64, @floatFromInt(summary.estimated_saved_dispatches)) / @as(f64, @floatFromInt(summary.covered_ops)) * 100.0
+    else
+        0.0;
+    std.debug.print(
+        "Program commands ({s}): {d} commands cover {d} ops, estimated {d} dispatches ({d} saved, {d:.1}% of ops); ops={d}, row={d}, rope={d}, projection_groups={d} ({d} anchors, {d} sidecars, max span {d})\n\n",
+        .{
+            label,
+            summary.commands,
+            summary.covered_ops,
+            summary.estimated_dispatches,
+            summary.estimated_saved_dispatches,
+            saved_pct,
+            summary.op_commands,
+            summary.row_chains,
+            summary.rope_chains,
+            summary.projection_groups,
+            summary.projection_anchors,
+            summary.projection_sidecars,
+            summary.max_projection_span_ops,
+        },
+    );
+}
+
 const neighborhood_edge: u8 = 255;
 
 pub fn printAnchorNeighborhoodSummary(

--- a/src/profile.zig
+++ b/src/profile.zig
@@ -379,8 +379,14 @@ pub fn printProgramCommandSummary(label: []const u8, summary: program_mod.Progra
         },
     );
     std.debug.print(
-        "  fused producer chains: rope_attention_store_chain={d} ({d} sidecars)\n\n",
-        .{ summary.rope_attention_store_chains, summary.rope_attention_store_chain_sidecars },
+        "  fused producer chains: rope_attention_store_chain={d} ({d} sidecars), rope_attention_store_group={d} ({d} ops, {d} sidecars)\n\n",
+        .{
+            summary.rope_attention_store_chains,
+            summary.rope_attention_store_chain_sidecars,
+            summary.rope_attention_store_groups,
+            summary.rope_attention_store_group_ops,
+            summary.rope_attention_store_group_sidecars,
+        },
     );
 }
 
@@ -576,6 +582,50 @@ pub fn printAttentionStoreGroupCandidateSummary(label: []const u8, ops: []const 
     );
 }
 
+pub fn printRopeAttentionStoreGroupCandidateSummary(label: []const u8, ops: []const DeviceOp, policy: program_mod.CommandStreamPolicy) void {
+    const summary = program_mod.summarizeRopeAttentionStoreGroupCandidates(ops, policy);
+    std.debug.print(
+        "RoPE attention-store group candidates ({s}): {d} anchors, formed={d} groups ({d} pairs, max {d}); first-pair missing={d}, candidates={d}, rejects geometry={d}, pair-missing={d}, before-emit={d}, delay={d}, attention-hoist={d}, sidecar-hoist={d}, selected-conflict={d}\n\n",
+        .{
+            label,
+            summary.anchors,
+            summary.formed_groups,
+            summary.grouped_pairs,
+            summary.max_group_pairs,
+            summary.first_pair_missing,
+            summary.candidate_ropes,
+            summary.geometry_rejects,
+            summary.pair_missing_rejects,
+            summary.before_emit_rejects,
+            summary.delay_rejects,
+            summary.attention_hoist_rejects,
+            summary.sidecar_hoist_rejects,
+            summary.selected_conflict_rejects,
+        },
+    );
+}
+
+pub fn printEarlyRopeAttentionStoreGroupCandidateSummary(label: []const u8, ops: []const DeviceOp, policy: program_mod.CommandStreamPolicy) void {
+    const summary = program_mod.summarizeEarlyRopeAttentionStoreGroupCandidates(ops, policy);
+    std.debug.print(
+        "Early RoPE attention-store group candidates ({s}): {d} anchors, formed={d} groups ({d} pairs, max {d}); first-pair missing={d}, candidates={d}, rejects geometry={d}, pair-missing={d}, rope-hoist={d}, attention-hoist={d}, selected-conflict={d}\n\n",
+        .{
+            label,
+            summary.anchors,
+            summary.formed_groups,
+            summary.grouped_pairs,
+            summary.max_group_pairs,
+            summary.first_pair_missing,
+            summary.candidate_ropes,
+            summary.geometry_rejects,
+            summary.pair_missing_rejects,
+            summary.rope_hoist_rejects,
+            summary.attention_hoist_rejects,
+            summary.selected_conflict_rejects,
+        },
+    );
+}
+
 pub fn printAttentionStoreRegionSummary(label: []const u8, ops: []const DeviceOp, units: []const program_mod.ScheduleUnit) void {
     var fusable: u32 = 0;
     var same_unit: u32 = 0;
@@ -646,6 +696,9 @@ pub fn printRegionProgramCommandSummary(
         total.attention_store_group_sidecars += summary.attention_store_group_sidecars;
         total.rope_attention_store_chains += summary.rope_attention_store_chains;
         total.rope_attention_store_chain_sidecars += summary.rope_attention_store_chain_sidecars;
+        total.rope_attention_store_groups += summary.rope_attention_store_groups;
+        total.rope_attention_store_group_ops += summary.rope_attention_store_group_ops;
+        total.rope_attention_store_group_sidecars += summary.rope_attention_store_group_sidecars;
         total.attention_batches += summary.attention_batches;
         total.attention_groups += summary.attention_groups;
         total.attention_group_ops += summary.attention_group_ops;

--- a/src/profile.zig
+++ b/src/profile.zig
@@ -342,7 +342,7 @@ pub fn printProgramCommandSummary(label: []const u8, summary: program_mod.Progra
     else
         0.0;
     std.debug.print(
-        "Program commands ({s}): {d} commands cover {d} ops, estimated {d} dispatches ({d} saved, {d:.1}% of ops); ops={d}, row={d}, rope={d}, projection_groups={d} ({d} anchors, {d} sidecars, max span {d})\n\n",
+        "Program commands ({s}): {d} commands cover {d} ops, estimated {d} dispatches ({d} saved, {d:.1}% of ops); ops={d}, row={d}, rope={d}, rope_batch={d}, movement_batch={d}, attention_batch={d}, projection_groups={d} ({d} anchors, {d} sidecars, max span {d})\n\n",
         .{
             label,
             summary.commands,
@@ -353,6 +353,9 @@ pub fn printProgramCommandSummary(label: []const u8, summary: program_mod.Progra
             summary.op_commands,
             summary.row_chains,
             summary.rope_chains,
+            summary.rope_batches,
+            summary.movement_batches,
+            summary.attention_batches,
             summary.projection_groups,
             summary.projection_anchors,
             summary.projection_sidecars,

--- a/src/profile.zig
+++ b/src/profile.zig
@@ -342,7 +342,7 @@ pub fn printProgramCommandSummary(label: []const u8, summary: program_mod.Progra
     else
         0.0;
     std.debug.print(
-        "Program commands ({s}): {d} commands cover {d} ops, estimated {d} dispatches ({d} saved, {d:.1}% of ops); ops={d}, row={d}, rope={d}, rope_batch={d}, movement_batch={d}, attention_batch={d}, elementwise_batch={d} ({d} ops), projection_chains={d} ({d} sidecars), projection_groups={d} ({d} anchors, {d} sidecars, max span {d})\n\n",
+        "Program commands ({s}): {d} commands cover {d} ops, estimated {d} dispatches ({d} saved, {d:.1}% of ops); ops={d}, row={d}, rope={d}, rope_batch={d}, movement_batch={d}, attention_batch={d}, attention_group={d} ({d} ops), elementwise_batch={d} ({d} ops), projection_chains={d} ({d} sidecars), projection_groups={d} ({d} anchors, {d} sidecars, max span {d})\n\n",
         .{
             label,
             summary.commands,
@@ -356,6 +356,8 @@ pub fn printProgramCommandSummary(label: []const u8, summary: program_mod.Progra
             summary.rope_batches,
             summary.movement_batches,
             summary.attention_batches,
+            summary.attention_groups,
+            summary.attention_group_ops,
             summary.elementwise_batches,
             summary.elementwise_ops,
             summary.projection_chains,

--- a/src/profile.zig
+++ b/src/profile.zig
@@ -342,7 +342,7 @@ pub fn printProgramCommandSummary(label: []const u8, summary: program_mod.Progra
     else
         0.0;
     std.debug.print(
-        "Program commands ({s}): {d} commands cover {d} ops, estimated {d} dispatches ({d} saved, {d:.1}% of ops); ops={d}, row={d}, rope={d}, rope_batch={d}, movement_batch={d}, movement_group={d} ({d} ops), attention_batch={d}, attention_group={d} ({d} ops), elementwise_batch={d} ({d} ops), projection_chains={d} ({d} sidecars), projection_groups={d} ({d} anchors, {d} sidecars, max span {d})\n\n",
+        "Program commands ({s}): {d} commands cover {d} ops, estimated {d} dispatches ({d} saved, {d:.1}% of ops); ops={d}, row={d}, rope={d}, rope_batch={d}, movement_batch={d}, movement_group={d} ({d} ops), attention_chain={d} ({d} sidecars), attention_store_chain={d} ({d} sidecars), attention_batch={d}, attention_group={d} ({d} ops), elementwise_batch={d} ({d} ops), projection_chains={d} ({d} sidecars), projection_groups={d} ({d} anchors, {d} sidecars, max span {d})\n\n",
         .{
             label,
             summary.commands,
@@ -357,6 +357,10 @@ pub fn printProgramCommandSummary(label: []const u8, summary: program_mod.Progra
             summary.movement_batches,
             summary.movement_groups,
             summary.movement_group_ops,
+            summary.attention_chains,
+            summary.attention_chain_sidecars,
+            summary.attention_store_chains,
+            summary.attention_store_chain_sidecars,
             summary.attention_batches,
             summary.attention_groups,
             summary.attention_group_ops,
@@ -487,6 +491,60 @@ pub fn printQMatmulSliceSidecarSummary(label: []const u8, ops: []const DeviceOp)
             },
         );
     }
+}
+
+pub fn printAttentionStoreSidecarSummary(label: []const u8, ops: []const DeviceOp) void {
+    var attentions: u32 = 0;
+    var immediate_slice: u32 = 0;
+    var immediate_compatible: u32 = 0;
+    var later_src_match: u32 = 0;
+    var later_compatible: u32 = 0;
+    var later_fusable: u32 = 0;
+    var blocked_read: u32 = 0;
+    var blocked_write_read: u32 = 0;
+    var blocked_write_write: u32 = 0;
+    var blocked_overflow: u32 = 0;
+
+    for (ops, 0..) |op, i| {
+        const att = switch (op) {
+            .attention => |att| att,
+            else => continue,
+        };
+        attentions += 1;
+
+        if (i + 1 < ops.len and ops[i + 1] == .slice_assign) {
+            immediate_slice += 1;
+            if (program_mod.attentionSliceStoreCompatible(att, ops[i + 1].slice_assign)) {
+                immediate_compatible += 1;
+            }
+        }
+
+        var scan = i + 1;
+        while (scan < ops.len) : (scan += 1) {
+            const sa = switch (ops[scan]) {
+                .slice_assign => |sa| sa,
+                else => continue,
+            };
+            if (sa.src != att.dst) continue;
+            later_src_match += 1;
+            if (program_mod.attentionSliceStoreCompatible(att, sa)) {
+                later_compatible += 1;
+                switch (program_mod.attentionStoreSidecarBlocker(ops, i, scan, sa)) {
+                    .none => later_fusable += 1,
+                    .candidate_read_written => blocked_read += 1,
+                    .sidecar_write_read => blocked_write_read += 1,
+                    .sidecar_write_written => blocked_write_write += 1,
+                    .overflow_conflict, .invalid_range => blocked_overflow += 1,
+                }
+            }
+            break;
+        }
+    }
+
+    std.debug.print(
+        "Attention store sidecars ({s}): {d} attentions, immediate slice_assign={d} ({d} compatible), later src matches={d} ({d} compatible, {d} fusable; blocked read={d}, write-read={d}, write-write={d}, overflow={d})\n\n",
+        .{ label, attentions, immediate_slice, immediate_compatible, later_src_match, later_compatible, later_fusable, blocked_read, blocked_write_read, blocked_write_write, blocked_overflow },
+    );
 }
 
 fn printNeighborhoodKey(comptime width: usize, key: [width]u8, center: usize) void {

--- a/src/profile.zig
+++ b/src/profile.zig
@@ -379,8 +379,11 @@ pub fn printProgramCommandSummary(label: []const u8, summary: program_mod.Progra
         },
     );
     std.debug.print(
-        "  fused producer chains: rope_attention_store_chain={d} ({d} sidecars), rope_attention_store_group={d} ({d} ops, {d} sidecars)\n\n",
+        "  fused producer chains: rope_store_group={d} ({d} ops, {d} sidecars), rope_attention_store_chain={d} ({d} sidecars), rope_attention_store_group={d} ({d} ops, {d} sidecars)\n\n",
         .{
+            summary.rope_store_groups,
+            summary.rope_store_group_ops,
+            summary.rope_store_group_sidecars,
             summary.rope_attention_store_chains,
             summary.rope_attention_store_chain_sidecars,
             summary.rope_attention_store_groups,
@@ -626,6 +629,27 @@ pub fn printEarlyRopeAttentionStoreGroupCandidateSummary(label: []const u8, ops:
     );
 }
 
+pub fn printRopeStoreGroupCandidateSummary(label: []const u8, ops: []const DeviceOp, policy: program_mod.CommandStreamPolicy) void {
+    const summary = program_mod.summarizeRopeStoreGroupCandidates(ops, policy);
+    std.debug.print(
+        "RoPE store group candidates ({s}): {d} anchors, formed={d} groups ({d} pairs, max {d}); first-pair missing={d}, candidates={d}, rejects geometry={d}, pair-missing={d}, hoist={d}, selected-conflict={d}, external-user={d}\n\n",
+        .{
+            label,
+            summary.anchors,
+            summary.formed_groups,
+            summary.grouped_pairs,
+            summary.max_group_pairs,
+            summary.first_pair_missing,
+            summary.candidate_ropes,
+            summary.geometry_rejects,
+            summary.pair_missing_rejects,
+            summary.hoist_rejects,
+            summary.selected_conflict_rejects,
+            summary.external_user_rejects,
+        },
+    );
+}
+
 pub fn printAttentionStoreRegionSummary(label: []const u8, ops: []const DeviceOp, units: []const program_mod.ScheduleUnit) void {
     var fusable: u32 = 0;
     var same_unit: u32 = 0;
@@ -684,6 +708,9 @@ pub fn printRegionProgramCommandSummary(
         total.row_chains += summary.row_chains;
         total.rope_chains += summary.rope_chains;
         total.rope_batches += summary.rope_batches;
+        total.rope_store_groups += summary.rope_store_groups;
+        total.rope_store_group_ops += summary.rope_store_group_ops;
+        total.rope_store_group_sidecars += summary.rope_store_group_sidecars;
         total.movement_batches += summary.movement_batches;
         total.movement_groups += summary.movement_groups;
         total.movement_group_ops += summary.movement_group_ops;

--- a/src/profile.zig
+++ b/src/profile.zig
@@ -342,7 +342,7 @@ pub fn printProgramCommandSummary(label: []const u8, summary: program_mod.Progra
     else
         0.0;
     std.debug.print(
-        "Program commands ({s}): {d} commands cover {d} ops, estimated {d} dispatches ({d} saved, {d:.1}% of ops); ops={d}, row={d}, rope={d}, rope_batch={d}, movement_batch={d}, attention_batch={d}, projection_groups={d} ({d} anchors, {d} sidecars, max span {d})\n\n",
+        "Program commands ({s}): {d} commands cover {d} ops, estimated {d} dispatches ({d} saved, {d:.1}% of ops); ops={d}, row={d}, rope={d}, rope_batch={d}, movement_batch={d}, attention_batch={d}, elementwise_batch={d} ({d} ops), projection_groups={d} ({d} anchors, {d} sidecars, max span {d})\n\n",
         .{
             label,
             summary.commands,
@@ -356,6 +356,8 @@ pub fn printProgramCommandSummary(label: []const u8, summary: program_mod.Progra
             summary.rope_batches,
             summary.movement_batches,
             summary.attention_batches,
+            summary.elementwise_batches,
+            summary.elementwise_ops,
             summary.projection_groups,
             summary.projection_anchors,
             summary.projection_sidecars,

--- a/src/profile.zig
+++ b/src/profile.zig
@@ -15,6 +15,7 @@ pub const DeviceProgram = backend.DeviceProgram;
 
 /// Number of distinct DeviceOp tags.
 const n_op_tags = 12;
+const n_program_command_kinds = @typeInfo(program_mod.ProgramCommandKind).@"enum".fields.len;
 
 /// Tag names in canonical order matching the DeviceOp union(enum) declaration.
 const tag_names = [n_op_tags][]const u8{
@@ -547,6 +548,96 @@ pub fn printAttentionStoreSidecarSummary(label: []const u8, ops: []const DeviceO
     );
 }
 
+pub fn printAttentionStoreRegionSummary(label: []const u8, ops: []const DeviceOp, units: []const program_mod.ScheduleUnit) void {
+    var fusable: u32 = 0;
+    var same_unit: u32 = 0;
+
+    for (ops, 0..) |op, i| {
+        const att = switch (op) {
+            .attention => |att| att,
+            else => continue,
+        };
+        var scan = i + 1;
+        while (scan < ops.len) : (scan += 1) {
+            const sa = switch (ops[scan]) {
+                .slice_assign => |sa| sa,
+                else => continue,
+            };
+            if (sa.src != att.dst) continue;
+            if (program_mod.attentionSliceStoreCompatible(att, sa) and
+                program_mod.canFuseAttentionStoreSidecar(ops, i, scan, sa))
+            {
+                fusable += 1;
+                if (opsShareScheduleUnit(i, scan, units)) same_unit += 1;
+            }
+            break;
+        }
+    }
+
+    std.debug.print(
+        "Attention store region coverage ({s}): {d}/{d} fusable pairs inside one region unit\n\n",
+        .{ label, same_unit, fusable },
+    );
+}
+
+pub fn printRegionProgramCommandSummary(
+    label: []const u8,
+    alloc: std.mem.Allocator,
+    ops: []const DeviceOp,
+    units: []const program_mod.ScheduleUnit,
+    policy: program_mod.CommandStreamPolicy,
+) !void {
+    var total = program_mod.ProgramCommandSummary{};
+    var regions: u32 = 0;
+    for (units) |unit| {
+        if (unit.kind != .pattern_region) continue;
+        const start: usize = @intCast(unit.op_start);
+        const end = start + @as(usize, unit.op_count);
+        if (end > ops.len) continue;
+        const commands = try program_mod.buildProgramCommands(alloc, ops[start..end], policy);
+        const summary = program_mod.summarizeProgramCommands(commands);
+        alloc.free(commands);
+        regions += 1;
+        total.commands += summary.commands;
+        total.covered_ops += summary.covered_ops;
+        total.estimated_dispatches += summary.estimated_dispatches;
+        total.estimated_saved_dispatches += summary.estimated_saved_dispatches;
+        total.op_commands += summary.op_commands;
+        total.row_chains += summary.row_chains;
+        total.rope_chains += summary.rope_chains;
+        total.rope_batches += summary.rope_batches;
+        total.movement_batches += summary.movement_batches;
+        total.movement_groups += summary.movement_groups;
+        total.movement_group_ops += summary.movement_group_ops;
+        total.attention_chains += summary.attention_chains;
+        total.attention_chain_sidecars += summary.attention_chain_sidecars;
+        total.attention_store_chains += summary.attention_store_chains;
+        total.attention_store_chain_sidecars += summary.attention_store_chain_sidecars;
+        total.attention_batches += summary.attention_batches;
+        total.attention_groups += summary.attention_groups;
+        total.attention_group_ops += summary.attention_group_ops;
+        total.elementwise_batches += summary.elementwise_batches;
+        total.elementwise_ops += summary.elementwise_ops;
+        total.projection_chains += summary.projection_chains;
+        total.projection_chain_sidecars += summary.projection_chain_sidecars;
+        total.projection_groups += summary.projection_groups;
+        total.projection_anchors += summary.projection_anchors;
+        total.projection_sidecars += summary.projection_sidecars;
+        total.max_projection_span_ops = @max(total.max_projection_span_ops, summary.max_projection_span_ops);
+    }
+    std.debug.print("Region-local command rollup ({s}): {d} regions\n", .{ label, regions });
+    printProgramCommandSummary(label, total);
+}
+
+fn opsShareScheduleUnit(a: usize, b: usize, units: []const program_mod.ScheduleUnit) bool {
+    for (units) |unit| {
+        const start: usize = @intCast(unit.op_start);
+        const end = start + @as(usize, unit.op_count);
+        if (a >= start and a < end and b >= start and b < end) return true;
+    }
+    return false;
+}
+
 fn printNeighborhoodKey(comptime width: usize, key: [width]u8, center: usize) void {
     for (key, 0..) |family_id, i| {
         if (i > 0) std.debug.print(" -> ", .{});
@@ -579,6 +670,10 @@ pub fn printTimingBreakdown(label: []const u8, n_tokens: u32, total_ns: u64) voi
 /// during CompiledProgram.execute(). Caller resets explicitly.
 pub const RuntimeProfile = struct {
     time_ns: [n_op_tags]u64 = [_]u64{0} ** n_op_tags,
+    program_command_counts: [n_program_command_kinds]u64 = [_]u64{0} ** n_program_command_kinds,
+    program_command_planned_counts: [n_program_command_kinds]u64 = [_]u64{0} ** n_program_command_kinds,
+    program_command_attempt_counts: [n_program_command_kinds]u64 = [_]u64{0} ** n_program_command_kinds,
+    program_command_failed_counts: [n_program_command_kinds]u64 = [_]u64{0} ** n_program_command_kinds,
     backend_op_count: u64 = 0,
     fallback_op_count: u64 = 0,
     backend_dispatch_count: u64 = 0,
@@ -590,6 +685,22 @@ pub const RuntimeProfile = struct {
 
     pub fn reset(self: *RuntimeProfile) void {
         self.* = .{};
+    }
+
+    pub fn recordProgramCommand(self: *RuntimeProfile, kind: program_mod.ProgramCommandKind) void {
+        self.program_command_counts[@intFromEnum(kind)] +%= 1;
+    }
+
+    pub fn recordProgramCommandPlanned(self: *RuntimeProfile, kind: program_mod.ProgramCommandKind) void {
+        self.program_command_planned_counts[@intFromEnum(kind)] +%= 1;
+    }
+
+    pub fn recordProgramCommandAttempt(self: *RuntimeProfile, kind: program_mod.ProgramCommandKind) void {
+        self.program_command_attempt_counts[@intFromEnum(kind)] +%= 1;
+    }
+
+    pub fn recordProgramCommandFailed(self: *RuntimeProfile, kind: program_mod.ProgramCommandKind) void {
+        self.program_command_failed_counts[@intFromEnum(kind)] +%= 1;
     }
 };
 
@@ -737,6 +848,43 @@ pub fn printRuntimeProfile(rt: RuntimeProfile, est: ProgramEstimates) void {
         std.debug.print("{s:<22} {d:>9.2} {d:>5.1}%  {d:>10.3} {d:>9.1}  {d:>10.4} {d:>8.1}\n", .{ tag_names[idx], t_ms, pct, gflop, gflop_s, gb, gb_s });
     }
     std.debug.print("{s:<22} {d:>9.2}\n\n", .{ "TOTAL", total_ms });
+
+    var printed_commands = false;
+    for (rt.program_command_counts, 0..) |count, i| {
+        if (count == 0) continue;
+        const kind: program_mod.ProgramCommandKind = @enumFromInt(i);
+        if (!printed_commands) {
+            std.debug.print("Program commands encoded:\n", .{});
+            printed_commands = true;
+        }
+        std.debug.print("  {s:<24} {d}\n", .{ kind.label(), count });
+    }
+    if (printed_commands) std.debug.print("\n", .{});
+
+    var printed_planned_commands = false;
+    for (rt.program_command_planned_counts, 0..) |count, i| {
+        if (count == 0) continue;
+        const kind: program_mod.ProgramCommandKind = @enumFromInt(i);
+        if (!printed_planned_commands) {
+            std.debug.print("Program commands planned:\n", .{});
+            printed_planned_commands = true;
+        }
+        std.debug.print("  {s:<24} {d}\n", .{ kind.label(), count });
+    }
+    if (printed_planned_commands) std.debug.print("\n", .{});
+
+    var printed_command_attempts = false;
+    for (rt.program_command_attempt_counts, 0..) |count, i| {
+        const failed = rt.program_command_failed_counts[i];
+        if (count == 0 and failed == 0) continue;
+        const kind: program_mod.ProgramCommandKind = @enumFromInt(i);
+        if (!printed_command_attempts) {
+            std.debug.print("Program command attempts:\n", .{});
+            printed_command_attempts = true;
+        }
+        std.debug.print("  {s:<24} attempts={d} refused={d}\n", .{ kind.label(), count, failed });
+    }
+    if (printed_command_attempts) std.debug.print("\n", .{});
 }
 
 // ── Tests ──────────────────────────────────────────────────────────

--- a/src/profile.zig
+++ b/src/profile.zig
@@ -342,7 +342,7 @@ pub fn printProgramCommandSummary(label: []const u8, summary: program_mod.Progra
     else
         0.0;
     std.debug.print(
-        "Program commands ({s}): {d} commands cover {d} ops, estimated {d} dispatches ({d} saved, {d:.1}% of ops); ops={d}, row={d}, rope={d}, rope_batch={d}, movement_batch={d}, attention_batch={d}, attention_group={d} ({d} ops), elementwise_batch={d} ({d} ops), projection_chains={d} ({d} sidecars), projection_groups={d} ({d} anchors, {d} sidecars, max span {d})\n\n",
+        "Program commands ({s}): {d} commands cover {d} ops, estimated {d} dispatches ({d} saved, {d:.1}% of ops); ops={d}, row={d}, rope={d}, rope_batch={d}, movement_batch={d}, movement_group={d} ({d} ops), attention_batch={d}, attention_group={d} ({d} ops), elementwise_batch={d} ({d} ops), projection_chains={d} ({d} sidecars), projection_groups={d} ({d} anchors, {d} sidecars, max span {d})\n\n",
         .{
             label,
             summary.commands,
@@ -355,6 +355,8 @@ pub fn printProgramCommandSummary(label: []const u8, summary: program_mod.Progra
             summary.rope_chains,
             summary.rope_batches,
             summary.movement_batches,
+            summary.movement_groups,
+            summary.movement_group_ops,
             summary.attention_batches,
             summary.attention_groups,
             summary.attention_group_ops,


### PR DESCRIPTION
## Summary
- Adds general command-stream projection sidecars for Metal qmatmul/qmatvec paths.
- Carries cache-store, elementwise, and RoPE/store sidecars through projection groups to reduce tiny dispatches while keeping the IR general.
- Adds capability/profile/stage-plan visibility for command stream fusion and projection RoPE sidecars.
- Updates perf target docs and SmolLM bench reporting for PR-readiness.

## Verification
- zig build test
- zig build -Doptimize=ReleaseFast
- zig build bench-frontier
- ./zig-out/bin/bench-llama-smollm data/missing.gguf 128 200 3 --stage-plan-only
- git diff --check

## Caveat
- Full SmolLM vs llama.cpp perf comparison was not run in this worktree because local model assets are absent.