### PR TITLE
Make Metal runtime timing opt-in

### DIFF
--- a/benchmarks/llama_smollm_bench.zig
+++ b/benchmarks/llama_smollm_bench.zig
@@ -10,6 +10,7 @@
 //!   ./zig-out/bin/bench-llama-smollm model.gguf 4 200 3 --metal-region
 //!   ./zig-out/bin/bench-llama-smollm model.gguf 128 200 3 --metal-prefill-device
 //!   ./zig-out/bin/bench-llama-smollm model.gguf 128 200 3 --metal-rope-cache-sidecars
+//!   ./zig-out/bin/bench-llama-smollm model.gguf 128 200 3 --profile-timing
 //!   ./zig-out/bin/bench-llama-smollm model.gguf 4 200 3 --print-stage-plan
 //!   ./zig-out/bin/bench-llama-smollm model.gguf 4 200 3 --stage-plan-only
 
@@ -493,6 +494,7 @@ pub fn main(init: std.process.Init) !void {
     const run_metal_region = hasFlag(args, "--metal-region");
     const run_metal_prefill_device = hasFlag(args, "--metal-prefill-device");
     const run_metal_rope_cache_sidecars = hasFlag(args, "--metal-rope-cache-sidecars");
+    const profile_timing = hasFlag(args, "--profile-timing");
     const stage_plan_only = hasFlag(args, "--stage-plan-only");
     const print_stage_plan = stage_plan_only or hasFlag(args, "--print-stage-plan");
     const model_is_gguf = isGGUF(cfg.model_path);
@@ -536,6 +538,7 @@ pub fn main(init: std.process.Init) !void {
             break :metal;
         };
         defer metal_be.deinit();
+        metal_be.setRuntimeTiming(profile_timing);
         if (print_stage_plan) {
             const caps = zgml.llm.stage_plan.StageCapabilities.fromBackendCapabilities(metal_be.backend().capabilities);
             try zgml.llm.stage_plan.printLlamaStagePlanSummary(config, &stdout.interface, caps, cfg.prompt_tokens);

--- a/docs/perf-targets.md
+++ b/docs/perf-targets.md
@@ -135,6 +135,13 @@ the durable rule: producer-sidecar lowerings should prove side-effect legality
 in the pure planner, then let Metal write the final side effect directly instead
 of materializing scratch tensors.
 
+Metal runtime timing is now opt-in (`--profile-timing` in the SmolLM benchmark).
+Cheap correctness/perf counters remain always on: backend/fallback placement,
+kernel dispatches, command-buffer syncs, scheduled-region lowering, and command
+stream command counts. This keeps throughput runs honest by avoiding hundreds of
+host clock reads per token/window while preserving the diagnostics that catch
+hidden CPU fallback.
+
 Projection cache stores now follow that same durable rule. The pure planner
 emits `projection_cache_group` for batched projections plus the direct slice
 stores they own, and Metal's qmatmul batch kernel supports multiple slice

--- a/scripts/bench_vs_ggml.sh
+++ b/scripts/bench_vs_ggml.sh
@@ -11,6 +11,9 @@
 # Usage:
 #   ./scripts/bench_vs_ggml.sh [prompt_tokens] [gen_tokens] [repetitions]
 #
+# Optional:
+#   ZGML_EXTRA_ARGS="--profile-timing" ./scripts/bench_vs_ggml.sh 128 200 3
+#
 # Artifacts:
 #   bench-results/smollm-<timestamp>-p<PROMPT>-g<GEN>-r<REPS>.md
 #   bench-results/smollm-<timestamp>-p<PROMPT>-g<GEN>-r<REPS>.json
@@ -27,6 +30,7 @@ cd "$ROOT"
 GGUF_F16="data/smollm/SmolLM-135M.f16.gguf"
 GGUF_Q8="data/smollm/SmolLM-135M.Q8_0.gguf"
 ZGML_MODEL="${ZGML_MODEL:-$GGUF_Q8}"
+ZGML_EXTRA_ARGS="${ZGML_EXTRA_ARGS:-}"
 ZGML_BIN="./zig-out/bin/bench-llama-smollm"
 OUT_DIR="${OUT_DIR:-bench-results}"
 STAMP="$(date -u +"%Y%m%dT%H%M%SZ")"
@@ -59,7 +63,8 @@ echo "machine=$MACHINE"
 echo
 
 echo "Running zgml benchmark..."
-ZGML_OUT="$("$ZGML_BIN" "$ZGML_MODEL" "$PROMPT" "$GEN" "$REPS" 2>&1)"
+read -r -a ZGML_EXTRA_ARGV <<< "$ZGML_EXTRA_ARGS"
+ZGML_OUT="$("$ZGML_BIN" "$ZGML_MODEL" "$PROMPT" "$GEN" "$REPS" "${ZGML_EXTRA_ARGV[@]}" 2>&1)"
 
 echo "Running llama.cpp Metal F16 benchmark..."
 GGML_F16_OUT="$(llama-bench -m "$GGUF_F16" -p "$PROMPT" -n "$GEN" -r "$REPS" -o md 2>&1 | grep -E '^\|')"
@@ -82,6 +87,7 @@ cat > "$MD_OUT" <<EOF
 - gen_tokens: \`$GEN\`
 - repetitions: \`$REPS\`
 - zgml_model: \`$ZGML_MODEL\`
+- zgml_extra_args: \`$ZGML_EXTRA_ARGS\`
 - llama_cpp_f16_model: \`$GGUF_F16\`
 - llama_cpp_q8_model: \`$GGUF_Q8\`
 - zgml_commit: \`$ZGML_COMMIT\`
@@ -119,12 +125,86 @@ $ZGML_STATUS
 \`\`\`
 EOF
 
-export DATE_UTC MACHINE PROMPT GEN REPS ZGML_MODEL GGUF_F16 GGUF_Q8 ZGML_COMMIT ZGML_STATUS ZIG_VERSION
+export DATE_UTC MACHINE PROMPT GEN REPS ZGML_MODEL ZGML_EXTRA_ARGS GGUF_F16 GGUF_Q8 ZGML_COMMIT ZGML_STATUS ZIG_VERSION
 export LLAMA_BENCH_PATH LLAMA_BREW_VERSION GGML_BREW_VERSION
 export ZGML_OUT GGML_F16_OUT GGML_Q8_OUT GGML_CPU_F16_OUT GGML_CPU_Q8_OUT
 python3 - <<'PY' > "$JSON_OUT"
 import json
 import os
+import re
+
+def parse_float(text):
+    m = re.search(r"([0-9]+(?:\.[0-9]+)?)", text)
+    return float(m.group(1)) if m else None
+
+def parse_zgml(text):
+    rows = {}
+    line_re = re.compile(
+        r"^\s*(?P<label>[^:]+):\s+prompt\s+(?P<prompt>[0-9.]+|[-—]+)\s+tok/s.*?"
+        r"decode\s+(?P<decode>[0-9.]+|[-—]+)\s+tok/s",
+    )
+    for line in text.splitlines():
+        m = line_re.search(line)
+        if not m:
+            continue
+        label = " ".join(m.group("label").split())
+        rows[label] = {
+            "prompt_tok_s": parse_float(m.group("prompt")),
+            "decode_tok_s": parse_float(m.group("decode")),
+        }
+    return rows
+
+def parse_llama_bench_md(text):
+    rows = {}
+    for line in text.splitlines():
+        if not line.startswith("|"):
+            continue
+        cells = [cell.strip() for cell in line.strip("|").split("|")]
+        if not cells or all(set(cell) <= {"-", ":"} for cell in cells):
+            continue
+        test_index = None
+        test_name = None
+        for i, cell in enumerate(cells):
+            if re.fullmatch(r"(pp|tg)\d+", cell):
+                test_index = i
+                test_name = cell
+                break
+        if test_index is None:
+            continue
+        tok_s = None
+        for cell in cells[test_index + 1:]:
+            tok_s = parse_float(cell)
+            if tok_s is not None:
+                break
+        if tok_s is not None:
+            rows[test_name] = {"tok_s": tok_s, "row": cells}
+    return rows
+
+def first_metric(rows, prefix):
+    for key, value in rows.items():
+        if key.startswith(prefix):
+            return value.get("tok_s")
+    return None
+
+def parity(zgml_rows, llama_rows):
+    pp = first_metric(llama_rows, "pp")
+    tg = first_metric(llama_rows, "tg")
+    out = {}
+    for label, row in zgml_rows.items():
+        ratios = {}
+        if pp and row.get("prompt_tok_s"):
+            ratios["prompt"] = row["prompt_tok_s"] / pp
+        if tg and row.get("decode_tok_s"):
+            ratios["decode"] = row["decode_tok_s"] / tg
+        if ratios:
+            out[label] = ratios
+    return out
+
+zgml = parse_zgml(os.environ["ZGML_OUT"])
+llama_metal_f16 = parse_llama_bench_md(os.environ["GGML_F16_OUT"])
+llama_metal_q8 = parse_llama_bench_md(os.environ["GGML_Q8_OUT"])
+llama_cpu_f16 = parse_llama_bench_md(os.environ["GGML_CPU_F16_OUT"])
+llama_cpu_q8 = parse_llama_bench_md(os.environ["GGML_CPU_Q8_OUT"])
 
 data = {
     "benchmark": "smollm-135m",
@@ -138,6 +218,7 @@ data = {
         "zgml_status": os.environ["ZGML_STATUS"],
         "zig_version": os.environ["ZIG_VERSION"],
         "zgml_model": os.environ["ZGML_MODEL"],
+        "zgml_extra_args": os.environ["ZGML_EXTRA_ARGS"],
         "llama_cpp_f16_model": os.environ["GGUF_F16"],
         "llama_cpp_q8_model": os.environ["GGUF_Q8"],
         "llama_bench_path": os.environ["LLAMA_BENCH_PATH"],
@@ -150,6 +231,15 @@ data = {
         "llama_cpp_metal_q8_0": os.environ["GGML_Q8_OUT"],
         "llama_cpp_cpu_f16": os.environ["GGML_CPU_F16_OUT"],
         "llama_cpp_cpu_q8_0": os.environ["GGML_CPU_Q8_OUT"],
+    },
+    "parsed": {
+        "zgml": zgml,
+        "llama_cpp_metal_f16": llama_metal_f16,
+        "llama_cpp_metal_q8_0": llama_metal_q8,
+        "llama_cpp_cpu_f16": llama_cpu_f16,
+        "llama_cpp_cpu_q8_0": llama_cpu_q8,
+        "parity_vs_llama_cpp_metal_f16": parity(zgml, llama_metal_f16),
+        "parity_vs_llama_cpp_metal_q8_0": parity(zgml, llama_metal_q8),
     },
 }
 print(json.dumps(data, indent=2))

--- a/src/backend/metal.zig
+++ b/src/backend/metal.zig
@@ -2,7 +2,8 @@
 //!
 //! Uses shared memory (MTLResourceStorageModeShared) so upload/download
 //! are plain memcpy — CPU and GPU see the same physical pages.
-//! Each dispatch is synchronous (commit + waitUntilCompleted).
+//! Kernel dispatches are encoded into a command session and committed at
+//! explicit sync/fallback boundaries.
 
 const std = @import("std");
 const backend_mod = @import("../backend.zig");
@@ -3687,6 +3688,7 @@ pub const MetalBackend = struct {
     fine_grained_program_dispatch: bool = false,
     region_program_dispatch: bool = false,
     projection_rope_cache_sidecars: bool = false,
+    runtime_timing: bool = false,
 
     pub fn init() !MetalBackend {
         const device = c.mtl_create_device() orelse return error.MetalNotAvailable;
@@ -3747,6 +3749,12 @@ pub const MetalBackend = struct {
 
     pub fn setQMatmulRopeCacheSidecars(self: *MetalBackend, enabled: bool) void {
         self.setProjectionRopeCacheSidecars(enabled);
+    }
+
+    /// Enable expensive per-op/per-command wall-clock timing. Cheap placement,
+    /// dispatch, command, fallback, and sync counts are always collected.
+    pub fn setRuntimeTiming(self: *MetalBackend, enabled: bool) void {
+        self.runtime_timing = enabled;
     }
 
     pub fn commandStreamPolicy(self: *const MetalBackend) program_mod.CommandStreamPolicy {
@@ -3901,6 +3909,14 @@ const CompiledProgram = struct {
     alloc: std.mem.Allocator,
     runtime_profile: profile_mod.RuntimeProfile = .{},
 
+    fn timingStart(self: *const CompiledProgram) i96 {
+        return if (self.backend.runtime_timing) nowNs() else @as(i96, 0);
+    }
+
+    fn timingElapsed(self: *const CompiledProgram, start_ns: i96) u64 {
+        return if (self.backend.runtime_timing) @intCast(nowNs() - start_ns) else 0;
+    }
+
     fn deinit(self: *CompiledProgram) void {
         releaseDeviceBuffers(self.device_bufs);
         releaseQWeightViews(self.qweight_views);
@@ -3914,6 +3930,7 @@ const CompiledProgram = struct {
     }
 
     fn execute(self: *CompiledProgram, inputs: []const backend_mod.ProgramIO, outputs: []const backend_mod.ProgramIO) void {
+        self.runtime_profile.timing_enabled = self.runtime_profile.timing_enabled or self.backend.runtime_timing;
         // Upload per-step inputs (token embed, pos, mask) via shared memory.
         reference.uploadToBuffers(self.ref_buffers, inputs);
 
@@ -3986,8 +4003,7 @@ const CompiledProgram = struct {
     }
 
     fn executeOp(self: *CompiledProgram, op: backend_mod.DeviceOp) void {
-        const tag: usize = @intFromEnum(op);
-        const t0 = nowNs();
+        const t0 = self.timingStart();
         if (self.tryEncodeGpuOp(op)) {
             self.runtime_profile.backend_op_count +%= 1;
         } else {
@@ -3995,22 +4011,24 @@ const CompiledProgram = struct {
             reference.executeOp(self.ref_buffers, self.ref_qweights, op);
             self.runtime_profile.fallback_op_count +%= 1;
         }
-        self.runtime_profile.time_ns[tag] +%= @intCast(nowNs() - t0);
+        const elapsed = self.timingElapsed(t0);
+        if (elapsed != 0) self.runtime_profile.time_ns[@intFromEnum(op)] +%= elapsed;
     }
 
     fn executeFallbackOp(self: *CompiledProgram, op: backend_mod.DeviceOp) void {
-        const tag: usize = @intFromEnum(op);
-        const t0 = nowNs();
+        const t0 = self.timingStart();
         reference.executeOp(self.ref_buffers, self.ref_qweights, op);
         self.runtime_profile.fallback_op_count +%= 1;
-        self.runtime_profile.time_ns[tag] +%= @intCast(nowNs() - t0);
+        const elapsed = self.timingElapsed(t0);
+        if (elapsed != 0) self.runtime_profile.time_ns[@intFromEnum(op)] +%= elapsed;
     }
 
     fn flushCommandsProfiled(self: *CompiledProgram) void {
         if (self.backend.active_commands == null) return;
-        const t0 = nowNs();
+        const t0 = self.timingStart();
         self.backend.flushCommands();
-        self.runtime_profile.sync_time_ns +%= @intCast(nowNs() - t0);
+        const elapsed = self.timingElapsed(t0);
+        if (elapsed != 0) self.runtime_profile.sync_time_ns +%= elapsed;
         self.runtime_profile.sync_count +%= 1;
     }
 
@@ -5779,9 +5797,9 @@ const CompiledProgram = struct {
                     }
                 }
 
-                const t0 = nowNs();
+                const t0 = self.timingStart();
                 self.encodeQMatvecBatch(ops, command.anchorIndices(), command.sidecarIndices());
-                self.recordRegionFusedRunFromIndices(ops, command.anchorIndices(), @intCast(nowNs() - t0));
+                self.recordRegionFusedRunFromIndices(ops, command.anchorIndices(), self.timingElapsed(t0));
                 for (command.sidecarIndices()) |maybe_idx| {
                     if (maybe_idx) |idx| self.recordRegionBackendOp(ops[idx], 0);
                 }
@@ -5801,9 +5819,9 @@ const CompiledProgram = struct {
                     }
                 }
 
-                const t0 = nowNs();
+                const t0 = self.timingStart();
                 self.encodeQMatmulBatch(ops, command.anchorIndices(), command.sidecarIndices());
-                self.recordRegionFusedRunFromIndices(ops, command.anchorIndices(), @intCast(nowNs() - t0));
+                self.recordRegionFusedRunFromIndices(ops, command.anchorIndices(), self.timingElapsed(t0));
                 for (command.sidecarIndices()) |maybe_idx| {
                     if (maybe_idx) |idx| self.recordRegionBackendOp(ops[idx], 0);
                 }
@@ -5872,7 +5890,7 @@ const CompiledProgram = struct {
             }
         }
 
-        const t0 = nowNs();
+        const t0 = self.timingStart();
         if (rope_pair_count == 0) {
             self.encodeQMatmulBatchWithSidecars(ops, command.anchorIndices(), &direct_sidecars);
         } else {
@@ -5907,7 +5925,7 @@ const CompiledProgram = struct {
             }
             self.encodeQMatmulRopeStoreBatch(ops, rope_pairs[0..rope_pair_count]);
         }
-        self.recordRegionFusedRunFromIndices(ops, command.anchorIndices(), @intCast(nowNs() - t0));
+        self.recordRegionFusedRunFromIndices(ops, command.anchorIndices(), self.timingElapsed(t0));
         for (command.carriedSidecarIndices()) |maybe_idx| {
             if (maybe_idx) |idx| self.recordRegionBackendOp(ops[idx], 0);
         }
@@ -5965,9 +5983,9 @@ const CompiledProgram = struct {
             }
         }
 
-        const t0 = nowNs();
+        const t0 = self.timingStart();
         self.encodeQMatvecBatchWithSidecars(ops, command.anchorIndices(), &sidecars);
-        self.recordRegionFusedRunFromIndices(ops, command.anchorIndices(), @intCast(nowNs() - t0));
+        self.recordRegionFusedRunFromIndices(ops, command.anchorIndices(), self.timingElapsed(t0));
         for (command.carriedSidecarIndices()) |maybe_idx| {
             if (maybe_idx) |idx| self.recordRegionBackendOp(ops[idx], 0);
         }
@@ -5993,7 +6011,7 @@ const CompiledProgram = struct {
     }
 
     fn tryEncodeRegionGpuOp(self: *CompiledProgram, op: backend_mod.DeviceOp) bool {
-        const t0 = nowNs();
+        const t0 = self.timingStart();
         const encoded = if (computeDispatchSpec(op)) |spec| blk: {
             self.encodeComputeDispatch(spec);
             break :blk true;
@@ -6033,7 +6051,7 @@ const CompiledProgram = struct {
             else => false,
         };
         if (encoded) {
-            self.recordRegionBackendOp(op, @intCast(nowNs() - t0));
+            self.recordRegionBackendOp(op, self.timingElapsed(t0));
         }
         return encoded;
     }
@@ -6240,7 +6258,7 @@ const CompiledProgram = struct {
         if (end > ops.len) return false;
 
         self.runtime_profile.recordProgramCommandAttempt(command.kind);
-        const t0 = nowNs();
+        const t0 = self.timingStart();
         const lowering = exactProgramCommandLowering(command.kind) orelse return false;
         const encoded = lowering.encode(self, ops, command);
 
@@ -6248,7 +6266,7 @@ const CompiledProgram = struct {
             self.runtime_profile.recordProgramCommandFailed(command.kind);
             return false;
         }
-        self.recordExactProgramCommandRun(ops, command, lowering, @intCast(nowNs() - t0));
+        self.recordExactProgramCommandRun(ops, command, lowering, self.timingElapsed(t0));
         self.runtime_profile.recordProgramCommand(command.kind);
         return true;
     }

--- a/src/profile.zig
+++ b/src/profile.zig
@@ -836,6 +836,7 @@ pub const RuntimeProfile = struct {
     schedule_reuse_count: u64 = 0,
     schedule_rebuild_count: u64 = 0,
     call_count: u32 = 0,
+    timing_enabled: bool = false,
 
     pub fn reset(self: *RuntimeProfile) void {
         self.* = .{};
@@ -1051,8 +1052,12 @@ pub fn printRuntimeProfile(rt: RuntimeProfile, est: ProgramEstimates) void {
         }
     }
     if (rt.sync_count > 0) {
-        const sync_ms: f64 = @as(f64, @floatFromInt(rt.sync_time_ns)) / 1_000_000.0;
-        std.debug.print("Backend sync: {d} waits, {d:.2} ms\n", .{ rt.sync_count, sync_ms });
+        if (rt.timing_enabled) {
+            const sync_ms: f64 = @as(f64, @floatFromInt(rt.sync_time_ns)) / 1_000_000.0;
+            std.debug.print("Backend sync: {d} waits, {d:.2} ms\n", .{ rt.sync_count, sync_ms });
+        } else {
+            std.debug.print("Backend sync: {d} waits\n", .{rt.sync_count});
+        }
     }
     if (rt.schedule_reuse_count > 0 or rt.schedule_rebuild_count > 0) {
         std.debug.print(
@@ -1060,25 +1065,29 @@ pub fn printRuntimeProfile(rt: RuntimeProfile, est: ProgramEstimates) void {
             .{ rt.schedule_reuse_count, rt.schedule_rebuild_count },
         );
     }
-    std.debug.print("{s:<22} {s:>9} {s:>6}  {s:>10} {s:>9}  {s:>10} {s:>8}\n", .{ "op", "time_ms", "pct", "GFLOP", "GFLOP/s", "GB", "GB/s" });
+    if (rt.timing_enabled and total_ns > 0) {
+        std.debug.print("{s:<22} {s:>9} {s:>6}  {s:>10} {s:>9}  {s:>10} {s:>8}\n", .{ "op", "time_ms", "pct", "GFLOP", "GFLOP/s", "GB", "GB/s" });
 
-    for (order) |idx| {
-        const t = rt.time_ns[idx];
-        if (t == 0) continue;
-        const t_ms: f64 = @as(f64, @floatFromInt(t)) / 1_000_000.0;
-        const pct: f64 = if (total_ns > 0) @as(f64, @floatFromInt(t)) / @as(f64, @floatFromInt(total_ns)) * 100.0 else 0.0;
+        for (order) |idx| {
+            const t = rt.time_ns[idx];
+            if (t == 0) continue;
+            const t_ms: f64 = @as(f64, @floatFromInt(t)) / 1_000_000.0;
+            const pct: f64 = @as(f64, @floatFromInt(t)) / @as(f64, @floatFromInt(total_ns)) * 100.0;
 
-        const total_flops: f64 = @as(f64, @floatFromInt(est.flops[idx])) * calls_f;
-        const total_bytes: f64 = @as(f64, @floatFromInt(est.bytes[idx])) * calls_f;
-        const gflop: f64 = total_flops / 1e9;
-        const gb: f64 = total_bytes / 1e9;
-        const t_s: f64 = @as(f64, @floatFromInt(t)) / 1e9;
-        const gflop_s: f64 = if (t_s > 0) gflop / t_s else 0.0;
-        const gb_s: f64 = if (t_s > 0) gb / t_s else 0.0;
+            const total_flops: f64 = @as(f64, @floatFromInt(est.flops[idx])) * calls_f;
+            const total_bytes: f64 = @as(f64, @floatFromInt(est.bytes[idx])) * calls_f;
+            const gflop: f64 = total_flops / 1e9;
+            const gb: f64 = total_bytes / 1e9;
+            const t_s: f64 = @as(f64, @floatFromInt(t)) / 1e9;
+            const gflop_s: f64 = if (t_s > 0) gflop / t_s else 0.0;
+            const gb_s: f64 = if (t_s > 0) gb / t_s else 0.0;
 
-        std.debug.print("{s:<22} {d:>9.2} {d:>5.1}%  {d:>10.3} {d:>9.1}  {d:>10.4} {d:>8.1}\n", .{ tag_names[idx], t_ms, pct, gflop, gflop_s, gb, gb_s });
+            std.debug.print("{s:<22} {d:>9.2} {d:>5.1}%  {d:>10.3} {d:>9.1}  {d:>10.4} {d:>8.1}\n", .{ tag_names[idx], t_ms, pct, gflop, gflop_s, gb, gb_s });
+        }
+        std.debug.print("{s:<22} {d:>9.2}\n\n", .{ "TOTAL", total_ms });
+    } else {
+        std.debug.print("Runtime timing: disabled (counts are still collected; enable backend timing for per-op time/throughput table)\n\n", .{});
     }
-    std.debug.print("{s:<22} {d:>9.2}\n\n", .{ "TOTAL", total_ms });
 
     var printed_commands = false;
     for (rt.program_command_counts, 0..) |count, i| {
@@ -1297,6 +1306,7 @@ test "RuntimeProfile reset" {
     rt.sync_time_ns = 13;
     rt.sync_count = 17;
     rt.call_count = 5;
+    rt.timing_enabled = true;
     rt.reset();
     try std.testing.expectEqual(@as(u64, 0), rt.time_ns[0]);
     try std.testing.expectEqual(ScheduleRegionStats{}, rt.schedule_regions);
@@ -1310,6 +1320,7 @@ test "RuntimeProfile reset" {
     try std.testing.expectEqual(@as(u64, 0), rt.sync_time_ns);
     try std.testing.expectEqual(@as(u64, 0), rt.sync_count);
     try std.testing.expectEqual(@as(u32, 0), rt.call_count);
+    try std.testing.expect(!rt.timing_enabled);
 }
 
 test "RuntimeProfile records schedule region lowerings" {


### PR DESCRIPTION
## Summary
- Makes expensive Metal per-op/per-command wall-clock timing opt-in while keeping cheap runtime counters always enabled.
- Adds `--profile-timing` to the SmolLM benchmark for detailed timing runs.
- Extends `bench_vs_ggml.sh` JSON output with parsed tok/s metrics and parity ratios.
- Documents the measurement posture in the perf target notes.

## Verification
- zig build test
- zig build -Doptimize=ReleaseFast
- zig build bench-frontier
- ./zig-out/bin/bench-llama-smollm data/missing.gguf 128 200 3 --stage-plan-only
- git diff --check

## Caveat
- Full model perf comparison still requires local SmolLM GGUF assets and llama-bench.